### PR TITLE
Add double factorization (X-DF and C-DF) of two-electron integrals

### DIFF
--- a/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
+++ b/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
@@ -288,13 +288,25 @@ to the §1/§2 worry — and a GPU port of it buys little on its own. After the 
 solve, the next target is the reconstruct/gradient contractions and the small
 eigendecompositions, all of which are still launch-bound at this size.
 
-**End-to-end CPU/GPU crossover is higher than the inner-solve crossover (~n=14-16)**
-because the full step also runs L-BFGS, the per-leaf eigh/Fréchet, and per-step
-host syncs — CuPy is still slower than NumPy end-to-end at n=16. Only once `n` is
-large enough that the reconstruct/gradient `einsum`s *and* the inner solve are all
-real GPU work (and iteration count is controlled, as it now is) does the GPU win
-end-to-end. That large-`n`, controlled-iteration regime is where this code can
-outrun CPU-bound implementations of the same algorithm.
+**End-to-end CPU/GPU crossover is ~n=18-20**, higher than the inner-solve
+crossover (~n=14-16), because the full step also runs L-BFGS, the per-leaf
+eigh/Fréchet, and per-step host syncs. Measured (accel path, identical problem per
+backend at each `n`, leaves as noted, rho=1e-3, maxiter=100):
+
+| n (leaves) | NumPy accel | CuPy accel | GPU vs CPU |
+|------------|-------------|------------|------------|
+| 16 (8)     | 5.9 s       | 9.6 s      | 0.6x (GPU loses) |
+| 20 (10)    | 12.0 s      | 8.1 s      | 1.5x       |
+| 24 (10)    | 11.2 s      | 5.4 s      | 2.1x       |
+
+(Errors differ across `n` because each is a different random ERI, unconverged at
+maxiter=100; the CPU-vs-GPU comparison is valid since both backends solve the same
+problem at each size.) The accelerator speedup itself holds steady at ~1.8-1.9x on
+both backends regardless of size. Only once `n` is large enough that the
+reconstruct/gradient `einsum`s *and* the inner solve are all real GPU work (and
+iteration count is controlled, as it now is) does the GPU win end-to-end — and the
+lead grows with size (2.1x by n=24). That large-`n`, controlled-iteration regime
+is where this code outruns CPU-bound implementations of the same algorithm.
 
 ### If/when it goes native, port only the matvec
 

--- a/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
+++ b/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
@@ -395,16 +395,31 @@ Measured with `benchmarks/double_factorization/bench_cg_inner_solve.py --leaf-sw
 | 64     | 2.12e-3      | 9.50e-4      | 0.45x     | 0.005 s   | 125.7 s   |
 | 96     | 9.72e-5      | 5.59e-4      | 5.75x     | 0.009 s   | 155.9 s   |
 
+**The 96-leaf "X-DF wins" above was a regularization artifact.** Re-running at a
+lighter `rho=1e-5` lifts the C-DF floor and C-DF beats X-DF at *every* leaf count:
+
+| leaves | X-DF rel | C-DF rel (rho=1e-5) | ratio | C-DF rel (rho=1e-3) | C-DF time (rho=1e-5) |
+|--------|----------|---------------------|-------|---------------------|----------------------|
+| 4      | 1.58e-1  | 5.22e-2             | 0.33x | 4.17e-2             | 91 s                 |
+| 16     | 4.93e-2  | 6.87e-3             | 0.14x | 7.08e-3             | 271 s                |
+| 32     | 2.08e-2  | 2.36e-3             | 0.11x | 3.11e-3             | 490 s                |
+| 64     | 2.12e-3  | 3.39e-4             | 0.16x | 9.50e-4             | 608 s                |
+| 96     | 9.72e-5  | 8.65e-5             | 0.89x | 5.59e-4             | 682 s                |
+
+The `rho` penalty grows with the cores, so it hurts most at high leaf count:
+dropping `rho` improved C-DF@64 by 2.8x and C-DF@96 by 6.5x (5.6e-4 -> 8.6e-5,
+flipping the 96-leaf result from 5.75x *worse* to 0.89x *better*). But lighter
+`rho` worsens conditioning, so the runtime rises 4-5x (the `rho=0` extreme is
+intractable, above). There is a genuine `rho` tradeoff: small `rho` for best
+reconstruction, larger `rho` for lowest one-norm and a tractable CG solve.
+
 Takeaways:
 - **C-DF's value is compression at low/moderate rank.** At 16 leaves C-DF reaches
   ~7e-3, an accuracy X-DF needs ~3-4x more leaves to match -- fewer leaves means a
   cheaper Givens fabric / lower block-encoding cost. That is the point of C-DF for
-  FTQC, and it holds for leaves up to ~64 here.
-- **X-DF wins at high leaf count.** By 96 leaves X-DF (9.7e-5) is approaching the
-  true rank (~177) and marches toward machine precision, while regularized C-DF is
-  *floored* by the `rho` penalty (and the maxiter budget), so X-DF overtakes it.
-  The `rho=1e-3` term is a confound for a pure accuracy comparison at high rank;
-  `rho=0` lifts the C-DF floor (at the cost of one-norm / conditioning).
+  FTQC. At near-full rank (96 leaves ~ true rank 177) both methods are near-exact,
+  so C-DF's edge there is real but marginal (0.89x) -- the compression win is a
+  low-rank phenomenon.
 - **Cost asymmetry is enormous.** X-DF is milliseconds; C-DF is 30-160 s (the
   iterative optimization), growing ~linearly in leaf count. C-DF is a one-time
   classical pre-processing investment justified only when the leaf savings matter
@@ -418,5 +433,8 @@ Takeaways:
   solve (an RC-DF benefit beyond shrinking the one-norm); the explicit lstsq solver
   tolerates `rho=0` (direct min-norm) but its design matrix OOMs at these leaf
   counts (>12 GB). Net: **C-DF-with-CG is inherently a regularized, low-to-moderate
-  rank tool**; for near-full-rank accuracy X-DF is both exact-ish and free, so the
-  96-leaf reversal above is the expected regime boundary, not a deficiency.
+  rank tool** -- `rho` must be large enough for a tractable CG solve but small
+  enough not to floor accuracy (`~1e-5` beats X-DF at all leaf counts here at 4-5x
+  the runtime; `1e-3` is faster but floors high-rank accuracy). For near-full-rank
+  accuracy X-DF is exact-ish and essentially free, so C-DF is worth its cost only
+  when the low-rank leaf savings (or the one-norm reduction) matter downstream.

--- a/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
+++ b/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
@@ -267,19 +267,34 @@ tolerance and conditioning, not by matvec efficiency:
 
 So the next wins are **algorithmic**, and they compound the Tier-0 kernel win:
 
-1. **Inexact inner solve / forcing sequence** — the inner solve does not need
-   `tol=1e-10` every L-BFGS step (the gradient only needs to be accurate enough).
-   Loosening to ~1e-4 early is already ~5x here, for free.
-2. **Warm-start CG across L-BFGS steps** — the cores move slowly between steps;
-   starting from the previous `Z` should collapse the iteration count.
-3. **Jacobi / diagonal preconditioner** — attacks the condition number directly
-   (larger `rho` already shows the conditioning effect above).
-4. **CUDA graph capture** (Tier-0 item 3) — amortizes the per-iteration launch
-   overhead that makes the GPU lose at small sizes.
+1. **[DONE] Inexact inner solve / forcing sequence + warm start.** The in-loop CG
+   no longer solves to `tol=1e-10` every L-BFGS step (`cg_optimization_tolerance`,
+   default `max(cg_tolerance, 1e-6)`) and warm-starts from the previous step's
+   cores (`cg_warm_start`, default `True`); only the single final solve is tight.
+   By the envelope theorem the gradient only needs to be approximate, so final
+   accuracy is unchanged. **End-to-end (synthetic n=16, 8 leaves, rho=1e-3,
+   maxiter=150): NumPy 11.2 -> 5.9 s (1.9x), CuPy 17.5 -> 9.6 s (1.8x)**, with the
+   final reconstruction error matching the cold/tight path.
+2. **[TODO] Jacobi / diagonal preconditioner** — attacks the condition number
+   directly (larger `rho` already shows the conditioning effect above).
+3. **[TODO] CUDA graph capture** (Tier-0 item 3) — amortizes the per-iteration
+   launch overhead that makes the GPU lose at small sizes.
 
-Only once iteration count is controlled does the GPU's batched-matvec advantage
-dominate end-to-end; that is the regime where this code can outrun CPU-bound
-implementations of the same algorithm.
+**Where the end-to-end time now goes** (profiled, full C-DF, CuPy, n=16, 8 leaves):
+inner CG solve ~53%, the `n^4` reconstruct/gradient `einsum`s + the per-leaf eigh
+in `unpack` (`expm_skew_symmetric`) ~45%, and `scipy.linalg.expm_frechet`
+(host) **only ~2%**. So the Fréchet derivative is *not* the bottleneck — contrary
+to the §1/§2 worry — and a GPU port of it buys little on its own. After the inner
+solve, the next target is the reconstruct/gradient contractions and the small
+eigendecompositions, all of which are still launch-bound at this size.
+
+**End-to-end CPU/GPU crossover is higher than the inner-solve crossover (~n=14-16)**
+because the full step also runs L-BFGS, the per-leaf eigh/Fréchet, and per-step
+host syncs — CuPy is still slower than NumPy end-to-end at n=16. Only once `n` is
+large enough that the reconstruct/gradient `einsum`s *and* the inner solve are all
+real GPU work (and iteration count is controlled, as it now is) does the GPU win
+end-to-end. That large-`n`, controlled-iteration regime is where this code can
+outrun CPU-bound implementations of the same algorithm.
 
 ### If/when it goes native, port only the matvec
 

--- a/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
+++ b/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
@@ -409,3 +409,14 @@ Takeaways:
   iterative optimization), growing ~linearly in leaf count. C-DF is a one-time
   classical pre-processing investment justified only when the leaf savings matter
   downstream (circuit depth, measurement variance), not for raw reconstruction.
+- **Regularization is load-bearing for CG tractability, not just the one-norm.**
+  A `rho=0` control run timed out before finishing a single leaf row. Cause
+  (measured, one inner solve at 64 leaves, n=19, tol=1e-6): the inner operator is
+  rank-deficient at `rho=0` (`lambda_min -> 0`), so CG iterations explode --
+  `rho=1e-3`: 407 iters / 0.27 s; `rho=1e-4`: 908 / 0.56 s; **`rho=0`: 4876 /
+  2.83 s (~12x)** -- and that is *per L-BFGS step*. So `rho>0` conditions the CG
+  solve (an RC-DF benefit beyond shrinking the one-norm); the explicit lstsq solver
+  tolerates `rho=0` (direct min-norm) but its design matrix OOMs at these leaf
+  counts (>12 GB). Net: **C-DF-with-CG is inherently a regularized, low-to-moderate
+  rank tool**; for near-full-rank accuracy X-DF is both exact-ish and free, so the
+  96-leaf reversal above is the expected regime boundary, not a deficiency.

--- a/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
+++ b/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
@@ -1,0 +1,170 @@
+# Double Factorization: C++ Port, Composition, and Distributed-Memory Notes
+
+Design/decision notes (no code). Context: the `double_factorization` feature
+(X-DF + C-DF, RC-DF regularization) is currently **pure Python** (NumPy/SciPy +
+CuPy for the NVIDIA cuSOLVER/cuBLAS path). Questions considered:
+
+1. How much effort to port it to C++ with nanobind bindings?
+2. Does that future-proof it for distributed memory (MPI / NCCL)?
+3. Does the existence of the separate **C++ qubitization / LCU block-encoding /
+   QSVT** feature (QPU kernels as C++ primitives) change the calculus?
+
+---
+
+## TL;DR
+
+- A faithful **full C++ port of the factorization is ~1 month**, dominated by
+  C-DF (the L-BFGS optimizer + the matrix-exponential Fréchet-derivative gradient
+  + the inner least-squares). X-DF alone is ~days.
+- **C++ is not the lever for distributed memory.** The compute is already native
+  (cuSOLVER/cuBLAS via CuPy / LAPACK). Distribution is about *data layout and the
+  distributed library*, and most of it can be driven from Python.
+- **Composition with the C++ qubitization stack happens at the data boundary, not
+  the language boundary.** Python DF can already feed the C++ kernels by passing
+  arrays as kernel arguments.
+- The **highest-leverage C++ work is a new DF block-encoding `__qpu__` kernel**
+  (which does not exist yet), not porting the classical factorization.
+- Port the classical factorization to C++ **only** for a Python-free end-to-end
+  pipeline or library-wide C++ consistency — not as a prerequisite for
+  composition or distribution.
+
+---
+
+## 1. Effort to port DF → C++ with nanobind
+
+The repo already has the scaffolding (`lib/`, `include/`, `python/bindings/`,
+CMake, nanobind). DF is *classical* dense linear algebra (no `__qpu__` kernels),
+so it would be a new standalone C++ module. The two halves differ sharply:
+
+### X-DF — easy (~days)
+- Pivoted Cholesky: a short loop, or LAPACK `?pstrf` / cuSOLVER.
+- Second factorization: `dsyevd` / cuSOLVER `Xsyevd`.
+- Reshape / symmetrize: trivial.
+- Maps cleanly onto BLAS/LAPACK/cuSOLVER (already linked via CUDA-Q).
+
+### C-DF — hard (~2–3 weeks) and the real cost
+Three pieces have no drop-in equivalent in the codebase today:
+1. **Optimizer.** `scipy.optimize.minimize(L-BFGS-B)` → add a C++ L-BFGS
+   (LBFGS++, liblbfgs, or hand-rolled). New dependency.
+2. **`scipy.linalg.expm_frechet`** (Fréchet derivative of the matrix exponential,
+   used in the analytic gradient). Biggest correctness risk — either port
+   scipy's scaling-and-squaring algorithm or use the closed form in the skew
+   eigenbasis (Daleckii–Krein divided differences). The Python gradient was
+   verified to ~4e-10; reproducing that in C++ takes care.
+3. **`expm` / `logm` of skew matrices, `lstsq`** — doable via eigh/LAPACK,
+   moderate.
+
+### Bindings + tests + re-validation (~1 week)
+nanobind returning the factorization structs is straightforward; re-establishing
+parity with the Python reference and the OpenFermion cross-check is the bulk.
+
+**Total: ~1 month**, concentrated in C-DF. On its own this buys nothing for
+distribution.
+
+---
+
+## 2. Language ≠ distribution
+
+Where DF gets big is **data**, not Python overhead:
+- ERI tensor `~n^4` and the supermatrix `n^2 x n^2` are the memory walls
+  (n ≈ 1000 → ~8 TB ERI). That is the motivation for distributing.
+- Compute is already native (CuPy → cuSOLVER/cuBLAS); Python only orchestrates.
+
+Distribution decomposes as:
+- **Tensor contractions** (C-DF einsums, the inner solve): distribute ERI blocks
+  over ranks → local GEMMs + `allreduce`. **Doable from Python** with CuPy +
+  CUDA-aware `mpi4py`, or CuPy's NCCL bindings (`cupy.cuda.nccl`). No C++ needed.
+- **Distributed dense eigendecomposition / Cholesky** of the supermatrix: the one
+  part with no good pure-Python option. Needs **cuSOLVERMp / cuBLASMp**
+  (multi-node multi-GPU, NCCL/NVSHMEM underneath) or ELPA / ScaLAPACK / SLATE —
+  all C/C++. This warrants a **thin C++/nanobind shim**, but it is glue around an
+  existing library, not a DF rewrite.
+- **The L-BFGS optimizer itself stays serial and tiny** — it acts on the small
+  rotation-generator vector (`num_leaves * n(n-1)/2`), not the big tensors. Only
+  the per-iteration objective/gradient (contractions + inner solve) needs
+  distributing.
+
+So a C++ port does **not** deliver distribution for free; the distribution lever
+is the backend + comm library either way.
+
+---
+
+## 3. Composition with the C++ qubitization / LCU / QSVT feature
+
+There is a separate feature where qubitization, LCU/PauliLCU block encoding, and
+QSVT are C++ `__qpu__` primitives. This is the strongest argument for C++ DF —
+but it points at a different deliverable.
+
+### Composition is at the data boundary
+DF outputs numbers: leaf rotations `U^t` (→ Givens angles), symmetric cores `Z^t`
+(→ controlled-phase angles), one-body eigenvalues. The C++ kernels consume arrays
+of doubles as kernel arguments. The repo *already* uses this pattern: in the QSVT
+and Givens features, **Python computes the plan/angles and passes them into the
+C++ `__qpu__` kernels**. So Python DF can already feed C++ qubitization today —
+the seam is `numpy array → nanobind kernel arg`, independent of where the array
+was computed. "C++ qubitization exists" does not, by itself, force DF into C++.
+
+### The real C++ gap is a DF *block-encoding kernel*
+The qubitization feature has a **generic Pauli-LCU** block encoding. A
+double-factorized Hamiltonian has a *much cheaper, structured* block encoding (the
+von Burg / Lee construction): apply the leaf Givens rotation `U^t`, controlled
+phase rotations on the diagonalized cores, reflect, uncompute. That is the **point
+of DF for FTQC** (lower one-norm λ → fewer Toffolis) and it is a **new `__qpu__`
+primitive that does not exist yet**.
+
+- It is naturally **C++** (a quantum-circuit primitive like the existing ones).
+- It **reuses the existing C++ Givens-rotation kernels** (from the Givens
+  Slater-determinant feature) and slots into the existing qubitization walk + QSVT.
+- It is **small and well-scoped** (hundreds of lines), not a month-long port.
+- It consumes Python-computed `U^t` / `Z^t` as kernel arguments.
+
+This is the high-leverage move: build the **DF block-encoding QPU kernel in C++**,
+without touching the classical factorization.
+
+### When porting the *factorization* to C++ is justified
+One specific scenario: a **fully C++-native, Python-free end-to-end pipeline** —
+"integrals → DF → block encoding → qubitization → resource estimate" in one C++
+process (a C++ costing/driver tool, or library consistency where every solver is
+C++ with thin bindings). Then C++ DF hands `U^t` / `Z^t` directly to the C++
+block-encoding kernel with no marshaling — the cleanest native story, and the
+strongest reason to absorb the ~1-month cost.
+
+If Python stays in the orchestration loop (the current repo pattern), keeping DF
+in Python is fine and the factorization port is low-value relative to its cost.
+
+---
+
+## 4. Scalability caveats independent of language
+
+These bite before the language does, and are needed in *either* Python or C++:
+
+- **The inner C-DF solve.** The default `inner_solver="lstsq"` builds an explicit
+  `n^4 x num_params` design matrix — fine for small/medium systems, but it does
+  **not** scale. The scalable form, the paper's **matrix-free conjugate-gradient**
+  solve (RC-DF Eqs. 25–30) applying the `A` operator via `n x n` contractions, is
+  now available as `inner_solver="cg"`. This is the form to carry into any C++ /
+  distributed port; the explicit lstsq path is the small-system reference.
+- **Forming the full `n^4` ERI / `n^2 x n^2` supermatrix** is itself the memory
+  wall; at scale, work directly from Cholesky / density-fitting vectors and never
+  materialize the dense tensor.
+
+---
+
+## 5. Recommended sequencing
+
+1. **First / highest value:** a **C++ DF block-encoding `__qpu__` kernel**,
+   consuming Python-computed `U^t` / `Z^t`, reusing the existing Givens +
+   qubitization primitives. This is what "compose with the C++ stack" actually
+   requires, and it is small.
+2. **Keep classical DF in Python** behind the existing backend abstraction
+   (`_backend.py`). If/when it becomes the bottleneck, distribute via CuPy +
+   NCCL/MPI and add a thin shim around a distributed eigensolver
+   (cuSOLVERMp / ELPA). Also switch the inner solve to matrix-free CG.
+3. **Port classical DF to C++ only** if committing to a Python-free end-to-end
+   pipeline or library-wide C++ consistency — then it composes in-process and the
+   ~1-month cost buys a clean native stack.
+
+**Net:** the C++ qubitization feature makes a **C++ DF block-encoding kernel**
+clearly worth building; it makes a **C++ port of the factorization** a real option
+but still a "native pipeline / consistency" decision, not a technical prerequisite
+for composition or distribution.

--- a/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
+++ b/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
@@ -379,3 +379,33 @@ it lines up with the distributed-eigensolver shim in §2.
   kernel via nanobind; CG driver and L-BFGS stay in Python.
 - **Tier 2 (C++/CUDA + NCCL):** partial-sum matvec with allreduce for distributed
   ERIs/leaves.
+
+---
+
+## 7. X-DF vs C-DF: accuracy and cost vs leaf count (H2O/6-311G)
+
+Measured with `benchmarks/double_factorization/bench_cg_inner_solve.py --leaf-sweep`
+(n=19, rho=1e-3, C-DF maxiter=300; X-DF auto->NumPy in ms, C-DF auto->GPU):
+
+| leaves | X-DF rel err | C-DF rel err | C-DF/X-DF | X-DF time | C-DF time |
+|--------|--------------|--------------|-----------|-----------|-----------|
+| 4      | 1.58e-1      | 4.17e-2      | 0.26x     | 0.001 s   | 28.6 s    |
+| 16     | 4.93e-2      | 7.08e-3      | 0.14x     | 0.001 s   | 65.4 s    |
+| 32     | 2.08e-2      | 3.11e-3      | 0.15x     | 0.002 s   | 91.1 s    |
+| 64     | 2.12e-3      | 9.50e-4      | 0.45x     | 0.005 s   | 125.7 s   |
+| 96     | 9.72e-5      | 5.59e-4      | 5.75x     | 0.009 s   | 155.9 s   |
+
+Takeaways:
+- **C-DF's value is compression at low/moderate rank.** At 16 leaves C-DF reaches
+  ~7e-3, an accuracy X-DF needs ~3-4x more leaves to match -- fewer leaves means a
+  cheaper Givens fabric / lower block-encoding cost. That is the point of C-DF for
+  FTQC, and it holds for leaves up to ~64 here.
+- **X-DF wins at high leaf count.** By 96 leaves X-DF (9.7e-5) is approaching the
+  true rank (~177) and marches toward machine precision, while regularized C-DF is
+  *floored* by the `rho` penalty (and the maxiter budget), so X-DF overtakes it.
+  The `rho=1e-3` term is a confound for a pure accuracy comparison at high rank;
+  `rho=0` lifts the C-DF floor (at the cost of one-norm / conditioning).
+- **Cost asymmetry is enormous.** X-DF is milliseconds; C-DF is 30-160 s (the
+  iterative optimization), growing ~linearly in leaf count. C-DF is a one-time
+  classical pre-processing investment justified only when the leaf savings matter
+  downstream (circuit depth, measurement variance), not for raw reconstruction.

--- a/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
+++ b/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
@@ -220,8 +220,10 @@ sub-second; a port only pays off at the active-space sizes where DF matters):
    `curvature`, `step`, `beta`) stay as on-device 0-d arrays; only the convergence
    test and the curvature guard convert to host (one scalar each per iteration),
    instead of the old full-reduction-returning-`float` on every inner product.
-3. **[TODO, optional]** wrap the CG iteration in a **CUDA graph** (CuPy supports
-   capture) to amortize remaining launch overhead.
+3. **[BLOCKED from Python]** wrap the CG iteration in a **CUDA graph** to amortize
+   remaining launch overhead. Not feasible from CuPy 13.6 — the matvec is a cuBLAS
+   call and CuPy errors on cuBLAS during stream capture. See the algorithmic
+   wins list below (item 5) for details and the native route.
 
 Items 1–2 are implemented in `_solve_inner_cores_cg`; they are reversible and
 preserve the NumPy/CuPy duality (verified identical to the lstsq solve, recon to
@@ -303,8 +305,21 @@ So the next wins are **algorithmic**, and they compound the Tier-0 kernel win:
    a **polynomial (Chebyshev) accelerator** on the known interval `[2rho, lambda_max]`
    -- which is also sync-free (no per-iteration dot products, so GPU-friendly) but
    needs `rho > 0` (falls back to CG at `rho = 0`). Deferred.
-5. **[TODO] CUDA graph capture** (Tier-0 item 3) — amortizes the per-iteration
-   launch overhead that makes the GPU lose at small sizes.
+5. **[BLOCKED from Python — needs native cuBLAS] CUDA graph capture** (Tier-0
+   item 3). Capturing the CG iteration as a CUDA graph would amortize the
+   per-iteration launch + Python overhead that makes the GPU lose at small sizes.
+   But the iteration's dominant op is the matvec, which is a cuBLAS GEMM (via
+   `einsum`/`matmul`), and **CuPy 13.6 errors with "calling cuBLAS API during
+   stream capture is currently unsupported"** — verified by prototype. So the one
+   op worth capturing is exactly the one CuPy forbids during capture; capturing
+   only the elementwise axpy/reductions (which *are* capture-safe) and leaving the
+   matvec outside saves almost nothing. Additional friction: `cupy.einsum` has no
+   `out=` (so the matvec result needs a `copyto` into a fixed buffer for stable
+   graph addresses anyway). The viable route is raw cuBLAS with a
+   capture-compatible workspace (`cublasSetStream`/`cublasSetWorkspace`) under the
+   CUDA driver graph API — i.e. the native C++/CUDA port (§1, §6 "port only the
+   matvec"), where the matvec kernel and the CG driver are captured together. Not
+   pursued from Python.
 
 **Where the end-to-end time went** (profiled *before* item 3, full C-DF, CuPy,
 n=16, 8 leaves): inner CG solve ~53%, the `n^4` reconstruct/gradient `einsum`s +

--- a/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
+++ b/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
@@ -24,6 +24,10 @@ CuPy for the NVIDIA cuSOLVER/cuBLAS path). Questions considered:
   arrays as kernel arguments.
 - The **highest-leverage C++ work is a new DF block-encoding `__qpu__` kernel**
   (which does not exist yet), not porting the classical factorization.
+- On the *classical* side, the highest-leverage native target is the **matrix-free
+  CG inner matvec**, not the optimizer. The cheap Python wins (batched-tensor
+  matvec, on-device CG scalars) are **done**; profile at scale before going
+  native. See §6.
 - Port the classical factorization to C++ **only** for a Python-free end-to-end
   pipeline or library-wide C++ consistency — not as a prerequisite for
   composition or distribution.
@@ -143,7 +147,8 @@ These bite before the language does, and are needed in *either* Python or C++:
   **not** scale. The scalable form, the paper's **matrix-free conjugate-gradient**
   solve (RC-DF Eqs. 25–30) applying the `A` operator via `n x n` contractions, is
   now available as `inner_solver="cg"`. This is the form to carry into any C++ /
-  distributed port; the explicit lstsq path is the small-system reference.
+  distributed port; the explicit lstsq path is the small-system reference. The CG
+  *matvec* is in fact the single highest-leverage native target in DF — see §6.
 - **Forming the full `n^4` ERI / `n^2 x n^2` supermatrix** is itself the memory
   wall; at scale, work directly from Cholesky / density-fitting vectors and never
   materialize the dense tensor.
@@ -168,3 +173,87 @@ These bite before the language does, and are needed in *either* Python or C++:
 clearly worth building; it makes a **C++ port of the factorization** a real option
 but still a "native pipeline / consistency" decision, not a technical prerequisite
 for composition or distribution.
+
+---
+
+## 6. The CG inner matvec: the highest-leverage native target
+
+Of everything in the classical factorization, the **matrix-free CG matvec**
+(`apply_operator` in `_solve_inner_cores_cg`) is the best C++/CUDA candidate —
+more so than the optimizer or `expm_frechet` flagged in §1. It is the one piece
+that is simultaneously **hot, regular, and small-matrix-dominated**, which is
+exactly where Python + CuPy leaves the most on the table and where hand control
+helps most.
+
+### Why this piece specifically
+
+- **It is the innermost loop.** `apply_operator` runs every CG iteration, CG runs
+  to convergence, and the whole solve runs every L-BFGS step — millions of
+  invocations over a full optimization.
+- **It is structured.** `A(Z)^t = sum_{t'} M_{tt'} Z^{t'} M_{tt'}^T` with
+  `M_{tt'} = (U^t^T U^{t'})` elementwise-squared is the *same* congruence batched
+  over `num_leaves^2` pairs — it maps cleanly onto batched GEMM or one fused
+  kernel.
+- **The matrices are small** (`n x n`, `n` = orbital count). Small GEMMs are
+  latency-bound, not throughput-bound, so the current code is dominated by
+  *overhead*, not arithmetic:
+  - `2 * num_leaves^2` tiny cuBLAS launches per matvec (`M@z`, then `…@M^T`),
+    driven from a **Python double `for t / for u` loop** that serializes launches
+    on one stream.
+  - CuPy allocates a temporary for every `@` and every `+`.
+  - `inner_product` calls `float(to_numpy(...))` — a **device→host sync every CG
+    iteration** — which stalls the pipeline and prevents overlap.
+
+### Do the cheap Python wins first (profile-gated)
+
+Most of that overhead is fixable without leaving Python, and the bottleneck
+should be *measured* before any port (at small/medium sizes the whole solve is
+sub-second; a port only pays off at the active-space sizes where DF matters):
+
+1. **[DONE]** **Vectorize the matvec into a batched `einsum`** over the leaf
+   index. `metric` is stacked as a `(t, t', k, l)` tensor and the operator is the
+   single contraction `einsum("tukl,ulm,tunm->tkn", metric, z, metric)` (a
+   strided-batched GEMM under cuBLAS), with the cores stacked as one
+   `(num_leaves, n, n)` array — replacing the `num_leaves^2` Python-driven launches
+   and the double `for t / for u` loop.
+2. **[DONE]** **Cut the per-iteration sync** — the CG scalars (`residual_norm_sq`,
+   `curvature`, `step`, `beta`) stay as on-device 0-d arrays; only the convergence
+   test and the curvature guard convert to host (one scalar each per iteration),
+   instead of the old full-reduction-returning-`float` on every inner product.
+3. **[TODO, optional]** wrap the CG iteration in a **CUDA graph** (CuPy supports
+   capture) to amortize remaining launch overhead.
+
+Items 1–2 are implemented in `_solve_inner_cores_cg`; they are reversible and
+preserve the NumPy/CuPy duality (verified identical to the lstsq solve, recon to
+~1e-14 and cores to ~1e-10 when the inner system is full rank).
+
+### If/when it goes native, port only the matvec
+
+The right seam is surgical: push **just `apply_operator`** (ideally with the
+dot/axpy reductions) across the nanobind boundary and **keep the CG driver and
+L-BFGS in Python**. The driver only touches tiny data (scalars, the small
+generator vector); the heavy, regular work is the congruence. This is the repo's
+existing pattern (Python orchestrates, C++/CUDA does the primitive) and it
+sidesteps everything expensive in a full port — the L-BFGS dependency,
+`expm_frechet`, and the OpenFermion re-validation.
+
+A fused kernel can keep `z`-blocks in shared memory across the `num_leaves^2`
+congruence terms, do the accumulation in registers, and run the reductions
+on-device — control CuPy cannot express.
+
+### This is also the distribution seam
+
+Once the matvec is a kernel over per-leaf / per-ERI-block partial sums,
+distributing it is an **NCCL allreduce of the partial `A(Z)^t`** across ranks.
+That — not single-GPU speed — is the real reason to own this in native code, and
+it lines up with the distributed-eigensolver shim in §2.
+
+### Sequencing
+
+- **Tier 0 (DONE, Python):** batched-tensor matvec + on-device CG scalars
+  (per-iteration host sync removed except the convergence/curvature guards).
+  Cheap, reversible, probably the bulk of the win.
+- **Tier 1 (C++/CUDA, when profiled as the bottleneck):** fused `apply_operator`
+  kernel via nanobind; CG driver and L-BFGS stay in Python.
+- **Tier 2 (C++/CUDA + NCCL):** partial-sum matvec with allreduce for distributed
+  ERIs/leaves.

--- a/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
+++ b/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
@@ -227,6 +227,60 @@ Items 1–2 are implemented in `_solve_inner_cores_cg`; they are reversible and
 preserve the NumPy/CuPy duality (verified identical to the lstsq solve, recon to
 ~1e-14 and cores to ~1e-10 when the inner system is full rank).
 
+### Measured (benchmarks/double_factorization/bench_cg_inner_solve.py)
+
+One inner core solve, warm-started X-DF rotations, `rho` = regularization.
+
+- **Tier-0 win (batched vs old list-based CG), H2O/STO-3G, n=7, 8 leaves,
+  rho=1e-3:** NumPy 64 → 39 ms (**1.7x**), CuPy 1921 → 204 ms (**9.4x**). The win
+  is GPU-weighted, as expected — batching removes the `num_leaves^2` micro-launches
+  and the per-iteration syncs that dominate on the GPU.
+- **H2O/6-311G, n=19, 20 leaves, rho=1e-3, tol=1e-10:** the lstsq design matrix is
+  **~4.0 GB** (vs a ~1 MB ERI) — this is the OOM that motivated CG. Batched CG:
+  NumPy 2557 ms, **CuPy 432 ms (~5.9x)**. So at the real problem size the GPU wins
+  and CG is the only solver that fits.
+- **At small sizes the GPU loses** (n=7: CuPy CG 204 ms vs CPU lstsq 30 ms). The
+  matvec is too small to saturate; per-iteration launch + sync latency dominates.
+- **Crossover and the GPU advantage** (synthetic, leaves=n, rho=1e-2, tol=1e-4):
+  GPU time stays nearly flat while CPU explodes, so the GPU lead compounds with
+  size — this is the regime where this code outruns CPU-bound implementations:
+
+  | n  | NumPy ms | CuPy ms | GPU speedup |
+  |----|----------|---------|-------------|
+  | 8  | 4.4      | 20.9    | 0.2x        |
+  | 12 | 18.2     | 24.8    | 0.7x        |
+  | 16 | 61.1     | 28.4    | 2.2x        |
+  | 20 | 164.8    | 31.2    | 5.3x        |
+  | 28 | 778.2    | 36.1    | 21.6x       |
+
+**The dominant cost is iteration count, not the matvec.** Time is ~linear in CG
+iterations (~0.6 ms/iter on GPU at n=19), and iterations are set by the inner
+tolerance and conditioning, not by matvec efficiency:
+
+| rho  | tol   | iters | GPU ms |
+|------|-------|-------|--------|
+| 1e-3 | 1e-10 | 700   | 435    |
+| 1e-3 | 1e-6  | 316   | 200    |
+| 1e-3 | 1e-4  | 119   | 81     |
+| 1e-2 | 1e-10 | 245   | 159    |
+| 1e-2 | 1e-4  | 60    | 45     |
+
+So the next wins are **algorithmic**, and they compound the Tier-0 kernel win:
+
+1. **Inexact inner solve / forcing sequence** — the inner solve does not need
+   `tol=1e-10` every L-BFGS step (the gradient only needs to be accurate enough).
+   Loosening to ~1e-4 early is already ~5x here, for free.
+2. **Warm-start CG across L-BFGS steps** — the cores move slowly between steps;
+   starting from the previous `Z` should collapse the iteration count.
+3. **Jacobi / diagonal preconditioner** — attacks the condition number directly
+   (larger `rho` already shows the conditioning effect above).
+4. **CUDA graph capture** (Tier-0 item 3) — amortizes the per-iteration launch
+   overhead that makes the GPU lose at small sizes.
+
+Only once iteration count is controlled does the GPU's batched-matvec advantage
+dominate end-to-end; that is the regime where this code can outrun CPU-bound
+implementations of the same algorithm.
+
 ### If/when it goes native, port only the matvec
 
 The right seam is surgical: push **just `apply_operator`** (ideally with the

--- a/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
+++ b/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
@@ -282,18 +282,37 @@ So the next wins are **algorithmic**, and they compound the Tier-0 kernel win:
    CPU-favorable until ~n=64). `"cupy"`/`"numpy"` still force a backend. This is
    the "best of both" the benchmarks call for: no GPU penalty on small inputs, GPU
    speedup (growing with `n`) on large ones.
-3. **[TODO] Jacobi / diagonal preconditioner** — attacks the condition number
-   directly (larger `rho` already shows the conditioning effect above).
-4. **[TODO] CUDA graph capture** (Tier-0 item 3) — amortizes the per-iteration
+3. **[DONE] Batched GPU-resident reconstruct/gradient + eigh.** The per-step work
+   outside the inner solve is now fully batched over leaves: `_reconstruct_dev` is
+   a single `einsum("tpk,tqk,tkl,trl,tsl->pqrs", ...)` (leaf sum folded in) instead
+   of a Python loop with a separate `n^4` einsum per leaf; the gradient `dO/dU` is
+   one `einsum("aqrs,tqk,tkl,trl,tsl->tak", ...)` with a single device->host
+   transfer; and `unpack` exponentiates all leaf generators in one *batched*
+   Hermitian eigh (`expm_skew_symmetric_batched`, a single cuSOLVER call) instead
+   of `num_leaves` separate ones. Numerically identical (all 25 tests pass).
+   GPU-weighted as expected (it removes per-leaf launch overhead): end-to-end
+   accel path at n=16, 8 leaves, maxiter=150 drops **CuPy 9.6 -> 7.9 s (1.21x),
+   NumPy 5.9 -> 5.3 s (1.10x)**; the gain grows with leaf count.
+4. **[WONT — Jacobi is a no-op here]** A Jacobi/diagonal (or block-Jacobi-by-leaf)
+   preconditioner does nothing for this operator: orthonormal leaves give
+   `M_tt = (U_t^T U_t)^{circ 2} = I`, so the operator is `A = (1+2rho) I + C` with
+   `C` the pure inter-leaf coupling (zero diagonal). The diagonal is *exactly
+   constant* (`1+2rho`; verified numerically), so Jacobi is a uniform rescale and
+   leaves CG convergence unchanged. The conditioning (`~3/(2rho)`: `lambda_min =
+   2rho` exactly, `lambda_max ~ 3`) lives entirely in `C`. The effective option is
+   a **polynomial (Chebyshev) accelerator** on the known interval `[2rho, lambda_max]`
+   -- which is also sync-free (no per-iteration dot products, so GPU-friendly) but
+   needs `rho > 0` (falls back to CG at `rho = 0`). Deferred.
+5. **[TODO] CUDA graph capture** (Tier-0 item 3) — amortizes the per-iteration
    launch overhead that makes the GPU lose at small sizes.
 
-**Where the end-to-end time now goes** (profiled, full C-DF, CuPy, n=16, 8 leaves):
-inner CG solve ~53%, the `n^4` reconstruct/gradient `einsum`s + the per-leaf eigh
-in `unpack` (`expm_skew_symmetric`) ~45%, and `scipy.linalg.expm_frechet`
-(host) **only ~2%**. So the Fréchet derivative is *not* the bottleneck — contrary
-to the §1/§2 worry — and a GPU port of it buys little on its own. After the inner
-solve, the next target is the reconstruct/gradient contractions and the small
-eigendecompositions, all of which are still launch-bound at this size.
+**Where the end-to-end time went** (profiled *before* item 3, full C-DF, CuPy,
+n=16, 8 leaves): inner CG solve ~53%, the `n^4` reconstruct/gradient `einsum`s +
+the per-leaf eigh in `unpack` (`expm_skew_symmetric`) ~45%, and
+`scipy.linalg.expm_frechet` (host) **only ~2%**. So the Fréchet derivative is
+*not* the bottleneck — contrary to the §1/§2 worry — and a GPU port of it buys
+little on its own. That ~45% reconstruct/gradient/eigh share is what item 3 above
+batched; `expm_frechet` is deliberately left on the host.
 
 **End-to-end CPU/GPU crossover is ~n=18-20**, higher than the inner-solve
 crossover (~n=14-16), because the full step also runs L-BFGS, the per-leaf

--- a/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
+++ b/DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md
@@ -275,9 +275,16 @@ So the next wins are **algorithmic**, and they compound the Tier-0 kernel win:
    accuracy is unchanged. **End-to-end (synthetic n=16, 8 leaves, rho=1e-3,
    maxiter=150): NumPy 11.2 -> 5.9 s (1.9x), CuPy 17.5 -> 9.6 s (1.8x)**, with the
    final reconstruction error matching the cold/tight path.
-2. **[TODO] Jacobi / diagonal preconditioner** — attacks the condition number
+2. **[DONE] Size-aware `auto` backend.** Since the GPU loses below the crossover,
+   `backend="auto"` now picks NumPy for small problems and CuPy only at/above an
+   empirical orbital-count threshold (C-DF `n >= 18`, X-DF `n >= 56`; the X-DF
+   crossover is higher — a cheap Cholesky loop + tiny per-leaf eigh stays
+   CPU-favorable until ~n=64). `"cupy"`/`"numpy"` still force a backend. This is
+   the "best of both" the benchmarks call for: no GPU penalty on small inputs, GPU
+   speedup (growing with `n`) on large ones.
+3. **[TODO] Jacobi / diagonal preconditioner** — attacks the condition number
    directly (larger `rho` already shows the conditioning effect above).
-3. **[TODO] CUDA graph capture** (Tier-0 item 3) — amortizes the per-iteration
+4. **[TODO] CUDA graph capture** (Tier-0 item 3) — amortizes the per-iteration
    launch overhead that makes the GPU lose at small sizes.
 
 **Where the end-to-end time now goes** (profiled, full C-DF, CuPy, n=16, 8 leaves):

--- a/benchmarks/double_factorization/bench_cg_inner_solve.py
+++ b/benchmarks/double_factorization/bench_cg_inner_solve.py
@@ -35,7 +35,8 @@ import cudaq_algorithms as algorithms
 df = algorithms.double_factorization
 from cudaq_algorithms.double_factorization import _factorization as F
 from cudaq_algorithms.double_factorization._backend import (resolve_backend,
-                                                            to_device, to_numpy)
+                                                            to_device,
+                                                            to_numpy)
 
 
 def _sync(xp):
@@ -192,7 +193,8 @@ def run_default(eri, num_leaves, rho, tol, repeats, ab):
         new_time, new_cores = time_call(
             lambda: F._solve_inner_cores_cg(eri_dev, rotations, xp, rho, tol,
                                             None), repeats, xp)
-        print(f"  CG (batched)       : {new_time*1e3:9.2f} ms   ({iters} iters)")
+        print(
+            f"  CG (batched)       : {new_time*1e3:9.2f} ms   ({iters} iters)")
 
         if ab:
             old_time, old_cores = time_call(
@@ -207,8 +209,8 @@ def run_default(eri, num_leaves, rho, tol, repeats, ab):
         gb = lstsq_design_gb(n, num_leaves)
         if gb <= 8.0:
             ls_time, ls_cores = time_call(
-                lambda: F._solve_inner_cores_lstsq(eri_dev, rotations, xp, rho),
-                repeats, xp)
+                lambda: F._solve_inner_cores_lstsq(eri_dev, rotations, xp, rho
+                                                   ), repeats, xp)
             rn = to_numpy(F._reconstruct_dev(rotations, new_cores, xp))
             rl = to_numpy(F._reconstruct_dev(rotations, ls_cores, xp))
             print(f"  lstsq (design {gb:.2f} GB): {ls_time*1e3:9.2f} ms   "
@@ -230,8 +232,8 @@ def run_tol_sweep(eri, num_leaves, repeats):
             for tol in (1e-10, 1e-6, 1e-4):
                 iters = cg_iterations(eri_dev, rotations, xp, rho, tol)
                 t, _ = time_call(
-                    lambda: F._solve_inner_cores_cg(eri_dev, rotations, xp, rho,
-                                                    tol, None), repeats, xp)
+                    lambda: F._solve_inner_cores_cg(
+                        eri_dev, rotations, xp, rho, tol, None), repeats, xp)
                 print(f"  {rho:>8g} {tol:>8g} {iters:>6d} {t*1e3:>9.1f}")
 
 
@@ -251,6 +253,45 @@ def run_scaling(rho, tol, repeats):
             print(f"  {n:>4} {n:>7} {iters:>6d} {t*1e3:>9.1f}")
 
 
+def run_full(num_leaves, rho, max_iterations, repeats):
+    """End-to-end compressed_double_factorization: warm-start + inexact in-loop
+    CG ('accel', the new defaults) vs the cold/tight in-loop solve ('plain'),
+    on a synthetic ERI. Verifies the final reconstruction error matches."""
+    n = 16
+    eri = synthetic_eri(n, num_vectors=max(2, num_leaves - 1), seed=5)
+    for backend in _backends():
+        print(f"\n=== full C-DF  {backend}  n={n}  leaves={num_leaves}  "
+              f"rho={rho:g}  maxiter={max_iterations} ===")
+
+        def solve(accel):
+            kw = dict(num_leaves=num_leaves,
+                      max_iterations=max_iterations,
+                      regularization=rho,
+                      inner_solver="cg",
+                      backend=backend)
+            if not accel:  # original behavior: cold start, tight in-loop solve
+                kw.update(cg_warm_start=False, cg_optimization_tolerance=1e-10)
+            return df.compressed_double_factorization(eri, **kw)
+
+        best_plain = best_accel = float("inf")
+        err_plain = err_accel = None
+        for _ in range(repeats):
+            t = time.perf_counter()
+            f = solve(False)
+            best_plain = min(best_plain, time.perf_counter() - t)
+            err_plain = df.factorization_error(eri, f)
+            t = time.perf_counter()
+            f = solve(True)
+            best_accel = min(best_accel, time.perf_counter() - t)
+            err_accel = df.factorization_error(eri, f)
+        print(
+            f"  plain (cold, tol=1e-10): {best_plain:7.2f} s  err={err_plain:.3e}"
+        )
+        print(
+            f"  accel (warm + inexact) : {best_accel:7.2f} s  err={err_accel:.3e}"
+            f"   speedup x{best_plain/best_accel:.1f}")
+
+
 def _backends():
     backends = ["numpy"]
     if df.cupy_gpu_available():
@@ -265,25 +306,33 @@ def main():
     parser.add_argument("--rho", type=float, default=1e-3)
     parser.add_argument("--tol", type=float, default=1e-10)
     parser.add_argument("--repeats", type=int, default=3)
-    parser.add_argument("--ab", action="store_true",
+    parser.add_argument("--ab",
+                        action="store_true",
                         help="also time the original list-based CG (slow)")
     parser.add_argument("--tol-sweep", action="store_true")
     parser.add_argument("--scaling", action="store_true")
+    parser.add_argument("--full",
+                        action="store_true",
+                        help="end-to-end C-DF: accel vs plain in-loop CG")
+    parser.add_argument("--max-iterations", type=int, default=150)
     args = parser.parse_args()
 
     if not df.cupy_gpu_available():
         print("(CuPy GPU not available -- NumPy only)")
 
-    eri = molecular_eri(args.basis)
-    print(f"H2O/{args.basis}: n={eri.shape[0]}  "
-          f"||eri||_F={np.linalg.norm(eri):.4f}")
-
-    if args.tol_sweep:
-        run_tol_sweep(eri, args.leaves, args.repeats)
-    elif args.scaling:
+    if args.full:  # synthetic ERI; no PySCF needed
+        run_full(args.leaves, args.rho, args.max_iterations, args.repeats)
+    elif args.scaling:  # synthetic sweep; no PySCF needed
         run_scaling(args.rho, args.tol, args.repeats)
     else:
-        run_default(eri, args.leaves, args.rho, args.tol, args.repeats, args.ab)
+        eri = molecular_eri(args.basis)
+        print(f"H2O/{args.basis}: n={eri.shape[0]}  "
+              f"||eri||_F={np.linalg.norm(eri):.4f}")
+        if args.tol_sweep:
+            run_tol_sweep(eri, args.leaves, args.repeats)
+        else:
+            run_default(eri, args.leaves, args.rho, args.tol, args.repeats,
+                        args.ab)
 
 
 if __name__ == "__main__":

--- a/benchmarks/double_factorization/bench_cg_inner_solve.py
+++ b/benchmarks/double_factorization/bench_cg_inner_solve.py
@@ -34,9 +34,9 @@ import cudaq_algorithms as algorithms
 
 df = algorithms.double_factorization
 from cudaq_algorithms.double_factorization import _factorization as F
-from cudaq_algorithms.double_factorization._backend import (resolve_backend,
-                                                            to_device,
-                                                            to_numpy)
+from cudaq_algorithms.double_factorization._backend import (
+    AUTO_GPU_MIN_ORBITALS_COMPRESSED, AUTO_GPU_MIN_ORBITALS_EXPLICIT,
+    resolve_backend, to_device, to_numpy)
 
 
 def _sync(xp):
@@ -291,6 +291,63 @@ def run_full(n, num_leaves, rho, max_iterations, repeats):
             f"   speedup x{best_plain/best_accel:.1f}")
 
 
+def run_leaf_sweep(eri, leaf_counts, rho, max_iterations, repeats):
+    """Time and accuracy vs leaf count for X-DF (Cholesky first factorization)
+    and C-DF (matrix-free CG inner solve), on a molecular ERI. Rows print as they
+    are computed so partial results survive if the large leaf counts run long."""
+    n = eri.shape[0]
+    norm = float(np.linalg.norm(eri))
+    xdf_backend = resolve_backend(
+        "auto", problem_size=n, gpu_min_size=AUTO_GPU_MIN_ORBITALS_EXPLICIT)[1]
+    cdf_backend = resolve_backend(
+        "auto", problem_size=n,
+        gpu_min_size=AUTO_GPU_MIN_ORBITALS_COMPRESSED)[1]
+    print(
+        f"\n=== leaf sweep  n={n}  rho={rho:g}  C-DF maxiter={max_iterations} "
+        f"  (auto backends: X-DF={xdf_backend}, C-DF={cdf_backend}) ===")
+    print(f"  {'leaves':>6} | {'X-DF s':>8} {'X-DF rel':>10} | "
+          f"{'C-DF s':>8} {'C-DF rel':>10}  {'C-DF/X-DF err':>13}")
+
+    for num_leaves in leaf_counts:
+
+        def do_xdf():
+            return df.explicit_double_factorization(
+                eri,
+                threshold=0.0,
+                max_num_leaves=num_leaves,
+                first_factorization="cholesky",
+                backend="auto")
+
+        def do_cdf():
+            return df.compressed_double_factorization(
+                eri,
+                num_leaves=num_leaves,
+                max_iterations=max_iterations,
+                regularization=rho,
+                inner_solver="cg",
+                backend="auto")
+
+        t_x, xdf = _best_time(do_xdf, repeats, xdf_backend)
+        x_rel = df.factorization_error(eri, xdf) / norm
+        t_c, cdf = _best_time(do_cdf, repeats, cdf_backend)
+        c_rel = df.factorization_error(eri, cdf) / norm
+        ratio = c_rel / x_rel if x_rel > 0 else float("nan")
+        print(f"  {num_leaves:>6} | {t_x:>8.3f} {x_rel:>10.3e} | "
+              f"{t_c:>8.3f} {c_rel:>10.3e}  {ratio:>12.2f}x")
+
+
+def _best_time(fn, repeats, backend_name):
+    xp, _ = resolve_backend(backend_name)
+    best = float("inf")
+    result = None
+    for _ in range(repeats):
+        start = time.perf_counter()
+        result = fn()
+        _sync(xp)
+        best = min(best, time.perf_counter() - start)
+    return best, result
+
+
 def _backends():
     backends = ["numpy"]
     if df.cupy_gpu_available():
@@ -318,6 +375,13 @@ def main():
                         default=16,
                         help="orbital count for --full (synthetic ERI)")
     parser.add_argument("--max-iterations", type=int, default=150)
+    parser.add_argument("--leaf-sweep",
+                        action="store_true",
+                        help="X-DF (Cholesky) and C-DF (CG) time/accuracy vs "
+                        "leaf count, on the molecular ERI")
+    parser.add_argument("--leaves-list",
+                        default="4,16,32,64,96",
+                        help="comma-separated leaf counts for --leaf-sweep")
     args = parser.parse_args()
 
     if not df.cupy_gpu_available():
@@ -332,7 +396,11 @@ def main():
         eri = molecular_eri(args.basis)
         print(f"H2O/{args.basis}: n={eri.shape[0]}  "
               f"||eri||_F={np.linalg.norm(eri):.4f}")
-        if args.tol_sweep:
+        if args.leaf_sweep:
+            leaf_counts = [int(x) for x in args.leaves_list.split(",")]
+            run_leaf_sweep(eri, leaf_counts, args.rho, args.max_iterations,
+                           args.repeats)
+        elif args.tol_sweep:
             run_tol_sweep(eri, args.leaves, args.repeats)
         else:
             run_default(eri, args.leaves, args.rho, args.tol, args.repeats,

--- a/benchmarks/double_factorization/bench_cg_inner_solve.py
+++ b/benchmarks/double_factorization/bench_cg_inner_solve.py
@@ -1,0 +1,290 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Benchmarks for the C-DF matrix-free CG inner core solve.
+
+Modes:
+  (default)     new batched CG vs explicit lstsq (where the design matrix fits),
+                on NumPy and CuPy.
+  --ab          also time the original list-based CG to measure the Tier-0
+                vectorization win. SLOW at n>=19 -- the list-based CG is exactly
+                what this work replaced.
+  --tol-sweep   CG iterations and time vs inner tolerance / regularization.
+                Shows that cost is iteration-bound, not matvec-bound.
+  --scaling     synthetic sweep in n to locate the CPU/GPU crossover.
+
+Default problem is H2O/6-311G (n = 19), the case that motivated the matrix-free
+path: there the lstsq design matrix is ~4 GB while the ERI itself is ~1 MB.
+
+    PYTHONPATH=build/python:/usr/local/cudaq python3 \
+        benchmarks/double_factorization/bench_cg_inner_solve.py --tol-sweep
+"""
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+
+import cudaq_algorithms as algorithms
+
+df = algorithms.double_factorization
+from cudaq_algorithms.double_factorization import _factorization as F
+from cudaq_algorithms.double_factorization._backend import (resolve_backend,
+                                                            to_device, to_numpy)
+
+
+def _sync(xp):
+    """Block until queued device work finishes (no-op on NumPy)."""
+    if xp.__name__ == "cupy":
+        xp.cuda.runtime.deviceSynchronize()
+
+
+def molecular_eri(basis):
+    from pyscf import ao2mo, gto, scf
+    mol = gto.M(atom="O 0 0 0; H 0 0 0.957; H 0 0.926 -0.24",
+                basis=basis,
+                verbose=0)
+    mf = scf.RHF(mol).run()
+    n = mf.mo_coeff.shape[1]
+    return np.asarray(ao2mo.restore("s1", ao2mo.kernel(mol, mf.mo_coeff), n))
+
+
+def synthetic_eri(n, num_vectors, seed=0):
+    rng = np.random.default_rng(seed)
+    leaves = rng.standard_normal((num_vectors, n, n))
+    leaves = 0.5 * (leaves + leaves.transpose(0, 2, 1))
+    return np.einsum("xpq,xrs->pqrs", leaves, leaves)
+
+
+def warm_start_rotations(eri, num_leaves, xp):
+    """Realistic leaf rotations: the top ``num_leaves`` X-DF leaves on device."""
+    xdf = df.explicit_double_factorization(eri,
+                                           threshold=0.0,
+                                           max_num_leaves=num_leaves)
+    rotations = xdf.leaf_rotations[:num_leaves]
+    while len(rotations) < num_leaves:  # pad if rank-deficient
+        rotations.append(np.eye(eri.shape[0]))
+    return [to_device(np.asarray(r, dtype=float), xp) for r in rotations]
+
+
+def cg_iterations(eri_dev, rotations_dev, xp, regularization, tolerance):
+    """Iteration count for the batched CG (mirrors _solve_inner_cores_cg)."""
+    n = eri_dev.shape[0]
+    num_leaves = len(rotations_dev)
+    rotations = xp.stack(rotations_dev)
+    metric = xp.einsum("tpk,upl->tukl", rotations, rotations)
+    metric = metric * metric
+    rhs = xp.stack(
+        [F._project_eri_into_leaf(eri_dev, u, xp) for u in rotations_dev])
+
+    def apply_operator(z):
+        out = xp.einsum("tukl,ulm,tunm->tkn", metric, z, metric, optimize=True)
+        return out + (2.0 * regularization) * z if regularization > 0 else out
+
+    ip = lambda x, y: xp.sum(x * y)
+    z = xp.zeros((num_leaves, n, n))
+    residual = rhs.copy()
+    direction = residual.copy()
+    rs = ip(residual, residual)
+    threshold = (tolerance**2) * max(float(to_numpy(rs)), 1.0)
+    iterations = 0
+    for _ in range(max(50, num_leaves * n * n)):
+        if float(to_numpy(rs)) <= threshold:
+            break
+        iterations += 1
+        ad = apply_operator(direction)
+        curvature = ip(direction, ad)
+        if float(to_numpy(curvature)) <= 0:
+            break
+        step = rs / curvature
+        z = z + step * direction
+        residual = residual - step * ad
+        new = ip(residual, residual)
+        direction = residual + (new / rs) * direction
+        rs = new
+    return iterations
+
+
+# --------------------------------------------------------------------------- #
+# The ORIGINAL list-based CG, reconstructed here so we can A/B the Tier-0 win.
+# (Double for-loop matvec; per-iteration host sync on every inner product.)
+# --------------------------------------------------------------------------- #
+def cg_list_based(eri_dev, rotations_dev, xp, regularization, tolerance):
+    n = eri_dev.shape[0]
+    num_leaves = len(rotations_dev)
+    overlaps = [[
+        rotations_dev[t].T @ rotations_dev[u] for u in range(num_leaves)
+    ] for t in range(num_leaves)]
+    metric = [[overlaps[t][u] * overlaps[t][u] for u in range(num_leaves)]
+              for t in range(num_leaves)]
+    rhs = [F._project_eri_into_leaf(eri_dev, u, xp) for u in rotations_dev]
+
+    def apply_operator(z):
+        result = []
+        for t in range(num_leaves):
+            acc = xp.zeros((n, n))
+            for u in range(num_leaves):
+                acc = acc + metric[t][u] @ z[u] @ metric[t][u].T
+            if regularization > 0.0:
+                acc = acc + 2.0 * regularization * z[t]
+            result.append(acc)
+        return result
+
+    def inner_product(x, y):
+        return float(to_numpy(sum(xp.sum(xi * yi) for xi, yi in zip(x, y))))
+
+    z = [xp.zeros((n, n)) for _ in range(num_leaves)]
+    residual = [r.copy() for r in rhs]
+    direction = [r.copy() for r in residual]
+    residual_norm_sq = inner_product(residual, residual)
+    threshold = (tolerance**2) * max(residual_norm_sq, 1.0)
+    for _ in range(max(50, num_leaves * n * n)):
+        if residual_norm_sq <= threshold:
+            break
+        operator_direction = apply_operator(direction)
+        curvature = inner_product(direction, operator_direction)
+        if curvature <= 0.0:
+            break
+        step = residual_norm_sq / curvature
+        z = [zi + step * di for zi, di in zip(z, direction)]
+        residual = [
+            ri - step * oi for ri, oi in zip(residual, operator_direction)
+        ]
+        new_norm_sq = inner_product(residual, residual)
+        beta = new_norm_sq / residual_norm_sq
+        direction = [ri + beta * di for ri, di in zip(residual, direction)]
+        residual_norm_sq = new_norm_sq
+    return [0.5 * (zi + zi.T) for zi in z]
+
+
+def time_call(fn, repeats, xp):
+    fn()  # warm up (allocations, cuBLAS handles)
+    _sync(xp)
+    best = float("inf")
+    result = None
+    for _ in range(repeats):
+        start = time.perf_counter()
+        result = fn()
+        _sync(xp)
+        best = min(best, time.perf_counter() - start)
+    return best, result
+
+
+def lstsq_design_gb(n, num_leaves):
+    return (n**4) * (num_leaves * n * (n + 1) // 2) * 8 / 1e9
+
+
+def run_default(eri, num_leaves, rho, tol, repeats, ab):
+    n = eri.shape[0]
+    for backend in _backends():
+        xp, name = resolve_backend(backend)
+        eri_dev = to_device(np.asarray(eri, dtype=float), xp)
+        rotations = warm_start_rotations(eri, num_leaves, xp)
+        print(f"\n=== {name}  n={n}  leaves={num_leaves}  rho={rho:g}  "
+              f"tol={tol:g} ===")
+
+        iters = cg_iterations(eri_dev, rotations, xp, rho, tol)
+        new_time, new_cores = time_call(
+            lambda: F._solve_inner_cores_cg(eri_dev, rotations, xp, rho, tol,
+                                            None), repeats, xp)
+        print(f"  CG (batched)       : {new_time*1e3:9.2f} ms   ({iters} iters)")
+
+        if ab:
+            old_time, old_cores = time_call(
+                lambda: cg_list_based(eri_dev, rotations, xp, rho, tol),
+                repeats, xp)
+            diff = max(
+                float(np.linalg.norm(to_numpy(a) - to_numpy(b)))
+                for a, b in zip(new_cores, old_cores))
+            print(f"  CG (old list-based): {old_time*1e3:9.2f} ms   "
+                  f"speedup x{old_time/new_time:.1f}   |dZ|={diff:.1e}")
+
+        gb = lstsq_design_gb(n, num_leaves)
+        if gb <= 8.0:
+            ls_time, ls_cores = time_call(
+                lambda: F._solve_inner_cores_lstsq(eri_dev, rotations, xp, rho),
+                repeats, xp)
+            rn = to_numpy(F._reconstruct_dev(rotations, new_cores, xp))
+            rl = to_numpy(F._reconstruct_dev(rotations, ls_cores, xp))
+            print(f"  lstsq (design {gb:.2f} GB): {ls_time*1e3:9.2f} ms   "
+                  f"|recon dCG-lstsq|={np.linalg.norm(rn-rl):.1e}")
+        else:
+            print(f"  lstsq: SKIPPED -- design matrix {gb:.1f} GB (> 8 GB); "
+                  f"this is the case CG exists for.")
+
+
+def run_tol_sweep(eri, num_leaves, repeats):
+    n = eri.shape[0]
+    for backend in _backends():
+        xp, name = resolve_backend(backend)
+        eri_dev = to_device(np.asarray(eri, dtype=float), xp)
+        rotations = warm_start_rotations(eri, num_leaves, xp)
+        print(f"\n=== tol/rho sweep  {name}  n={n}  leaves={num_leaves} ===")
+        print(f"  {'rho':>8} {'tol':>8} {'iters':>6} {'ms':>9}")
+        for rho in (1e-3, 1e-2):
+            for tol in (1e-10, 1e-6, 1e-4):
+                iters = cg_iterations(eri_dev, rotations, xp, rho, tol)
+                t, _ = time_call(
+                    lambda: F._solve_inner_cores_cg(eri_dev, rotations, xp, rho,
+                                                    tol, None), repeats, xp)
+                print(f"  {rho:>8g} {tol:>8g} {iters:>6d} {t*1e3:>9.1f}")
+
+
+def run_scaling(rho, tol, repeats):
+    for backend in _backends():
+        xp, name = resolve_backend(backend)
+        print(f"\n=== scaling sweep (synthetic)  {name}  rho={rho:g} ===")
+        print(f"  {'n':>4} {'leaves':>7} {'iters':>6} {'ms':>9}")
+        for n in (8, 16, 24, 32, 48):
+            eri = synthetic_eri(n, num_vectors=max(2, n // 2), seed=1)
+            eri_dev = to_device(eri, xp)
+            rotations = warm_start_rotations(eri, n, xp)
+            iters = cg_iterations(eri_dev, rotations, xp, rho, tol)
+            t, _ = time_call(
+                lambda: F._solve_inner_cores_cg(eri_dev, rotations, xp, rho,
+                                                tol, None), repeats, xp)
+            print(f"  {n:>4} {n:>7} {iters:>6d} {t*1e3:>9.1f}")
+
+
+def _backends():
+    backends = ["numpy"]
+    if df.cupy_gpu_available():
+        backends.append("cupy")
+    return backends
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--basis", default="6-311g")
+    parser.add_argument("--leaves", type=int, default=20)
+    parser.add_argument("--rho", type=float, default=1e-3)
+    parser.add_argument("--tol", type=float, default=1e-10)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--ab", action="store_true",
+                        help="also time the original list-based CG (slow)")
+    parser.add_argument("--tol-sweep", action="store_true")
+    parser.add_argument("--scaling", action="store_true")
+    args = parser.parse_args()
+
+    if not df.cupy_gpu_available():
+        print("(CuPy GPU not available -- NumPy only)")
+
+    eri = molecular_eri(args.basis)
+    print(f"H2O/{args.basis}: n={eri.shape[0]}  "
+          f"||eri||_F={np.linalg.norm(eri):.4f}")
+
+    if args.tol_sweep:
+        run_tol_sweep(eri, args.leaves, args.repeats)
+    elif args.scaling:
+        run_scaling(args.rho, args.tol, args.repeats)
+    else:
+        run_default(eri, args.leaves, args.rho, args.tol, args.repeats, args.ab)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/double_factorization/bench_cg_inner_solve.py
+++ b/benchmarks/double_factorization/bench_cg_inner_solve.py
@@ -253,11 +253,10 @@ def run_scaling(rho, tol, repeats):
             print(f"  {n:>4} {n:>7} {iters:>6d} {t*1e3:>9.1f}")
 
 
-def run_full(num_leaves, rho, max_iterations, repeats):
+def run_full(n, num_leaves, rho, max_iterations, repeats):
     """End-to-end compressed_double_factorization: warm-start + inexact in-loop
     CG ('accel', the new defaults) vs the cold/tight in-loop solve ('plain'),
     on a synthetic ERI. Verifies the final reconstruction error matches."""
-    n = 16
     eri = synthetic_eri(n, num_vectors=max(2, num_leaves - 1), seed=5)
     for backend in _backends():
         print(f"\n=== full C-DF  {backend}  n={n}  leaves={num_leaves}  "
@@ -314,6 +313,10 @@ def main():
     parser.add_argument("--full",
                         action="store_true",
                         help="end-to-end C-DF: accel vs plain in-loop CG")
+    parser.add_argument("--n",
+                        type=int,
+                        default=16,
+                        help="orbital count for --full (synthetic ERI)")
     parser.add_argument("--max-iterations", type=int, default=150)
     args = parser.parse_args()
 
@@ -321,7 +324,8 @@ def main():
         print("(CuPy GPU not available -- NumPy only)")
 
     if args.full:  # synthetic ERI; no PySCF needed
-        run_full(args.leaves, args.rho, args.max_iterations, args.repeats)
+        run_full(args.n, args.leaves, args.rho, args.max_iterations,
+                 args.repeats)
     elif args.scaling:  # synthetic sweep; no PySCF needed
         run_scaling(args.rho, args.tol, args.repeats)
     else:

--- a/docs/double_factorization.md
+++ b/docs/double_factorization.md
@@ -35,7 +35,7 @@ accepts `backend="auto"` (default), `"cupy"`, or `"numpy"`.
 | function | description |
 |----------|-------------|
 | `explicit_double_factorization(eri, threshold=1e-8, max_num_leaves=None, second_factor_threshold=0.0, first_factorization="cholesky", backend="auto")` | X-DF (rank-one cores). First factorization defaults to **pivoted Cholesky**; pass `first_factorization="eigendecomposition"` for the eigendecomposition variant. |
-| `compressed_double_factorization(eri, num_leaves, max_iterations=2000, tolerance=1e-10, regularization=0.0, backend="auto")` | C-DF by least-squares optimization (warm-started from X-DF). `regularization=rho>0` enables **RC-DF** (see below). |
+| `compressed_double_factorization(eri, num_leaves, max_iterations=2000, tolerance=1e-10, regularization=0.0, inner_solver="lstsq", cg_tolerance=1e-10, cg_max_iterations=None, backend="auto")` | C-DF by least-squares optimization (warm-started from X-DF). `regularization=rho>0` enables **RC-DF** (see below). `inner_solver="cg"` selects the matrix-free inner core solve (see below). |
 | `reconstruct_eri(factorization)` | Rebuild the `(pq\|rs)` tensor from a factorization. |
 | `factorization_error(eri, factorization)` | Frobenius norm of the reconstruction residual. |
 | `modified_one_body_integrals(one_body, eri)` | The DF one-body correction `kappa_pq = h_pq - 1/2 sum_r (pr\|qr)`. |
@@ -79,6 +79,24 @@ depends on the integral magnitude (the paper uses `~1e-6` to `1e-3`); pick it by
 trading off `factorization_error` against `double_factorization_one_norm`. By the
 envelope theorem the analytic optimization gradient is unchanged in form, so
 RC-DF runs at the same per-iteration cost as plain C-DF.
+
+## Inner core solve: explicit vs matrix-free
+
+At each L-BFGS step the symmetric cores `Z^t` are recovered exactly by a linear
+solve for fixed rotations. Two solvers are available via `inner_solver`:
+
+- `"lstsq"` (default) forms an explicit `n^4 x num_params` design matrix and
+  solves it with least squares. Simple and robust for small/medium systems, but
+  the design matrix does not scale.
+- `"cg"` is the **matrix-free conjugate-gradient** solve (RC-DF,
+  [arXiv:2212.07957](https://arxiv.org/abs/2212.07957), Eqs. 25-30). It applies
+  the normal-equations operator `A(Z)^t = sum_{t'} M_{tt'} Z^{t'} M_{tt'}^T` with
+  `M_{tt'} = (U^t^T U^{t'})` elementwise-squared — only `n x n` matrix products,
+  never materializing the design matrix — so it scales to large orbital counts.
+  `cg_tolerance` and `cg_max_iterations` control the CG iteration.
+
+Both solvers produce the same reconstruction; when the inner system is full rank
+(e.g. `regularization > 0`) they produce the same cores to machine precision.
 
 ## Example
 

--- a/docs/double_factorization.md
+++ b/docs/double_factorization.md
@@ -1,0 +1,66 @@
+# Double Factorization (X-DF and C-DF)
+
+`cudaq_algorithms.double_factorization` factorizes the two-electron integrals of
+an electronic-structure Hamiltonian into a sum of low-rank, diagonalizable pieces
+— the representation used by double-factorized block encodings, qubitization, and
+measurement schemes. It implements the explicit (X-DF) and compressed (C-DF)
+variants of Cohn, Motta, and Parrish, *Quantum Filter Diagonalization with
+Compressed Double-Factorized Hamiltonians*, PRX Quantum **2**, 040352 (2021)
+([arXiv:2104.08957](https://arxiv.org/abs/2104.08957)).
+
+## Convention
+
+The two-electron integrals are supplied in **chemist notation** `(pq|rs)` over
+real spatial orbitals (8-fold symmetric), as an `(n, n, n, n)` array `eri` with
+`eri[p, q, r, s] == (pq|rs)` (e.g. from `pyscf.ao2mo.restore("s1", ...)`).
+
+Double factorization writes
+
+```
+(pq|rs)  ~=  sum_t sum_{k,l} U^t_pk U^t_qk  Z^t_kl  U^t_rl U^t_sl
+```
+
+with orthogonal **leaf rotations** `U^t` (which compile into a Givens-rotation
+fabric) and symmetric **core** matrices `Z^t`.
+
+## Backends (NVIDIA math libraries)
+
+Heavy linear algebra (eigendecompositions, tensor contractions, least squares)
+runs on the NVIDIA math libraries — cuSOLVER and cuBLAS via **CuPy** — when a GPU
+is available, and falls back to **NumPy/SciPy** otherwise. Every entry point
+accepts `backend="auto"` (default), `"cupy"`, or `"numpy"`.
+
+## API
+
+| function | description |
+|----------|-------------|
+| `explicit_double_factorization(eri, eigenvalue_threshold=1e-8, max_num_leaves=None, second_factor_threshold=0.0, backend="auto")` | X-DF via nested eigendecompositions (rank-one cores). |
+| `compressed_double_factorization(eri, num_leaves, max_iterations=2000, tolerance=1e-10, regularization=0.0, backend="auto")` | C-DF by least-squares optimization (warm-started from X-DF). |
+| `reconstruct_eri(factorization)` | Rebuild the `(pq\|rs)` tensor from a factorization. |
+| `factorization_error(eri, factorization)` | Frobenius norm of the reconstruction residual. |
+| `modified_one_body_integrals(one_body, eri)` | The DF one-body correction `kappa_pq = h_pq - 1/2 sum_r (pr\|qr)`. |
+| `double_factorization_one_norm(factorization, one_body_eigenvalues)` | LCU one-norm `lambda` of the DF Hamiltonian. |
+
+All functions return/operate on a `DoubleFactorization` dataclass with
+`num_orbitals`, `leaf_rotations` (`U^t`), `leaf_cores` (`Z^t`), `num_leaves`, and
+`reconstruct_eri()`.
+
+## X-DF vs C-DF
+
+- **X-DF** is exact and cheap: the ERI supermatrix is eigendecomposed into leaves
+  `(pq|rs) = sum_t lambda_t V^t_pq V^t_rs` (truncating small `|lambda_t|`), then
+  each symmetric leaf `V^t` is eigendecomposed to give `U^t` and the rank-one core
+  `Z^t_kl = lambda_t gamma^t_k gamma^t_l`. At full rank the reconstruction is
+  exact to machine precision.
+- **C-DF** lifts the rank-one restriction on `Z^t` and minimizes
+  `O = 1/2 || eri - reconstruction ||_F^2` over a fixed number of leaves. The leaf
+  rotations are parameterized as `U^t = exp(X^t)` (antisymmetric `X^t`) and
+  optimized with L-BFGS, while the symmetric cores are solved in closed form at
+  each step (the two-step scheme of the paper, warm-started from X-DF). C-DF
+  reaches a target accuracy with substantially fewer leaves than X-DF.
+
+## Example
+
+See [`examples/double_factorization/double_factorization.py`](../examples/double_factorization/double_factorization.py),
+which factorizes H2O/STO-3G integrals from PySCF and compares X-DF and C-DF
+reconstruction errors at equal leaf counts.

--- a/docs/double_factorization.md
+++ b/docs/double_factorization.md
@@ -35,7 +35,7 @@ accepts `backend="auto"` (default), `"cupy"`, or `"numpy"`.
 | function | description |
 |----------|-------------|
 | `explicit_double_factorization(eri, threshold=1e-8, max_num_leaves=None, second_factor_threshold=0.0, first_factorization="cholesky", backend="auto")` | X-DF (rank-one cores). First factorization defaults to **pivoted Cholesky**; pass `first_factorization="eigendecomposition"` for the eigendecomposition variant. |
-| `compressed_double_factorization(eri, num_leaves, max_iterations=2000, tolerance=1e-10, regularization=0.0, inner_solver="lstsq", cg_tolerance=1e-10, cg_max_iterations=None, backend="auto")` | C-DF by least-squares optimization (warm-started from X-DF). `regularization=rho>0` enables **RC-DF** (see below). `inner_solver="cg"` selects the matrix-free inner core solve (see below). |
+| `compressed_double_factorization(eri, num_leaves, max_iterations=2000, tolerance=1e-10, regularization=0.0, inner_solver="lstsq", cg_tolerance=1e-10, cg_max_iterations=None, cg_warm_start=True, cg_optimization_tolerance=None, backend="auto")` | C-DF by least-squares optimization (warm-started from X-DF). `regularization=rho>0` enables **RC-DF** (see below). `inner_solver="cg"` selects the matrix-free inner core solve, with `cg_warm_start` / `cg_optimization_tolerance` accelerators (see below). |
 | `reconstruct_eri(factorization)` | Rebuild the `(pq\|rs)` tensor from a factorization. |
 | `factorization_error(eri, factorization)` | Frobenius norm of the reconstruction residual. |
 | `modified_one_body_integrals(one_body, eri)` | The DF one-body correction `kappa_pq = h_pq - 1/2 sum_r (pr\|qr)`. |
@@ -97,6 +97,20 @@ solve for fixed rotations. Two solvers are available via `inner_solver`:
 
 Both solvers produce the same reconstruction; when the inner system is full rank
 (e.g. `regularization > 0`) they produce the same cores to machine precision.
+
+The CG inner solve is **iteration-bound**: its cost is roughly linear in the
+number of CG iterations, which is set by the requested tolerance and the
+conditioning, not by the matvec. Two accelerators (active only for
+`inner_solver="cg"`) cut the per-step cost without changing the final accuracy:
+
+- **`cg_warm_start=True`** seeds each L-BFGS step's CG from the previous step's
+  cores. The cores move slowly between steps, so the warm start collapses the
+  iteration count.
+- **`cg_optimization_tolerance`** (default `max(cg_tolerance, 1e-6)`) solves the
+  *in-loop* systems only loosely — an inexact inner solve, which is sound here
+  because the envelope theorem only needs an approximate gradient — while the
+  single **final** solve is tightened to `cg_tolerance`. So the returned cores
+  are accurate even though the optimization steps used a cheap inner solve.
 
 ## Example
 

--- a/docs/double_factorization.md
+++ b/docs/double_factorization.md
@@ -34,7 +34,7 @@ accepts `backend="auto"` (default), `"cupy"`, or `"numpy"`.
 
 | function | description |
 |----------|-------------|
-| `explicit_double_factorization(eri, eigenvalue_threshold=1e-8, max_num_leaves=None, second_factor_threshold=0.0, backend="auto")` | X-DF via nested eigendecompositions (rank-one cores). |
+| `explicit_double_factorization(eri, threshold=1e-8, max_num_leaves=None, second_factor_threshold=0.0, first_factorization="cholesky", backend="auto")` | X-DF (rank-one cores). First factorization defaults to **pivoted Cholesky**; pass `first_factorization="eigendecomposition"` for the eigendecomposition variant. |
 | `compressed_double_factorization(eri, num_leaves, max_iterations=2000, tolerance=1e-10, regularization=0.0, backend="auto")` | C-DF by least-squares optimization (warm-started from X-DF). |
 | `reconstruct_eri(factorization)` | Rebuild the `(pq\|rs)` tensor from a factorization. |
 | `factorization_error(eri, factorization)` | Frobenius norm of the reconstruction residual. |
@@ -47,11 +47,17 @@ All functions return/operate on a `DoubleFactorization` dataclass with
 
 ## X-DF vs C-DF
 
-- **X-DF** is exact and cheap: the ERI supermatrix is eigendecomposed into leaves
-  `(pq|rs) = sum_t lambda_t V^t_pq V^t_rs` (truncating small `|lambda_t|`), then
-  each symmetric leaf `V^t` is eigendecomposed to give `U^t` and the rank-one core
-  `Z^t_kl = lambda_t gamma^t_k gamma^t_l`. At full rank the reconstruction is
-  exact to machine precision.
+- **X-DF** is exact and cheap. The first factorization of the ERI supermatrix
+  into symmetric leaves `(pq|rs) = sum_t L^t_pq L^t_rs` defaults to **pivoted
+  Cholesky**: the ERI matrix is positive semidefinite (a Gram matrix of orbital
+  densities), so Cholesky is rank-revealing — it keeps leaves while the residual
+  pivot exceeds `threshold` and stops at the true rank (at most the symmetric-pair
+  dimension `n(n+1)/2`), which is cheaper than a full eigendecomposition. (Pass
+  `first_factorization="eigendecomposition"` for the symmetric-eigendecomposition
+  variant, `(pq|rs) = sum_t lambda_t V^t_pq V^t_rs`, required for indefinite
+  inputs.) Each symmetric leaf is then eigendecomposed to give `U^t` and the
+  rank-one core `Z^t`. At full rank the reconstruction is exact to machine
+  precision, independent of the first-factor method.
 - **C-DF** lifts the rank-one restriction on `Z^t` and minimizes
   `O = 1/2 || eri - reconstruction ||_F^2` over a fixed number of leaves. The leaf
   rotations are parameterized as `U^t = exp(X^t)` (antisymmetric `X^t`) and

--- a/docs/double_factorization.md
+++ b/docs/double_factorization.md
@@ -35,11 +35,11 @@ accepts `backend="auto"` (default), `"cupy"`, or `"numpy"`.
 | function | description |
 |----------|-------------|
 | `explicit_double_factorization(eri, threshold=1e-8, max_num_leaves=None, second_factor_threshold=0.0, first_factorization="cholesky", backend="auto")` | X-DF (rank-one cores). First factorization defaults to **pivoted Cholesky**; pass `first_factorization="eigendecomposition"` for the eigendecomposition variant. |
-| `compressed_double_factorization(eri, num_leaves, max_iterations=2000, tolerance=1e-10, regularization=0.0, backend="auto")` | C-DF by least-squares optimization (warm-started from X-DF). |
+| `compressed_double_factorization(eri, num_leaves, max_iterations=2000, tolerance=1e-10, regularization=0.0, backend="auto")` | C-DF by least-squares optimization (warm-started from X-DF). `regularization=rho>0` enables **RC-DF** (see below). |
 | `reconstruct_eri(factorization)` | Rebuild the `(pq\|rs)` tensor from a factorization. |
 | `factorization_error(eri, factorization)` | Frobenius norm of the reconstruction residual. |
 | `modified_one_body_integrals(one_body, eri)` | The DF one-body correction `kappa_pq = h_pq - 1/2 sum_r (pr\|qr)`. |
-| `double_factorization_one_norm(factorization, one_body_eigenvalues)` | LCU one-norm `lambda` of the DF Hamiltonian. |
+| `double_factorization_one_norm(factorization, one_body_eigenvalues, convention="lcu")` | One-norm `lambda` of the DF Hamiltonian; `convention="lcu"` (Pauli-rotation) or `"burg"` (qubitization). |
 
 All functions return/operate on a `DoubleFactorization` dataclass with
 `num_orbitals`, `leaf_rotations` (`U^t`), `leaf_cores` (`Z^t`), `num_leaves`, and
@@ -64,6 +64,21 @@ All functions return/operate on a `DoubleFactorization` dataclass with
   optimized with L-BFGS, while the symmetric cores are solved in closed form at
   each step (the two-step scheme of the paper, warm-started from X-DF). C-DF
   reaches a target accuracy with substantially fewer leaves than X-DF.
+
+## RC-DF regularization
+
+Setting `regularization=rho > 0` enables **regularized C-DF** (RC-DF, Oumarou
+et al., *Quantum* **8**, 1371 (2024), [arXiv:2212.07957](https://arxiv.org/abs/2212.07957)),
+adding the L2 penalty `rho * sum_{t,k,l} (Z^t_kl)^2` to the objective (Eq. 17).
+The penalty is folded into the inner core solve as a ridge term, so it actually
+shrinks the cores `Z^t` (it also conditions the otherwise rank-deficient inner
+system). Smaller cores lower the Hamiltonian one-norm `lambda` — and hence the
+qubitization runtime and measurement variance — at a modest cost in
+reconstruction accuracy. `rho` is an absolute coefficient whose useful scale
+depends on the integral magnitude (the paper uses `~1e-6` to `1e-3`); pick it by
+trading off `factorization_error` against `double_factorization_one_norm`. By the
+envelope theorem the analytic optimization gradient is unchanged in form, so
+RC-DF runs at the same per-iteration cost as plain C-DF.
 
 ## Example
 

--- a/docs/double_factorization.md
+++ b/docs/double_factorization.md
@@ -30,6 +30,14 @@ runs on the NVIDIA math libraries — cuSOLVER and cuBLAS via **CuPy** — when 
 is available, and falls back to **NumPy/SciPy** otherwise. Every entry point
 accepts `backend="auto"` (default), `"cupy"`, or `"numpy"`.
 
+`"auto"` is **size-aware**: below an empirical orbital-count crossover the GPU's
+per-kernel launch and host-sync latency makes it slower than NumPy, so `auto`
+stays on the CPU for small problems and switches to the GPU only once the work is
+large enough to amortize that overhead (and the GPU lead then grows with `n`). The
+crossovers differ by method — C-DF (contraction-heavy) crosses around `n ≈ 18`,
+while X-DF (a cheap Cholesky loop + tiny per-leaf eigh) stays CPU-favorable until
+`n ≈ 56`. Pass `backend="cupy"` or `"numpy"` to force a backend regardless of size.
+
 ## API
 
 | function | description |

--- a/examples/double_factorization/double_factorization.py
+++ b/examples/double_factorization/double_factorization.py
@@ -47,14 +47,14 @@ def main():
     print(f"  backend: {backend_name}")
     print(f"  orbitals: {eri.shape[0]}   ||eri||_F: {norm:.6f}")
 
-    full = df.explicit_double_factorization(eri, eigenvalue_threshold=0.0,
+    full = df.explicit_double_factorization(eri, threshold=0.0,
                                             backend=backend)
     print("\nX-DF (explicit):")
     print(f"  full-rank leaves: {full.num_leaves}   "
           f"reconstruction error: {df.factorization_error(eri, full):.3e}")
     for threshold in (1.0e-2, 1.0e-3, 1.0e-4):
         truncated = df.explicit_double_factorization(
-            eri, eigenvalue_threshold=threshold, backend=backend)
+            eri, threshold=threshold, backend=backend)
         rel = df.factorization_error(eri, truncated) / norm
         print(f"  threshold {threshold:.0e}: leaves={truncated.num_leaves:2d}  "
               f"rel error={rel:.3e}")
@@ -62,7 +62,7 @@ def main():
     print("\nC-DF (compressed) vs X-DF at equal leaf count:")
     for num_leaves in (2, 4):
         explicit = df.explicit_double_factorization(eri,
-                                                    eigenvalue_threshold=0.0,
+                                                    threshold=0.0,
                                                     max_num_leaves=num_leaves,
                                                     backend=backend)
         compressed = df.compressed_double_factorization(eri,

--- a/examples/double_factorization/double_factorization.py
+++ b/examples/double_factorization/double_factorization.py
@@ -47,17 +47,20 @@ def main():
     print(f"  backend: {backend_name}")
     print(f"  orbitals: {eri.shape[0]}   ||eri||_F: {norm:.6f}")
 
-    full = df.explicit_double_factorization(eri, threshold=0.0,
+    full = df.explicit_double_factorization(eri,
+                                            threshold=0.0,
                                             backend=backend)
     print("\nX-DF (explicit):")
     print(f"  full-rank leaves: {full.num_leaves}   "
           f"reconstruction error: {df.factorization_error(eri, full):.3e}")
     for threshold in (1.0e-2, 1.0e-3, 1.0e-4):
-        truncated = df.explicit_double_factorization(
-            eri, threshold=threshold, backend=backend)
+        truncated = df.explicit_double_factorization(eri,
+                                                     threshold=threshold,
+                                                     backend=backend)
         rel = df.factorization_error(eri, truncated) / norm
-        print(f"  threshold {threshold:.0e}: leaves={truncated.num_leaves:2d}  "
-              f"rel error={rel:.3e}")
+        print(
+            f"  threshold {threshold:.0e}: leaves={truncated.num_leaves:2d}  "
+            f"rel error={rel:.3e}")
 
     print("\nC-DF (compressed) vs X-DF at equal leaf count:")
     for num_leaves in (2, 4):

--- a/examples/double_factorization/double_factorization.py
+++ b/examples/double_factorization/double_factorization.py
@@ -1,0 +1,80 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Explicit (X-DF) and compressed (C-DF) double factorization of the two-electron
+integrals, following Cohn, Motta, and Parrish, PRX Quantum 2, 040352 (2021).
+
+Generates restricted Hartree-Fock molecular-orbital integrals for H2O/STO-3G with
+PySCF, then double-factorizes the ERI tensor two ways:
+
+  * X-DF: exact nested eigendecompositions (rank-one cores), truncated by leaf
+    eigenvalue magnitude.
+  * C-DF: a least-squares-optimized factorization that reaches comparable
+    accuracy with far fewer leaves.
+
+Heavy linear algebra uses the NVIDIA math libraries (cuSOLVER/cuBLAS via CuPy)
+when a GPU is available; otherwise it falls back to NumPy/SciPy.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+import cudaq_algorithms as algorithms
+
+df = algorithms.double_factorization
+
+
+def water_mo_eri():
+    from pyscf import ao2mo, gto, scf
+    mol = gto.M(atom="O 0 0 0; H 0 0 0.957; H 0 0.926 -0.24",
+                basis="sto-3g",
+                verbose=0)
+    mf = scf.RHF(mol).run()
+    n = mf.mo_coeff.shape[1]
+    return np.asarray(ao2mo.restore("s1", ao2mo.kernel(mol, mf.mo_coeff), n))
+
+
+def main():
+    backend = "auto"
+    _, backend_name = df.resolve_backend(backend)
+    eri = water_mo_eri()
+    norm = np.linalg.norm(eri)
+    print("Double factorization of H2O/STO-3G two-electron integrals")
+    print(f"  backend: {backend_name}")
+    print(f"  orbitals: {eri.shape[0]}   ||eri||_F: {norm:.6f}")
+
+    full = df.explicit_double_factorization(eri, eigenvalue_threshold=0.0,
+                                            backend=backend)
+    print("\nX-DF (explicit):")
+    print(f"  full-rank leaves: {full.num_leaves}   "
+          f"reconstruction error: {df.factorization_error(eri, full):.3e}")
+    for threshold in (1.0e-2, 1.0e-3, 1.0e-4):
+        truncated = df.explicit_double_factorization(
+            eri, eigenvalue_threshold=threshold, backend=backend)
+        rel = df.factorization_error(eri, truncated) / norm
+        print(f"  threshold {threshold:.0e}: leaves={truncated.num_leaves:2d}  "
+              f"rel error={rel:.3e}")
+
+    print("\nC-DF (compressed) vs X-DF at equal leaf count:")
+    for num_leaves in (2, 4):
+        explicit = df.explicit_double_factorization(eri,
+                                                    eigenvalue_threshold=0.0,
+                                                    max_num_leaves=num_leaves,
+                                                    backend=backend)
+        compressed = df.compressed_double_factorization(eri,
+                                                        num_leaves=num_leaves,
+                                                        max_iterations=600,
+                                                        backend=backend)
+        x_rel = df.factorization_error(eri, explicit) / norm
+        c_rel = df.factorization_error(eri, compressed) / norm
+        print(f"  leaves={num_leaves:2d}:  X-DF rel error={x_rel:.3e}   "
+              f"C-DF rel error={c_rel:.3e}")
+        assert c_rel <= x_rel + 1.0e-6
+
+
+if __name__ == "__main__":
+    main()

--- a/python/cudaq_algorithms/__init__.py
+++ b/python/cudaq_algorithms/__init__.py
@@ -3,3 +3,6 @@ try:
     from ._pycudaq_algorithms import __version__
 except ImportError:
     raise
+
+# Pure-Python classical preprocessing (no compiled extension dependency).
+from . import double_factorization

--- a/python/cudaq_algorithms/double_factorization/__init__.py
+++ b/python/cudaq_algorithms/double_factorization/__init__.py
@@ -17,8 +17,8 @@ from ._factorization import (DoubleFactorization,
                              compressed_double_factorization,
                              double_factorization_one_norm,
                              explicit_double_factorization,
-                             factorization_error,
-                             modified_one_body_integrals, reconstruct_eri)
+                             factorization_error, modified_one_body_integrals,
+                             reconstruct_eri)
 
 __all__ = [
     "DoubleFactorization",

--- a/python/cudaq_algorithms/double_factorization/__init__.py
+++ b/python/cudaq_algorithms/double_factorization/__init__.py
@@ -1,0 +1,33 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Double factorization of two-electron integrals (X-DF and C-DF).
+
+Explicit (X-DF) and compressed (C-DF) double factorization following Cohn,
+Motta, and Parrish, PRX Quantum 2, 040352 (2021) (arXiv:2104.08957). Heavy
+linear algebra runs on the NVIDIA math libraries (cuSOLVER / cuBLAS via CuPy)
+when a GPU is available, with a NumPy/SciPy fallback selected automatically.
+"""
+from ._backend import cupy_gpu_available, resolve_backend
+from ._factorization import (DoubleFactorization,
+                             compressed_double_factorization,
+                             double_factorization_one_norm,
+                             explicit_double_factorization,
+                             factorization_error,
+                             modified_one_body_integrals, reconstruct_eri)
+
+__all__ = [
+    "DoubleFactorization",
+    "explicit_double_factorization",
+    "compressed_double_factorization",
+    "reconstruct_eri",
+    "factorization_error",
+    "modified_one_body_integrals",
+    "double_factorization_one_norm",
+    "cupy_gpu_available",
+    "resolve_backend",
+]

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -1,0 +1,81 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Array-backend selection for double factorization.
+
+Prefers the NVIDIA math libraries (cuSOLVER / cuBLAS via CuPy) when a GPU is
+available, and falls back to NumPy otherwise. All public double-factorization
+APIs accept a ``backend`` argument of ``"auto"`` (default), ``"cupy"``, or
+``"numpy"``.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+try:  # CuPy is optional; absence simply forces the NumPy path.
+    import cupy as _cupy  # type: ignore
+except Exception:  # pragma: no cover - environment without CuPy
+    _cupy = None
+
+
+def cupy_gpu_available() -> bool:
+    """Return True when CuPy is importable and at least one GPU is visible."""
+    if _cupy is None:
+        return False
+    try:
+        return _cupy.cuda.runtime.getDeviceCount() > 0
+    except Exception:  # pragma: no cover - driver/runtime issues
+        return False
+
+
+def resolve_backend(backend: str = "auto"):
+    """Return ``(array_module, name)`` for the requested backend.
+
+    ``"auto"`` selects CuPy when a GPU is available, otherwise NumPy.
+    """
+    if backend == "numpy":
+        return np, "numpy"
+    if backend == "cupy":
+        if not cupy_gpu_available():
+            raise RuntimeError(
+                "double_factorization error - the 'cupy' backend was requested "
+                "but no CuPy/GPU is available.")
+        return _cupy, "cupy"
+    if backend == "auto":
+        if cupy_gpu_available():
+            return _cupy, "cupy"
+        return np, "numpy"
+    raise ValueError(
+        f"double_factorization error - unknown backend '{backend}'; expected "
+        "'auto', 'cupy', or 'numpy'.")
+
+
+def to_device(array, xp):
+    """Move a host/device array onto the backend ``xp``."""
+    if xp is np:
+        return np.asarray(array)
+    return xp.asarray(array)
+
+
+def to_numpy(array) -> np.ndarray:
+    """Return a host NumPy copy of a NumPy or CuPy array."""
+    if _cupy is not None and isinstance(array, _cupy.ndarray):
+        return _cupy.asnumpy(array)
+    return np.asarray(array)
+
+
+def expm_skew_symmetric(generator, xp):
+    """Matrix exponential of a real antisymmetric matrix, returning an orthogonal
+    matrix. Uses a Hermitian eigendecomposition (cuSOLVER on the CuPy backend),
+    avoiding any dependence on a general matrix-exponential routine."""
+    generator = xp.asarray(generator)
+    # i * X is Hermitian for real antisymmetric X, so eigh applies.
+    hermitian = 1j * generator
+    eigenvalues, eigenvectors = xp.linalg.eigh(hermitian)
+    phases = xp.exp(-1j * eigenvalues)
+    rotated = (eigenvectors * phases) @ eigenvectors.conj().T
+    return xp.real(rotated)

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -21,6 +21,15 @@ try:  # CuPy is optional; absence simply forces the NumPy path.
 except Exception:  # pragma: no cover - environment without CuPy
     _cupy = None
 
+# Empirical CPU/GPU crossovers (orbital count ``n``) for ``backend="auto"``.
+# Below these the GPU's per-kernel launch + host-sync latency makes CuPy slower
+# than NumPy; above them the batched cuSOLVER/cuBLAS linear algebra wins and the
+# lead grows with ``n``. X-DF (a cheap Cholesky loop + tiny per-leaf eigh) stays
+# CPU-favorable far longer than the contraction-heavy C-DF optimization. See
+# benchmarks/double_factorization/ and DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md.
+AUTO_GPU_MIN_ORBITALS_COMPRESSED = 18
+AUTO_GPU_MIN_ORBITALS_EXPLICIT = 56
+
 
 def cupy_gpu_available() -> bool:
     """Return True when CuPy is importable and at least one GPU is visible."""
@@ -32,10 +41,14 @@ def cupy_gpu_available() -> bool:
         return False
 
 
-def resolve_backend(backend: str = "auto"):
+def resolve_backend(backend: str = "auto", problem_size=None, gpu_min_size=0):
     """Return ``(array_module, name)`` for the requested backend.
 
-    ``"auto"`` selects CuPy when a GPU is available, otherwise NumPy.
+    ``"auto"`` selects CuPy when a GPU is available *and* the problem is large
+    enough to amortize GPU launch/sync overhead -- i.e. ``problem_size`` (the
+    orbital count ``n``) is at least ``gpu_min_size`` -- otherwise NumPy. With no
+    ``problem_size`` hint it keeps the legacy behavior: CuPy whenever a GPU is
+    present. ``"cupy"`` / ``"numpy"`` force the backend regardless of size.
     """
     if backend == "numpy":
         return np, "numpy"
@@ -46,7 +59,8 @@ def resolve_backend(backend: str = "auto"):
                 "but no CuPy/GPU is available.")
         return _cupy, "cupy"
     if backend == "auto":
-        if cupy_gpu_available():
+        if cupy_gpu_available() and (problem_size is None
+                                     or problem_size >= gpu_min_size):
             return _cupy, "cupy"
         return np, "numpy"
     raise ValueError(

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -93,3 +93,19 @@ def expm_skew_symmetric(generator, xp):
     phases = xp.exp(-1j * eigenvalues)
     rotated = (eigenvectors * phases) @ eigenvectors.conj().T
     return xp.real(rotated)
+
+
+def expm_skew_symmetric_batched(generators, xp):
+    """Batched :func:`expm_skew_symmetric` over a stack of real antisymmetric
+    matrices ``generators`` (shape ``(num_leaves, n, n)``). One batched Hermitian
+    eigendecomposition instead of ``num_leaves`` separate ones -- on the CuPy
+    backend this is a single cuSOLVER call rather than a Python-driven loop."""
+    generators = xp.asarray(generators)
+    hermitian = 1j * generators
+    eigenvalues, eigenvectors = xp.linalg.eigh(
+        hermitian)  # batched over axis 0
+    phases = xp.exp(-1j * eigenvalues)  # (num_leaves, n)
+    # Scale each leaf's eigenvector columns by its phases, then V diag(phase) V^H.
+    scaled = eigenvectors * phases[:, None, :]
+    rotated = scaled @ xp.conj(eigenvectors).transpose(0, 2, 1)
+    return xp.real(rotated)

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -49,7 +49,8 @@ class DoubleFactorization:
     leaf_rotations: List[np.ndarray]
     leaf_cores: List[np.ndarray]
     method: str
-    eigenvalues: Optional[np.ndarray] = None  # first-factor eigenvalues (X-DF)
+    first_factorization: Optional[str] = None  # "cholesky" or "eigendecomposition"
+    leaf_weights: Optional[np.ndarray] = None  # first-factor pivots/eigenvalues
 
     @property
     def num_leaves(self) -> int:
@@ -77,6 +78,56 @@ def _sorted_symmetric_eigendecomposition(matrix, xp):
     return eigenvalues[order], eigenvectors[:, order]
 
 
+def _pivoted_cholesky(matrix, threshold, max_rank, xp):
+    """Pivoted Cholesky factorization of a symmetric positive-semidefinite
+    matrix: returns ``(vectors, pivots)`` with ``matrix ~= sum_t v_t v_t^T``.
+
+    The largest residual-diagonal entry is pivoted on at each step, so the
+    factorization is rank-revealing and stops once that pivot drops to or below
+    ``threshold`` (or after ``max_rank`` vectors). This is the standard
+    Cholesky/density-fitting decomposition of the (PSD) electron-repulsion
+    integrals; non-positive residual pivots (numerical null space) terminate it.
+    """
+    m = matrix.shape[0]
+    residual = xp.real(xp.diag(matrix)).astype(float).copy()
+    initial_max = float(xp.max(residual)) if m else 0.0
+    # Rank-revealing floor: stop once the residual pivot reaches the numerical
+    # null space. Without this, threshold == 0 would keep extracting vectors with
+    # vanishing (eventually denormal) pivots, and dividing by sqrt(pivot) yields
+    # garbage rotations.
+    floor = max(float(threshold), initial_max * 1.0e-14)
+    vectors: List = []
+    pivots: List[float] = []
+    limit = m if max_rank is None else min(int(max_rank), m)
+    for _ in range(limit):
+        pivot_index = int(xp.argmax(residual))
+        pivot = float(residual[pivot_index])
+        if pivot <= floor:
+            break
+        column = matrix[:, pivot_index].astype(float).copy()
+        for previous in vectors:
+            column = column - previous * float(previous[pivot_index])
+        vector = column / xp.sqrt(xp.asarray(pivot))
+        vectors.append(vector)
+        pivots.append(pivot)
+        residual = residual - vector * vector
+        residual = xp.where(residual > 0.0, residual, 0.0)
+    return vectors, pivots
+
+
+def _second_factorization(leaf, scale, second_factor_threshold, xp):
+    """Eigendecompose a symmetric leaf ``L = U diag(gamma) U^T`` and return
+    ``(U, Z)`` with the symmetric core ``Z = scale * outer(gamma, gamma)``."""
+    leaf = 0.5 * (leaf + leaf.T)
+    gamma, rotation = xp.linalg.eigh(leaf)
+    if second_factor_threshold > 0.0:
+        importance = xp.sum(xp.abs(gamma))
+        gamma = xp.where(importance * xp.abs(gamma) > second_factor_threshold,
+                         gamma, 0.0)
+    core = scale * xp.outer(gamma, gamma)
+    return to_numpy(rotation), to_numpy(core)
+
+
 def _validate_eri(eri) -> int:
     eri = np.asarray(eri)
     if eri.ndim != 4 or len(set(eri.shape)) != 1:
@@ -88,63 +139,78 @@ def _validate_eri(eri) -> int:
 
 def explicit_double_factorization(
         eri,
-        eigenvalue_threshold: float = 1.0e-8,
+        threshold: float = 1.0e-8,
         max_num_leaves: Optional[int] = None,
         second_factor_threshold: float = 0.0,
+        first_factorization: str = "cholesky",
         backend: str = "auto") -> DoubleFactorization:
-    """Explicit double factorization (X-DF) via nested eigendecompositions.
+    """Explicit double factorization (X-DF).
 
-    First factorization: the ERI supermatrix ``V_{(pq),(rs)}`` is symmetrized and
-    eigendecomposed into leaves ``(pq|rs) = sum_t lambda_t V^t_pq V^t_rs``; leaves
-    with ``|lambda_t| <= eigenvalue_threshold`` (and beyond ``max_num_leaves``)
-    are dropped. Second factorization: each symmetric leaf ``V^t`` is
-    eigendecomposed, ``V^t = U^t diag(gamma^t) (U^t)^T``, giving the rank-one core
-    ``Z^t_kl = lambda_t gamma^t_k gamma^t_l``. ``second_factor_threshold`` (an
-    importance-weighted cutoff matching OpenFermion's convention) optionally zeros
-    small ``gamma^t_k``.
+    First factorization of the ERI supermatrix ``(pq|rs) = sum_t L^t_pq L^t_rs``
+    into symmetric leaves ``L^t``:
+
+    * ``first_factorization="cholesky"`` (default) -- pivoted Cholesky of the
+      positive-semidefinite ERI matrix. Rank-revealing: it keeps leaves while the
+      residual-diagonal pivot exceeds ``threshold`` (the numerical null space
+      terminates it), so it stops at the true factorization rank.
+    * ``first_factorization="eigendecomposition"`` -- symmetric eigendecomposition
+      ``(pq|rs) = sum_t lambda_t V^t_pq V^t_rs`` keeping ``|lambda_t| > threshold``.
+      Required for indefinite inputs; the ERI is PSD so Cholesky is preferred.
+
+    ``max_num_leaves`` caps the leaf count. Second factorization: each symmetric
+    leaf is eigendecomposed, ``L^t = U^t diag(gamma^t) (U^t)^T``, giving the
+    rank-one core ``Z^t = outer(gamma^t, gamma^t)`` (scaled by ``lambda_t`` in the
+    eigendecomposition case). ``second_factor_threshold`` optionally zeros small
+    ``gamma^t_k`` (importance-weighted, matching OpenFermion's convention).
 
     Returns a :class:`DoubleFactorization` with NumPy arrays.
     """
     n = _validate_eri(eri)
     xp, _ = resolve_backend(backend)
     eri_dev = to_device(np.asarray(eri, dtype=float), xp)
-
     supermatrix = eri_dev.reshape(n * n, n * n)
     supermatrix = 0.5 * (supermatrix + supermatrix.T)
-    eigenvalues, eigenvectors = _sorted_symmetric_eigendecomposition(
-        supermatrix, xp)
 
-    abs_eigenvalues = to_numpy(xp.abs(eigenvalues))
     rotations: List[np.ndarray] = []
     cores: List[np.ndarray] = []
-    kept_eigenvalues: List[float] = []
+    weights: List[float] = []
 
-    for index in range(n * n):
-        if abs_eigenvalues[index] <= eigenvalue_threshold:
-            break
-        if max_num_leaves is not None and len(rotations) >= max_num_leaves:
-            break
-
-        lam = eigenvalues[index]
-        leaf = eigenvectors[:, index].reshape(n, n)
-        leaf = 0.5 * (leaf + leaf.T)  # leaves are symmetric by ERI symmetry
-        gamma, leaf_rotation = xp.linalg.eigh(leaf)
-
-        if second_factor_threshold > 0.0:
-            importance = xp.sum(xp.abs(gamma))
-            gamma = xp.where(importance * xp.abs(gamma) > second_factor_threshold,
-                             gamma, 0.0)
-
-        core = lam * xp.outer(gamma, gamma)
-        rotations.append(to_numpy(leaf_rotation))
-        cores.append(to_numpy(core))
-        kept_eigenvalues.append(float(to_numpy(lam)))
+    if first_factorization == "cholesky":
+        vectors, pivots = _pivoted_cholesky(supermatrix, threshold,
+                                            max_num_leaves, xp)
+        for vector, pivot in zip(vectors, pivots):
+            rotation, core = _second_factorization(vector.reshape(n, n), 1.0,
+                                                   second_factor_threshold, xp)
+            rotations.append(rotation)
+            cores.append(core)
+            weights.append(pivot)
+    elif first_factorization == "eigendecomposition":
+        eigenvalues, eigenvectors = _sorted_symmetric_eigendecomposition(
+            supermatrix, xp)
+        abs_eigenvalues = to_numpy(xp.abs(eigenvalues))
+        for index in range(n * n):
+            if abs_eigenvalues[index] <= threshold:
+                break
+            if max_num_leaves is not None and len(rotations) >= max_num_leaves:
+                break
+            lam = eigenvalues[index]
+            rotation, core = _second_factorization(
+                eigenvectors[:, index].reshape(n, n), lam,
+                second_factor_threshold, xp)
+            rotations.append(rotation)
+            cores.append(core)
+            weights.append(float(to_numpy(lam)))
+    else:
+        raise ValueError(
+            "double_factorization error - first_factorization must be "
+            "'cholesky' or 'eigendecomposition'.")
 
     return DoubleFactorization(num_orbitals=n,
                                leaf_rotations=rotations,
                                leaf_cores=cores,
                                method="X-DF",
-                               eigenvalues=np.asarray(kept_eigenvalues))
+                               first_factorization=first_factorization,
+                               leaf_weights=np.asarray(weights))
 
 
 def _leaf_outer_columns(rotation, xp):
@@ -220,7 +286,7 @@ def _initial_generators(eri, num_leaves, n, backend):
     """Warm-start antisymmetric generators from a truncated X-DF (identity pads
     any missing leaves)."""
     xdf = explicit_double_factorization(eri,
-                                        eigenvalue_threshold=0.0,
+                                        threshold=0.0,
                                         max_num_leaves=num_leaves,
                                         backend=backend)
     generators = []

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -32,8 +32,9 @@ import numpy as np
 import scipy.linalg
 import scipy.optimize
 
-from ._backend import (expm_skew_symmetric, resolve_backend, to_device,
-                       to_numpy)
+from ._backend import (AUTO_GPU_MIN_ORBITALS_COMPRESSED,
+                       AUTO_GPU_MIN_ORBITALS_EXPLICIT, expm_skew_symmetric,
+                       resolve_backend, to_device, to_numpy)
 
 
 @dataclass
@@ -168,7 +169,9 @@ def explicit_double_factorization(
     Returns a :class:`DoubleFactorization` with NumPy arrays.
     """
     n = _validate_eri(eri)
-    xp, _ = resolve_backend(backend)
+    xp, _ = resolve_backend(backend,
+                            problem_size=n,
+                            gpu_min_size=AUTO_GPU_MIN_ORBITALS_EXPLICIT)
     eri_dev = to_device(np.asarray(eri, dtype=float), xp)
     supermatrix = eri_dev.reshape(n * n, n * n)
     supermatrix = 0.5 * (supermatrix + supermatrix.T)
@@ -491,7 +494,9 @@ def compressed_double_factorization(
         raise ValueError(
             "double_factorization error - inner_solver must be 'lstsq' or 'cg'."
         )
-    xp, _ = resolve_backend(backend)
+    xp, _ = resolve_backend(backend,
+                            problem_size=n,
+                            gpu_min_size=AUTO_GPU_MIN_ORBITALS_COMPRESSED)
     eri_dev = to_device(np.asarray(eri, dtype=float), xp)
 
     if initial_generators is None:

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -1,0 +1,385 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Explicit (X-DF) and compressed (C-DF) double factorization.
+
+Follows Cohn, Motta, and Parrish, "Quantum Filter Diagonalization with
+Compressed Double-Factorized Hamiltonians," PRX Quantum 2, 040352 (2021)
+(arXiv:2104.08957).
+
+The two-electron integrals are taken in chemist notation ``(pq|rs)`` over real
+spatial orbitals (8-fold symmetry), i.e. an ``(n, n, n, n)`` array ``eri`` with
+``eri[p, q, r, s] == (pq|rs)``. Double factorization writes
+
+    (pq|rs) ~= sum_t sum_kl U^t_pk U^t_qk Z^t_kl U^t_rl U^t_sl
+
+with orthogonal "leaf" rotations ``U^t`` (the Givens-rotation fabric) and
+symmetric "core" matrices ``Z^t``. X-DF obtains these from nested
+eigendecompositions (each ``Z^t`` is rank one). C-DF instead minimizes the
+least-squares reconstruction error, allowing general symmetric ``Z^t`` and far
+fewer leaves at equal accuracy.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import numpy as np
+import scipy.linalg
+import scipy.optimize
+
+from ._backend import (expm_skew_symmetric, resolve_backend, to_device,
+                       to_numpy)
+
+
+@dataclass
+class DoubleFactorization:
+    """Result of a double factorization of the two-electron integrals.
+
+    ``leaf_rotations[t]`` is the orthogonal matrix ``U^t`` (shape
+    ``(num_orbitals, num_orbitals)``) and ``leaf_cores[t]`` is the symmetric
+    core ``Z^t`` for leaf ``t``. ``method`` is ``"X-DF"`` or ``"C-DF"``.
+    """
+
+    num_orbitals: int
+    leaf_rotations: List[np.ndarray]
+    leaf_cores: List[np.ndarray]
+    method: str
+    eigenvalues: Optional[np.ndarray] = None  # first-factor eigenvalues (X-DF)
+
+    @property
+    def num_leaves(self) -> int:
+        return len(self.leaf_rotations)
+
+    def reconstruct_eri(self) -> np.ndarray:
+        """Reconstruct the ``(n, n, n, n)`` chemist-notation ERI tensor."""
+        n = self.num_orbitals
+        eri = np.zeros((n, n, n, n), dtype=float)
+        for rotation, core in zip(self.leaf_rotations, self.leaf_cores):
+            eri += np.einsum("pk,qk,kl,rl,sl->pqrs",
+                             rotation,
+                             rotation,
+                             core,
+                             rotation,
+                             rotation,
+                             optimize=True)
+        return eri
+
+
+def _sorted_symmetric_eigendecomposition(matrix, xp):
+    """Eigenpairs of a symmetric matrix, ordered by descending |eigenvalue|."""
+    eigenvalues, eigenvectors = xp.linalg.eigh(matrix)
+    order = xp.argsort(xp.abs(eigenvalues))[::-1]
+    return eigenvalues[order], eigenvectors[:, order]
+
+
+def _validate_eri(eri) -> int:
+    eri = np.asarray(eri)
+    if eri.ndim != 4 or len(set(eri.shape)) != 1:
+        raise ValueError(
+            "double_factorization error - eri must be a square rank-4 tensor "
+            "(n, n, n, n) in chemist notation (pq|rs).")
+    return eri.shape[0]
+
+
+def explicit_double_factorization(
+        eri,
+        eigenvalue_threshold: float = 1.0e-8,
+        max_num_leaves: Optional[int] = None,
+        second_factor_threshold: float = 0.0,
+        backend: str = "auto") -> DoubleFactorization:
+    """Explicit double factorization (X-DF) via nested eigendecompositions.
+
+    First factorization: the ERI supermatrix ``V_{(pq),(rs)}`` is symmetrized and
+    eigendecomposed into leaves ``(pq|rs) = sum_t lambda_t V^t_pq V^t_rs``; leaves
+    with ``|lambda_t| <= eigenvalue_threshold`` (and beyond ``max_num_leaves``)
+    are dropped. Second factorization: each symmetric leaf ``V^t`` is
+    eigendecomposed, ``V^t = U^t diag(gamma^t) (U^t)^T``, giving the rank-one core
+    ``Z^t_kl = lambda_t gamma^t_k gamma^t_l``. ``second_factor_threshold`` (an
+    importance-weighted cutoff matching OpenFermion's convention) optionally zeros
+    small ``gamma^t_k``.
+
+    Returns a :class:`DoubleFactorization` with NumPy arrays.
+    """
+    n = _validate_eri(eri)
+    xp, _ = resolve_backend(backend)
+    eri_dev = to_device(np.asarray(eri, dtype=float), xp)
+
+    supermatrix = eri_dev.reshape(n * n, n * n)
+    supermatrix = 0.5 * (supermatrix + supermatrix.T)
+    eigenvalues, eigenvectors = _sorted_symmetric_eigendecomposition(
+        supermatrix, xp)
+
+    abs_eigenvalues = to_numpy(xp.abs(eigenvalues))
+    rotations: List[np.ndarray] = []
+    cores: List[np.ndarray] = []
+    kept_eigenvalues: List[float] = []
+
+    for index in range(n * n):
+        if abs_eigenvalues[index] <= eigenvalue_threshold:
+            break
+        if max_num_leaves is not None and len(rotations) >= max_num_leaves:
+            break
+
+        lam = eigenvalues[index]
+        leaf = eigenvectors[:, index].reshape(n, n)
+        leaf = 0.5 * (leaf + leaf.T)  # leaves are symmetric by ERI symmetry
+        gamma, leaf_rotation = xp.linalg.eigh(leaf)
+
+        if second_factor_threshold > 0.0:
+            importance = xp.sum(xp.abs(gamma))
+            gamma = xp.where(importance * xp.abs(gamma) > second_factor_threshold,
+                             gamma, 0.0)
+
+        core = lam * xp.outer(gamma, gamma)
+        rotations.append(to_numpy(leaf_rotation))
+        cores.append(to_numpy(core))
+        kept_eigenvalues.append(float(to_numpy(lam)))
+
+    return DoubleFactorization(num_orbitals=n,
+                               leaf_rotations=rotations,
+                               leaf_cores=cores,
+                               method="X-DF",
+                               eigenvalues=np.asarray(kept_eigenvalues))
+
+
+def _leaf_outer_columns(rotation, xp):
+    """Return ``A`` with ``A[:, k] = vec(u_k u_k^T)`` for rotation columns u_k."""
+    n = rotation.shape[0]
+    outer = xp.einsum("pk,qk->pqk", rotation, rotation)
+    return outer.reshape(n * n, n)
+
+
+def _solve_inner_cores(eri_dev, rotations_dev, xp):
+    """Least-squares optimal symmetric cores ``{Z^t}`` for fixed rotations.
+
+    Solves ``min_Z || eri - sum_t U^t Z^t (U^t)^T (congruence) ||_F`` exactly
+    (linear in the symmetric ``Z^t``) via a pseudoinverse / least squares, the
+    inner step of the two-step C-DF scheme.
+    """
+    n = eri_dev.shape[0]
+    target = eri_dev.reshape(-1)
+
+    columns = []
+    metadata = []  # (leaf, k, l) with k <= l
+    for leaf_index, rotation in enumerate(rotations_dev):
+        a = _leaf_outer_columns(rotation, xp)  # (n*n, n)
+        for k in range(n):
+            for l in range(k, n):
+                column = xp.outer(a[:, k], a[:, l])
+                if l != k:
+                    column = column + xp.outer(a[:, l], a[:, k])
+                columns.append(column.reshape(-1))
+                metadata.append((leaf_index, k, l))
+
+    design = xp.stack(columns, axis=1)
+    solution = xp.linalg.lstsq(design, target, rcond=None)[0]
+
+    cores = [xp.zeros((n, n)) for _ in rotations_dev]
+    for index, (leaf_index, k, l) in enumerate(metadata):
+        value = solution[index]
+        cores[leaf_index][k, l] = value
+        cores[leaf_index][l, k] = value
+    return cores
+
+
+def _reconstruct_dev(rotations_dev, cores_dev, xp):
+    n = rotations_dev[0].shape[0]
+    eri = xp.zeros((n, n, n, n))
+    for rotation, core in zip(rotations_dev, cores_dev):
+        eri = eri + xp.einsum("pk,qk,kl,rl,sl->pqrs",
+                              rotation,
+                              rotation,
+                              core,
+                              rotation,
+                              rotation,
+                              optimize=True)
+    return eri
+
+
+def _skew_to_vector(generator, n):
+    rows, cols = np.tril_indices(n, k=-1)
+    return generator[rows, cols]
+
+
+def _vector_to_skew(vector, n, xp):
+    generator = xp.zeros((n, n))
+    rows, cols = np.tril_indices(n, k=-1)
+    rows = xp.asarray(rows)
+    cols = xp.asarray(cols)
+    generator[rows, cols] = vector
+    generator[cols, rows] = -vector
+    return generator
+
+
+def _initial_generators(eri, num_leaves, n, backend):
+    """Warm-start antisymmetric generators from a truncated X-DF (identity pads
+    any missing leaves)."""
+    xdf = explicit_double_factorization(eri,
+                                        eigenvalue_threshold=0.0,
+                                        max_num_leaves=num_leaves,
+                                        backend=backend)
+    generators = []
+    for rotation in xdf.leaf_rotations:
+        rotation = np.asarray(rotation, dtype=float).copy()
+        # exp(antisymmetric) is always special orthogonal (det +1), but eigh
+        # leaf rotations can be reflections (det -1), which have no real
+        # antisymmetric logarithm. Flipping one column flips the determinant
+        # without changing u_k u_k^T (hence without changing the factorization),
+        # so force det +1 before taking the logarithm.
+        if np.linalg.det(rotation) < 0.0:
+            rotation[:, 0] *= -1.0
+        skew = scipy.linalg.logm(rotation).real
+        skew = 0.5 * (skew - skew.T)  # clean numerical asymmetry
+        generators.append(skew)
+    while len(generators) < num_leaves:
+        generators.append(np.zeros((n, n)))
+    return generators[:num_leaves]
+
+
+def compressed_double_factorization(
+        eri,
+        num_leaves: int,
+        max_iterations: int = 2000,
+        tolerance: float = 1.0e-10,
+        regularization: float = 0.0,
+        initial_generators: Optional[List[np.ndarray]] = None,
+        backend: str = "auto") -> DoubleFactorization:
+    """Compressed double factorization (C-DF) by least-squares optimization.
+
+    Minimizes ``O = 1/2 || eri - sum_t U^t Z^t (U^t)^T (congruence) ||_F^2`` over
+    a fixed number of leaves. Uses the two-step scheme of arXiv:2104.08957: the
+    leaf rotations are parameterized as ``U^t = exp(X^t)`` with antisymmetric
+    ``X^t`` and optimized with L-BFGS (warm-started from X-DF), while the
+    symmetric cores ``Z^t`` are solved exactly in closed form at each step.
+
+    ``regularization`` adds an optional ``rho * sum_t ||Z^t||_F^2`` penalty
+    (the RC-DF extension, arXiv:2212.07957); default 0 reproduces plain C-DF.
+
+    Returns a :class:`DoubleFactorization` with NumPy arrays.
+    """
+    n = _validate_eri(eri)
+    if num_leaves < 1:
+        raise ValueError(
+            "double_factorization error - num_leaves must be >= 1.")
+    xp, _ = resolve_backend(backend)
+    eri_dev = to_device(np.asarray(eri, dtype=float), xp)
+
+    if initial_generators is None:
+        initial_generators = _initial_generators(eri, num_leaves, n, backend)
+
+    x0 = np.concatenate(
+        [_skew_to_vector(np.asarray(g), n) for g in initial_generators])
+
+    per_leaf = n * (n - 1) // 2
+    lower = np.tril_indices(n, k=-1)
+
+    def unpack(parameter_vector):
+        skews, rotations = [], []
+        for leaf_index in range(num_leaves):
+            chunk = parameter_vector[leaf_index * per_leaf:(leaf_index + 1) *
+                                     per_leaf]
+            skew = _vector_to_skew(to_device(chunk, xp), n, xp)
+            skews.append(skew)
+            rotations.append(expm_skew_symmetric(skew, xp))
+        return skews, rotations
+
+    def objective(parameter_vector):
+        _, rotations = unpack(parameter_vector)
+        cores = _solve_inner_cores(eri_dev, rotations, xp)
+        residual = eri_dev - _reconstruct_dev(rotations, cores, xp)
+        loss = 0.5 * xp.sum(residual * residual)
+        if regularization > 0.0:
+            loss = loss + regularization * sum(
+                xp.sum(core * core) for core in cores)
+        return float(to_numpy(loss))
+
+    def objective_and_gradient(parameter_vector):
+        # Analytic gradient (regularization == 0 only): with the inner cores at
+        # their least-squares optimum, dO/dZ = 0, so by the envelope theorem the
+        # gradient is dO/dU chained through dU/dX (the matrix-exponential
+        # derivative). dO/dU^t_ak = -4 sum_qrsl Delta_aqrs U_qk Z_kl U_rl U_sl
+        # (Eq. 17 of arXiv:2104.08957).
+        skews, rotations = unpack(parameter_vector)
+        cores = _solve_inner_cores(eri_dev, rotations, xp)
+        residual = eri_dev - _reconstruct_dev(rotations, cores, xp)
+        loss = float(to_numpy(0.5 * xp.sum(residual * residual)))
+
+        gradient_chunks = []
+        for skew, rotation, core in zip(skews, rotations, cores):
+            grad_u = -4.0 * xp.einsum("aqrs,qk,kl,rl,sl->ak",
+                                      residual,
+                                      rotation,
+                                      core,
+                                      rotation,
+                                      rotation,
+                                      optimize=True)
+            # Adjoint of d(exp)/dX: grad_X = L_exp(X^T, grad_U) (Frechet
+            # derivative), then project onto the antisymmetric parameters.
+            grad_u_host = to_numpy(grad_u)
+            skew_host = to_numpy(skew)
+            grad_x = scipy.linalg.expm_frechet(skew_host.T,
+                                               grad_u_host,
+                                               compute_expm=False)
+            grad_x = grad_x - grad_x.T
+            gradient_chunks.append(grad_x[lower])
+        return loss, np.concatenate(gradient_chunks)
+
+    use_analytic = regularization == 0.0
+    result = scipy.optimize.minimize(
+        objective_and_gradient if use_analytic else objective,
+        x0,
+        method="L-BFGS-B",
+        jac=use_analytic,
+        options={
+            "maxiter": max_iterations,
+            "ftol": tolerance,
+            "gtol": tolerance,
+        })
+
+    _, rotations = unpack(result.x)
+    cores = _solve_inner_cores(eri_dev, rotations, xp)
+    return DoubleFactorization(
+        num_orbitals=n,
+        leaf_rotations=[to_numpy(r) for r in rotations],
+        leaf_cores=[to_numpy(c) for c in cores],
+        method="C-DF")
+
+
+def reconstruct_eri(factorization: DoubleFactorization) -> np.ndarray:
+    """Reconstruct the chemist-notation ERI tensor from a factorization."""
+    return factorization.reconstruct_eri()
+
+
+def factorization_error(eri, factorization: DoubleFactorization) -> float:
+    """Frobenius norm of the ERI reconstruction residual."""
+    return float(
+        np.linalg.norm(np.asarray(eri, dtype=float) -
+                       factorization.reconstruct_eri()))
+
+
+def modified_one_body_integrals(one_body, eri) -> np.ndarray:
+    """Return the DF-corrected one-body matrix ``kappa_pq = h_pq - 1/2 sum_r
+    (pr|qr)`` (Eq. 3 of arXiv:2104.08957), used when assembling the full
+    double-factorized Hamiltonian from the two-body factorization."""
+    one_body = np.asarray(one_body, dtype=float)
+    eri = np.asarray(eri, dtype=float)
+    return one_body - 0.5 * np.einsum("prqr->pq", eri, optimize=True)
+
+
+def double_factorization_one_norm(factorization: DoubleFactorization,
+                                  one_body_eigenvalues) -> float:
+    """LCU one-norm ``lambda`` of the double-factorized Hamiltonian (RC-DF
+    Eq. 13): ``sum_k |F_k| + sum_t (sum_{k<l} |Z^t_kl| + 1/4 sum_k |Z^t_kk|)``."""
+    one_body_eigenvalues = np.asarray(one_body_eigenvalues, dtype=float)
+    lam = float(np.sum(np.abs(one_body_eigenvalues)))
+    for core in factorization.leaf_cores:
+        core = np.asarray(core)
+        # sum_{k<l} |Z_kl| (strict upper triangle) + 1/4 sum_k |Z_kk|
+        lam += float(np.sum(np.abs(np.triu(core, k=1))))
+        lam += 0.25 * float(np.sum(np.abs(np.diag(core))))
+    return lam

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -234,7 +234,8 @@ def _solve_inner_cores_cg(eri_dev,
                           xp,
                           regularization=0.0,
                           tolerance=1.0e-10,
-                          max_iterations=None):
+                          max_iterations=None,
+                          initial_guess=None):
     """Matrix-free conjugate-gradient solve for the symmetric cores ``{Z^t}``.
 
     Solves the same normal equations as the least-squares solver,
@@ -251,6 +252,11 @@ def _solve_inner_cores_cg(eri_dev,
     driven launches, and the CG scalars stay on device -- only the convergence and
     curvature guards sync to host. This scales to large orbital counts where the
     explicit design matrix is infeasible.
+
+    ``initial_guess`` (a stacked ``(num_leaves, n, n)`` array) warm-starts CG. In
+    the C-DF optimizer the rotations -- and hence the cores -- change slowly
+    between L-BFGS steps, so seeding from the previous step's solution collapses
+    the iteration count.
     """
     n = eri_dev.shape[0]
     num_leaves = len(rotations_dev)
@@ -273,8 +279,12 @@ def _solve_inner_cores_cg(eri_dev,
         # A device scalar (0-d array); converted to host only where needed.
         return xp.sum(x * y)
 
-    z = xp.zeros((num_leaves, n, n))
-    residual = rhs.copy()  # r = rhs - A(0) = rhs since z = 0
+    if initial_guess is None:
+        z = xp.zeros((num_leaves, n, n))
+        residual = rhs.copy()  # r = rhs - A(0) = rhs since z = 0
+    else:
+        z = xp.asarray(initial_guess).copy()
+        residual = rhs - apply_operator(z)
     direction = residual.copy()
     residual_norm_sq = inner_product(residual, residual)
     threshold = (tolerance**2) * max(float(to_numpy(residual_norm_sq)), 1.0)
@@ -358,16 +368,18 @@ def _solve_inner_cores(eri_dev,
                        regularization=0.0,
                        solver="lstsq",
                        cg_tolerance=1.0e-10,
-                       cg_max_iterations=None):
+                       cg_max_iterations=None,
+                       initial_guess=None):
     """Dispatch the inner core solve to the explicit ``"lstsq"`` solver or the
-    matrix-free ``"cg"`` solver."""
+    matrix-free ``"cg"`` solver. ``initial_guess`` warm-starts CG and is ignored
+    by the direct lstsq solver."""
     if solver == "lstsq":
         return _solve_inner_cores_lstsq(eri_dev, rotations_dev, xp,
                                         regularization)
     if solver == "cg":
         return _solve_inner_cores_cg(eri_dev, rotations_dev, xp,
                                      regularization, cg_tolerance,
-                                     cg_max_iterations)
+                                     cg_max_iterations, initial_guess)
     raise ValueError(
         "double_factorization error - inner_solver must be 'lstsq' or 'cg'.")
 
@@ -435,6 +447,8 @@ def compressed_double_factorization(
         inner_solver: str = "lstsq",
         cg_tolerance: float = 1.0e-10,
         cg_max_iterations: Optional[int] = None,
+        cg_warm_start: bool = True,
+        cg_optimization_tolerance: Optional[float] = None,
         initial_generators: Optional[List[np.ndarray]] = None,
         backend: str = "auto") -> DoubleFactorization:
     """Compressed double factorization (C-DF) by least-squares optimization.
@@ -459,6 +473,14 @@ def compressed_double_factorization(
     matrix and scales to large orbital counts. ``cg_tolerance`` and
     ``cg_max_iterations`` control the CG solve.
 
+    For ``inner_solver="cg"`` two accelerators cut the per-step CG cost without
+    changing the final accuracy: ``cg_warm_start`` (default ``True``) seeds each
+    step's CG from the previous step's cores -- which move slowly between L-BFGS
+    steps -- and ``cg_optimization_tolerance`` (default ``max(cg_tolerance,
+    1e-6)``) solves the *in-loop* systems only loosely (an inexact inner solve;
+    the gradient need only be approximate by the envelope theorem) while the
+    single final solve is tightened to ``cg_tolerance``.
+
     Returns a :class:`DoubleFactorization` with NumPy arrays.
     """
     n = _validate_eri(eri)
@@ -481,6 +503,12 @@ def compressed_double_factorization(
     per_leaf = n * (n - 1) // 2
     lower = np.tril_indices(n, k=-1)
 
+    # Inexact in-loop CG (forcing sequence) + warm start across L-BFGS steps.
+    use_warm = inner_solver == "cg" and cg_warm_start
+    loop_tolerance = (cg_optimization_tolerance if cg_optimization_tolerance
+                      is not None else max(cg_tolerance, 1.0e-6))
+    warm_state = {"z": None}
+
     def unpack(parameter_vector):
         skews, rotations = [], []
         for leaf_index in range(num_leaves):
@@ -500,8 +528,11 @@ def compressed_double_factorization(
         # U_sl (Eq. 17 of arXiv:2104.08957).
         skews, rotations = unpack(parameter_vector)
         cores = _solve_inner_cores(eri_dev, rotations, xp, regularization,
-                                   inner_solver, cg_tolerance,
-                                   cg_max_iterations)
+                                   inner_solver, loop_tolerance,
+                                   cg_max_iterations,
+                                   warm_state["z"] if use_warm else None)
+        if use_warm:
+            warm_state["z"] = xp.stack(cores)
         residual = eri_dev - _reconstruct_dev(rotations, cores, xp)
         loss = 0.5 * xp.sum(residual * residual)
         if regularization > 0.0:
@@ -539,9 +570,11 @@ def compressed_double_factorization(
                                          "gtol": tolerance,
                                      })
 
+    # Final cores at the tight cg_tolerance (warm-started from the last step).
     _, rotations = unpack(result.x)
     cores = _solve_inner_cores(eri_dev, rotations, xp, regularization,
-                               inner_solver, cg_tolerance, cg_max_iterations)
+                               inner_solver, cg_tolerance, cg_max_iterations,
+                               warm_state["z"] if use_warm else None)
     return DoubleFactorization(num_orbitals=n,
                                leaf_rotations=[to_numpy(r) for r in rotations],
                                leaf_cores=[to_numpy(c) for c in cores],

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -245,59 +245,59 @@ def _solve_inner_cores_cg(eri_dev,
         M_{tt'} = (U^t^T U^{t'}) elementwise-squared      (Eq. 27)
 
     so each matvec is just ``n x n`` matrix products; the ERIs are contracted
-    only once to build the RHS ``R^t``. This scales to large orbital counts where
-    the explicit design matrix is infeasible.
+    only once to build the RHS ``R^t``. The cores are stacked into a single
+    ``(num_leaves, n, n)`` array so the whole operator is one batched ``einsum``
+    (a strided-batched GEMM under cuBLAS) rather than ``num_leaves^2`` Python-
+    driven launches, and the CG scalars stay on device -- only the convergence and
+    curvature guards sync to host. This scales to large orbital counts where the
+    explicit design matrix is infeasible.
     """
     n = eri_dev.shape[0]
     num_leaves = len(rotations_dev)
 
-    overlaps = [[
-        rotations_dev[t].T @ rotations_dev[u] for u in range(num_leaves)
-    ] for t in range(num_leaves)]
-    metric = [[overlaps[t][u] * overlaps[t][u] for u in range(num_leaves)]
-              for t in range(num_leaves)]
-    rhs = [_project_eri_into_leaf(eri_dev, u, xp) for u in rotations_dev]
+    # M_{tt'} = (U^t^T U^{t'}) elementwise-squared, stacked as (t, t', k, l).
+    rotations = xp.stack(rotations_dev)
+    metric = xp.einsum("tpk,upl->tukl", rotations, rotations)
+    metric = metric * metric
+    rhs = xp.stack(
+        [_project_eri_into_leaf(eri_dev, u, xp) for u in rotations_dev])
 
     def apply_operator(z):
-        result = []
-        for t in range(num_leaves):
-            acc = xp.zeros((n, n))
-            for u in range(num_leaves):
-                acc = acc + metric[t][u] @ z[u] @ metric[t][u].T
-            if regularization > 0.0:
-                acc = acc + 2.0 * regularization * z[t]
-            result.append(acc)
-        return result
+        # A(Z)^t = sum_{t'} M_{tt'} Z^{t'} M_{tt'}^T, all leaves at once.
+        out = xp.einsum("tukl,ulm,tunm->tkn", metric, z, metric, optimize=True)
+        if regularization > 0.0:
+            out = out + (2.0 * regularization) * z
+        return out
 
     def inner_product(x, y):
-        return float(to_numpy(sum(xp.sum(xi * yi) for xi, yi in zip(x, y))))
+        # A device scalar (0-d array); converted to host only where needed.
+        return xp.sum(x * y)
 
-    z = [xp.zeros((n, n)) for _ in range(num_leaves)]
-    residual = [r.copy() for r in rhs]  # r = rhs - A(0)
-    direction = [r.copy() for r in residual]
+    z = xp.zeros((num_leaves, n, n))
+    residual = rhs.copy()  # r = rhs - A(0) = rhs since z = 0
+    direction = residual.copy()
     residual_norm_sq = inner_product(residual, residual)
-    threshold = (tolerance**2) * max(residual_norm_sq, 1.0)
+    threshold = (tolerance**2) * max(float(to_numpy(residual_norm_sq)), 1.0)
     limit = max_iterations if max_iterations is not None else max(
         50, num_leaves * n * n)
 
     for _ in range(limit):
-        if residual_norm_sq <= threshold:
+        if float(to_numpy(residual_norm_sq)) <= threshold:
             break
         operator_direction = apply_operator(direction)
         curvature = inner_product(direction, operator_direction)
-        if curvature <= 0.0:
+        if float(to_numpy(curvature)) <= 0.0:
             break
-        step = residual_norm_sq / curvature
-        z = [zi + step * di for zi, di in zip(z, direction)]
-        residual = [
-            ri - step * oi for ri, oi in zip(residual, operator_direction)
-        ]
+        step = residual_norm_sq / curvature  # device scalar
+        z = z + step * direction
+        residual = residual - step * operator_direction
         new_norm_sq = inner_product(residual, residual)
-        beta = new_norm_sq / residual_norm_sq
-        direction = [ri + beta * di for ri, di in zip(residual, direction)]
+        beta = new_norm_sq / residual_norm_sq  # device scalar
+        direction = residual + beta * direction
         residual_norm_sq = new_norm_sq
 
-    return [0.5 * (zi + zi.T) for zi in z]
+    z = 0.5 * (z + z.transpose(0, 2, 1))
+    return [z[t] for t in range(num_leaves)]
 
 
 def _solve_inner_cores_lstsq(eri_dev, rotations_dev, xp, regularization=0.0):

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -49,8 +49,10 @@ class DoubleFactorization:
     leaf_rotations: List[np.ndarray]
     leaf_cores: List[np.ndarray]
     method: str
-    first_factorization: Optional[str] = None  # "cholesky" or "eigendecomposition"
-    leaf_weights: Optional[np.ndarray] = None  # first-factor pivots/eigenvalues
+    first_factorization: Optional[
+        str] = None  # "cholesky" or "eigendecomposition"
+    leaf_weights: Optional[
+        np.ndarray] = None  # first-factor pivots/eigenvalues
 
     @property
     def num_leaves(self) -> int:
@@ -425,11 +427,10 @@ def compressed_double_factorization(
 
     _, rotations = unpack(result.x)
     cores = _solve_inner_cores(eri_dev, rotations, xp, regularization)
-    return DoubleFactorization(
-        num_orbitals=n,
-        leaf_rotations=[to_numpy(r) for r in rotations],
-        leaf_cores=[to_numpy(c) for c in cores],
-        method="C-DF")
+    return DoubleFactorization(num_orbitals=n,
+                               leaf_rotations=[to_numpy(r) for r in rotations],
+                               leaf_cores=[to_numpy(c) for c in cores],
+                               method="C-DF")
 
 
 def reconstruct_eri(factorization: DoubleFactorization) -> np.ndarray:
@@ -440,8 +441,8 @@ def reconstruct_eri(factorization: DoubleFactorization) -> np.ndarray:
 def factorization_error(eri, factorization: DoubleFactorization) -> float:
     """Frobenius norm of the ERI reconstruction residual."""
     return float(
-        np.linalg.norm(np.asarray(eri, dtype=float) -
-                       factorization.reconstruct_eri()))
+        np.linalg.norm(
+            np.asarray(eri, dtype=float) - factorization.reconstruct_eri()))
 
 
 def modified_one_body_integrals(one_body, eri) -> np.ndarray:
@@ -481,7 +482,8 @@ def double_factorization_one_norm(factorization: DoubleFactorization,
 
     if convention == "burg":
         for core in factorization.leaf_cores:
-            eigenvalues, vectors = np.linalg.eigh(np.asarray(core, dtype=float))
+            eigenvalues, vectors = np.linalg.eigh(np.asarray(core,
+                                                             dtype=float))
             root = (vectors * np.sqrt(eigenvalues.astype(complex))) @ \
                 vectors.conj().T  # W = sqrt(Z), possibly complex
             column_abs_sum = np.sum(np.abs(root), axis=0)  # sum_k |W_ki| per i

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -222,7 +222,85 @@ def _leaf_outer_columns(rotation, xp):
     return outer.reshape(n * n, n)
 
 
-def _solve_inner_cores(eri_dev, rotations_dev, xp, regularization=0.0):
+def _project_eri_into_leaf(eri_dev, rotation, xp):
+    """R^t_kl = sum_pqrs U^t_pk U^t_qk (pq|rs) U^t_rl U^t_sl (the RHS of the inner
+    normal equations / projection of the ERIs into a leaf's rotated basis)."""
+    a = xp.einsum("pk,qk->pqk", rotation, rotation)
+    return xp.einsum("pqk,pqrs,rsl->kl", a, eri_dev, a, optimize=True)
+
+
+def _solve_inner_cores_cg(eri_dev,
+                          rotations_dev,
+                          xp,
+                          regularization=0.0,
+                          tolerance=1.0e-10,
+                          max_iterations=None):
+    """Matrix-free conjugate-gradient solve for the symmetric cores ``{Z^t}``.
+
+    Solves the same normal equations as the least-squares solver,
+    ``(A + 2 rho I) Z = R``, but never forms the ``n^4 x num_params`` design
+    matrix (RC-DF Eqs. 25-30). The operator factorizes as
+
+        A(Z)^t = sum_{t'} M_{tt'} Z^{t'} M_{tt'}^T ,
+        M_{tt'} = (U^t^T U^{t'}) elementwise-squared      (Eq. 27)
+
+    so each matvec is just ``n x n`` matrix products; the ERIs are contracted
+    only once to build the RHS ``R^t``. This scales to large orbital counts where
+    the explicit design matrix is infeasible.
+    """
+    n = eri_dev.shape[0]
+    num_leaves = len(rotations_dev)
+
+    overlaps = [[
+        rotations_dev[t].T @ rotations_dev[u] for u in range(num_leaves)
+    ] for t in range(num_leaves)]
+    metric = [[overlaps[t][u] * overlaps[t][u] for u in range(num_leaves)]
+              for t in range(num_leaves)]
+    rhs = [_project_eri_into_leaf(eri_dev, u, xp) for u in rotations_dev]
+
+    def apply_operator(z):
+        result = []
+        for t in range(num_leaves):
+            acc = xp.zeros((n, n))
+            for u in range(num_leaves):
+                acc = acc + metric[t][u] @ z[u] @ metric[t][u].T
+            if regularization > 0.0:
+                acc = acc + 2.0 * regularization * z[t]
+            result.append(acc)
+        return result
+
+    def inner_product(x, y):
+        return float(to_numpy(sum(xp.sum(xi * yi) for xi, yi in zip(x, y))))
+
+    z = [xp.zeros((n, n)) for _ in range(num_leaves)]
+    residual = [r.copy() for r in rhs]  # r = rhs - A(0)
+    direction = [r.copy() for r in residual]
+    residual_norm_sq = inner_product(residual, residual)
+    threshold = (tolerance**2) * max(residual_norm_sq, 1.0)
+    limit = max_iterations if max_iterations is not None else max(
+        50, num_leaves * n * n)
+
+    for _ in range(limit):
+        if residual_norm_sq <= threshold:
+            break
+        operator_direction = apply_operator(direction)
+        curvature = inner_product(direction, operator_direction)
+        if curvature <= 0.0:
+            break
+        step = residual_norm_sq / curvature
+        z = [zi + step * di for zi, di in zip(z, direction)]
+        residual = [
+            ri - step * oi for ri, oi in zip(residual, operator_direction)
+        ]
+        new_norm_sq = inner_product(residual, residual)
+        beta = new_norm_sq / residual_norm_sq
+        direction = [ri + beta * di for ri, di in zip(residual, direction)]
+        residual_norm_sq = new_norm_sq
+
+    return [0.5 * (zi + zi.T) for zi in z]
+
+
+def _solve_inner_cores_lstsq(eri_dev, rotations_dev, xp, regularization=0.0):
     """Least-squares optimal symmetric cores ``{Z^t}`` for fixed rotations.
 
     Solves, for fixed ``U^t``,
@@ -230,10 +308,11 @@ def _solve_inner_cores(eri_dev, rotations_dev, xp, regularization=0.0):
         min_Z  1/2 || eri - sum_t U^t Z^t (U^t)^T (congruence) ||_F^2
                   + rho * sum_{t,k,l} (Z^t_kl)^2
 
-    exactly (linear in the symmetric ``Z^t``). The ``rho`` (``regularization``)
-    term is the RC-DF L2 penalty (arXiv:2212.07957, Eq. 17); it shrinks the cores
-    and also conditions the otherwise rank-deficient inner system. Implemented as
-    an augmented least-squares / ridge solve.
+    exactly (linear in the symmetric ``Z^t``) via an explicit design matrix. The
+    ``rho`` (``regularization``) term is the RC-DF L2 penalty
+    (arXiv:2212.07957, Eq. 17); it shrinks the cores and conditions the otherwise
+    rank-deficient inner system. See ``_solve_inner_cores_cg`` for the matrix-free
+    alternative that scales to large orbital counts.
     """
     n = eri_dev.shape[0]
     target = eri_dev.reshape(-1)
@@ -271,6 +350,26 @@ def _solve_inner_cores(eri_dev, rotations_dev, xp, regularization=0.0):
         cores[leaf_index][k, l] = value
         cores[leaf_index][l, k] = value
     return cores
+
+
+def _solve_inner_cores(eri_dev,
+                       rotations_dev,
+                       xp,
+                       regularization=0.0,
+                       solver="lstsq",
+                       cg_tolerance=1.0e-10,
+                       cg_max_iterations=None):
+    """Dispatch the inner core solve to the explicit ``"lstsq"`` solver or the
+    matrix-free ``"cg"`` solver."""
+    if solver == "lstsq":
+        return _solve_inner_cores_lstsq(eri_dev, rotations_dev, xp,
+                                        regularization)
+    if solver == "cg":
+        return _solve_inner_cores_cg(eri_dev, rotations_dev, xp,
+                                     regularization, cg_tolerance,
+                                     cg_max_iterations)
+    raise ValueError(
+        "double_factorization error - inner_solver must be 'lstsq' or 'cg'.")
 
 
 def _reconstruct_dev(rotations_dev, cores_dev, xp):
@@ -333,6 +432,9 @@ def compressed_double_factorization(
         max_iterations: int = 2000,
         tolerance: float = 1.0e-10,
         regularization: float = 0.0,
+        inner_solver: str = "lstsq",
+        cg_tolerance: float = 1.0e-10,
+        cg_max_iterations: Optional[int] = None,
         initial_generators: Optional[List[np.ndarray]] = None,
         backend: str = "auto") -> DoubleFactorization:
     """Compressed double factorization (C-DF) by least-squares optimization.
@@ -351,12 +453,22 @@ def compressed_double_factorization(
     coefficient (its useful scale depends on the integral magnitude; the paper
     uses ~1e-6 to 1e-3). ``rho = 0`` reproduces plain C-DF.
 
+    ``inner_solver`` selects how the cores are solved each step: ``"lstsq"``
+    (default) forms an explicit design matrix, while ``"cg"`` is the matrix-free
+    conjugate-gradient solve (RC-DF Eqs. 25-30) that avoids the ``n^4``-row design
+    matrix and scales to large orbital counts. ``cg_tolerance`` and
+    ``cg_max_iterations`` control the CG solve.
+
     Returns a :class:`DoubleFactorization` with NumPy arrays.
     """
     n = _validate_eri(eri)
     if num_leaves < 1:
         raise ValueError(
             "double_factorization error - num_leaves must be >= 1.")
+    if inner_solver not in ("lstsq", "cg"):
+        raise ValueError(
+            "double_factorization error - inner_solver must be 'lstsq' or 'cg'."
+        )
     xp, _ = resolve_backend(backend)
     eri_dev = to_device(np.asarray(eri, dtype=float), xp)
 
@@ -387,7 +499,9 @@ def compressed_double_factorization(
         # any regularization. dO/dU^t_ak = -4 sum_qrsl Delta_aqrs U_qk Z_kl U_rl
         # U_sl (Eq. 17 of arXiv:2104.08957).
         skews, rotations = unpack(parameter_vector)
-        cores = _solve_inner_cores(eri_dev, rotations, xp, regularization)
+        cores = _solve_inner_cores(eri_dev, rotations, xp, regularization,
+                                   inner_solver, cg_tolerance,
+                                   cg_max_iterations)
         residual = eri_dev - _reconstruct_dev(rotations, cores, xp)
         loss = 0.5 * xp.sum(residual * residual)
         if regularization > 0.0:
@@ -426,7 +540,8 @@ def compressed_double_factorization(
                                      })
 
     _, rotations = unpack(result.x)
-    cores = _solve_inner_cores(eri_dev, rotations, xp, regularization)
+    cores = _solve_inner_cores(eri_dev, rotations, xp, regularization,
+                               inner_solver, cg_tolerance, cg_max_iterations)
     return DoubleFactorization(num_orbitals=n,
                                leaf_rotations=[to_numpy(r) for r in rotations],
                                leaf_cores=[to_numpy(c) for c in cores],

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -220,12 +220,18 @@ def _leaf_outer_columns(rotation, xp):
     return outer.reshape(n * n, n)
 
 
-def _solve_inner_cores(eri_dev, rotations_dev, xp):
+def _solve_inner_cores(eri_dev, rotations_dev, xp, regularization=0.0):
     """Least-squares optimal symmetric cores ``{Z^t}`` for fixed rotations.
 
-    Solves ``min_Z || eri - sum_t U^t Z^t (U^t)^T (congruence) ||_F`` exactly
-    (linear in the symmetric ``Z^t``) via a pseudoinverse / least squares, the
-    inner step of the two-step C-DF scheme.
+    Solves, for fixed ``U^t``,
+
+        min_Z  1/2 || eri - sum_t U^t Z^t (U^t)^T (congruence) ||_F^2
+                  + rho * sum_{t,k,l} (Z^t_kl)^2
+
+    exactly (linear in the symmetric ``Z^t``). The ``rho`` (``regularization``)
+    term is the RC-DF L2 penalty (arXiv:2212.07957, Eq. 17); it shrinks the cores
+    and also conditions the otherwise rank-deficient inner system. Implemented as
+    an augmented least-squares / ridge solve.
     """
     n = eri_dev.shape[0]
     target = eri_dev.reshape(-1)
@@ -243,6 +249,18 @@ def _solve_inner_cores(eri_dev, rotations_dev, xp):
                 metadata.append((leaf_index, k, l))
 
     design = xp.stack(columns, axis=1)
+
+    if regularization > 0.0:
+        # Augmented rows enforce the L2 penalty rho * ||Z||_F^2 (full k, l). For
+        # the k <= l parameterization, off-diagonal entries appear twice in
+        # ||Z||_F^2, so they carry weight 2 (diagonal weight 1). The factor 2
+        # below comes from the 1/2 on the least-squares term in Eq. 17.
+        weights = xp.asarray(
+            [1.0 if k == l else 2.0 for (_, k, l) in metadata])
+        penalty = xp.sqrt(2.0 * regularization * weights)
+        design = xp.concatenate([design, xp.diag(penalty)], axis=0)
+        target = xp.concatenate([target, xp.zeros(penalty.shape[0])], axis=0)
+
     solution = xp.linalg.lstsq(design, target, rcond=None)[0]
 
     cores = [xp.zeros((n, n)) for _ in rotations_dev]
@@ -323,8 +341,13 @@ def compressed_double_factorization(
     ``X^t`` and optimized with L-BFGS (warm-started from X-DF), while the
     symmetric cores ``Z^t`` are solved exactly in closed form at each step.
 
-    ``regularization`` adds an optional ``rho * sum_t ||Z^t||_F^2`` penalty
-    (the RC-DF extension, arXiv:2212.07957); default 0 reproduces plain C-DF.
+    ``regularization`` (``rho``) enables RC-DF (arXiv:2212.07957, Eq. 17): the
+    L2 penalty ``rho * sum_{t,k,l} (Z^t_kl)^2`` is added to the objective and,
+    crucially, folded into the inner core solve as a ridge term. It shrinks the
+    cores -- lowering the Hamiltonian one-norm ``lambda`` and the measurement
+    variance -- and conditions the inner system. ``rho`` is an absolute
+    coefficient (its useful scale depends on the integral magnitude; the paper
+    uses ~1e-6 to 1e-3). ``rho = 0`` reproduces plain C-DF.
 
     Returns a :class:`DoubleFactorization` with NumPy arrays.
     """
@@ -354,26 +377,21 @@ def compressed_double_factorization(
             rotations.append(expm_skew_symmetric(skew, xp))
         return skews, rotations
 
-    def objective(parameter_vector):
-        _, rotations = unpack(parameter_vector)
-        cores = _solve_inner_cores(eri_dev, rotations, xp)
+    def objective_and_gradient(parameter_vector):
+        # Two-step objective O(X) with the cores Z at their (regularized)
+        # least-squares optimum. Because dO/dZ = 0 there, the envelope theorem
+        # gives dO/dX = (dO/dU at fixed Z) chained through dU/dX; the L2 penalty
+        # has no explicit X-dependence, so the gradient keeps the same form for
+        # any regularization. dO/dU^t_ak = -4 sum_qrsl Delta_aqrs U_qk Z_kl U_rl
+        # U_sl (Eq. 17 of arXiv:2104.08957).
+        skews, rotations = unpack(parameter_vector)
+        cores = _solve_inner_cores(eri_dev, rotations, xp, regularization)
         residual = eri_dev - _reconstruct_dev(rotations, cores, xp)
         loss = 0.5 * xp.sum(residual * residual)
         if regularization > 0.0:
             loss = loss + regularization * sum(
                 xp.sum(core * core) for core in cores)
-        return float(to_numpy(loss))
-
-    def objective_and_gradient(parameter_vector):
-        # Analytic gradient (regularization == 0 only): with the inner cores at
-        # their least-squares optimum, dO/dZ = 0, so by the envelope theorem the
-        # gradient is dO/dU chained through dU/dX (the matrix-exponential
-        # derivative). dO/dU^t_ak = -4 sum_qrsl Delta_aqrs U_qk Z_kl U_rl U_sl
-        # (Eq. 17 of arXiv:2104.08957).
-        skews, rotations = unpack(parameter_vector)
-        cores = _solve_inner_cores(eri_dev, rotations, xp)
-        residual = eri_dev - _reconstruct_dev(rotations, cores, xp)
-        loss = float(to_numpy(0.5 * xp.sum(residual * residual)))
+        loss = float(to_numpy(loss))
 
         gradient_chunks = []
         for skew, rotation, core in zip(skews, rotations, cores):
@@ -395,20 +413,18 @@ def compressed_double_factorization(
             gradient_chunks.append(grad_x[lower])
         return loss, np.concatenate(gradient_chunks)
 
-    use_analytic = regularization == 0.0
-    result = scipy.optimize.minimize(
-        objective_and_gradient if use_analytic else objective,
-        x0,
-        method="L-BFGS-B",
-        jac=use_analytic,
-        options={
-            "maxiter": max_iterations,
-            "ftol": tolerance,
-            "gtol": tolerance,
-        })
+    result = scipy.optimize.minimize(objective_and_gradient,
+                                     x0,
+                                     method="L-BFGS-B",
+                                     jac=True,
+                                     options={
+                                         "maxiter": max_iterations,
+                                         "ftol": tolerance,
+                                         "gtol": tolerance,
+                                     })
 
     _, rotations = unpack(result.x)
-    cores = _solve_inner_cores(eri_dev, rotations, xp)
+    cores = _solve_inner_cores(eri_dev, rotations, xp, regularization)
     return DoubleFactorization(
         num_orbitals=n,
         leaf_rotations=[to_numpy(r) for r in rotations],
@@ -438,14 +454,39 @@ def modified_one_body_integrals(one_body, eri) -> np.ndarray:
 
 
 def double_factorization_one_norm(factorization: DoubleFactorization,
-                                  one_body_eigenvalues) -> float:
-    """LCU one-norm ``lambda`` of the double-factorized Hamiltonian (RC-DF
-    Eq. 13): ``sum_k |F_k| + sum_t (sum_{k<l} |Z^t_kl| + 1/4 sum_k |Z^t_kk|)``."""
+                                  one_body_eigenvalues,
+                                  convention: str = "lcu") -> float:
+    """One-norm ``lambda`` of the double-factorized Hamiltonian (RC-DF,
+    arXiv:2212.07957), used to assess factorization quality.
+
+    ``convention="lcu"`` (Eq. 13) -- the LCU / Pauli-rotation norm
+    ``sum_k |F_k| + sum_t (sum_{k<l} |Z^t_kl| + 1/4 sum_k |Z^t_kk|)``.
+
+    ``convention="burg"`` (Eq. 15) -- the qubitization norm
+    ``sum_k |F_k| + 1/4 sum_t sum_i (sum_k |W^t_ki|)^2`` with ``W^t = sqrt(Z^t)``
+    (the matrix square root, which may be complex for indefinite cores).
+
+    ``one_body_eigenvalues`` are the diagonal one-body (Fock-like) eigenvalues.
+    """
     one_body_eigenvalues = np.asarray(one_body_eigenvalues, dtype=float)
     lam = float(np.sum(np.abs(one_body_eigenvalues)))
-    for core in factorization.leaf_cores:
-        core = np.asarray(core)
-        # sum_{k<l} |Z_kl| (strict upper triangle) + 1/4 sum_k |Z_kk|
-        lam += float(np.sum(np.abs(np.triu(core, k=1))))
-        lam += 0.25 * float(np.sum(np.abs(np.diag(core))))
-    return lam
+
+    if convention == "lcu":
+        for core in factorization.leaf_cores:
+            core = np.asarray(core)
+            # sum_{k<l} |Z_kl| (strict upper triangle) + 1/4 sum_k |Z_kk|
+            lam += float(np.sum(np.abs(np.triu(core, k=1))))
+            lam += 0.25 * float(np.sum(np.abs(np.diag(core))))
+        return lam
+
+    if convention == "burg":
+        for core in factorization.leaf_cores:
+            eigenvalues, vectors = np.linalg.eigh(np.asarray(core, dtype=float))
+            root = (vectors * np.sqrt(eigenvalues.astype(complex))) @ \
+                vectors.conj().T  # W = sqrt(Z), possibly complex
+            column_abs_sum = np.sum(np.abs(root), axis=0)  # sum_k |W_ki| per i
+            lam += 0.25 * float(np.sum(column_abs_sum**2))
+        return lam
+
+    raise ValueError(
+        "double_factorization error - convention must be 'lcu' or 'burg'.")

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -33,8 +33,9 @@ import scipy.linalg
 import scipy.optimize
 
 from ._backend import (AUTO_GPU_MIN_ORBITALS_COMPRESSED,
-                       AUTO_GPU_MIN_ORBITALS_EXPLICIT, expm_skew_symmetric,
-                       resolve_backend, to_device, to_numpy)
+                       AUTO_GPU_MIN_ORBITALS_EXPLICIT,
+                       expm_skew_symmetric_batched, resolve_backend, to_device,
+                       to_numpy)
 
 
 @dataclass
@@ -388,17 +389,25 @@ def _solve_inner_cores(eri_dev,
 
 
 def _reconstruct_dev(rotations_dev, cores_dev, xp):
-    n = rotations_dev[0].shape[0]
-    eri = xp.zeros((n, n, n, n))
-    for rotation, core in zip(rotations_dev, cores_dev):
-        eri = eri + xp.einsum("pk,qk,kl,rl,sl->pqrs",
-                              rotation,
-                              rotation,
-                              core,
-                              rotation,
-                              rotation,
-                              optimize=True)
-    return eri
+    # Stack the leaves and reconstruct in a single batched contraction (the sum
+    # over leaves t is folded into the einsum), instead of a Python loop with a
+    # separate n^4 einsum and accumulation per leaf.
+    rotations = rotations_dev if _is_stacked(rotations_dev) else xp.stack(
+        list(rotations_dev))
+    cores = cores_dev if _is_stacked(cores_dev) else xp.stack(list(cores_dev))
+    return xp.einsum("tpk,tqk,tkl,trl,tsl->pqrs",
+                     rotations,
+                     rotations,
+                     cores,
+                     rotations,
+                     rotations,
+                     optimize=True)
+
+
+def _is_stacked(arrays):
+    """True for a single stacked ``(num_leaves, n, n)`` array, False for a list
+    of ``(n, n)`` leaf arrays."""
+    return hasattr(arrays, "ndim") and arrays.ndim == 3
 
 
 def _skew_to_vector(generator, n):
@@ -515,13 +524,15 @@ def compressed_double_factorization(
     warm_state = {"z": None}
 
     def unpack(parameter_vector):
-        skews, rotations = [], []
-        for leaf_index in range(num_leaves):
-            chunk = parameter_vector[leaf_index * per_leaf:(leaf_index + 1) *
-                                     per_leaf]
-            skew = _vector_to_skew(to_device(chunk, xp), n, xp)
-            skews.append(skew)
-            rotations.append(expm_skew_symmetric(skew, xp))
+        # Build all leaf generators, then exponentiate them in one batched
+        # Hermitian eigendecomposition (single cuSOLVER call on GPU). Returns
+        # stacked (num_leaves, n, n) arrays.
+        skews = xp.stack([
+            _vector_to_skew(
+                to_device(parameter_vector[i * per_leaf:(i + 1) * per_leaf],
+                          xp), n, xp) for i in range(num_leaves)
+        ])
+        rotations = expm_skew_symmetric_batched(skews, xp)
         return skews, rotations
 
     def objective_and_gradient(parameter_vector):
@@ -545,21 +556,24 @@ def compressed_double_factorization(
                 xp.sum(core * core) for core in cores)
         loss = float(to_numpy(loss))
 
+        # dO/dU for all leaves in one batched contraction, then a single
+        # device->host transfer (the leaf index t is the batch axis).
+        cores_dev = cores if _is_stacked(cores) else xp.stack(list(cores))
+        grad_u_all = to_numpy(-4.0 * xp.einsum("aqrs,tqk,tkl,trl,tsl->tak",
+                                               residual,
+                                               rotations,
+                                               cores_dev,
+                                               rotations,
+                                               rotations,
+                                               optimize=True))
+        skews_host = to_numpy(skews)
         gradient_chunks = []
-        for skew, rotation, core in zip(skews, rotations, cores):
-            grad_u = -4.0 * xp.einsum("aqrs,qk,kl,rl,sl->ak",
-                                      residual,
-                                      rotation,
-                                      core,
-                                      rotation,
-                                      rotation,
-                                      optimize=True)
+        for leaf_index in range(num_leaves):
             # Adjoint of d(exp)/dX: grad_X = L_exp(X^T, grad_U) (Frechet
-            # derivative), then project onto the antisymmetric parameters.
-            grad_u_host = to_numpy(grad_u)
-            skew_host = to_numpy(skew)
-            grad_x = scipy.linalg.expm_frechet(skew_host.T,
-                                               grad_u_host,
+            # derivative), then project onto the antisymmetric parameters. The
+            # Frechet step stays on the host (it is ~2% of the step cost).
+            grad_x = scipy.linalg.expm_frechet(skews_host[leaf_index].T,
+                                               grad_u_all[leaf_index],
                                                compute_expm=False)
             grad_x = grad_x - grad_x.T
             gradient_chunks.append(grad_x[lower])

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -224,6 +224,34 @@ def test_compressed_matrix_free_cg_matches_lstsq(backend):
                                            backend=backend)
 
 
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_cg_accelerators_preserve_accuracy(backend):
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=11)
+    # The warm-start + inexact-in-loop accelerators (defaults) must reach the
+    # same final reconstruction as the cold-start, tight-in-loop CG: the single
+    # final solve is always tightened to cg_tolerance.
+    for regularization in (0.0, 1.0e-2):
+        accel = df.compressed_double_factorization(
+            eri,
+            num_leaves=2,
+            max_iterations=800,
+            regularization=regularization,
+            inner_solver="cg",
+            backend=backend)
+        plain = df.compressed_double_factorization(
+            eri,
+            num_leaves=2,
+            max_iterations=800,
+            regularization=regularization,
+            inner_solver="cg",
+            cg_warm_start=False,
+            cg_optimization_tolerance=1.0e-10,
+            backend=backend)
+        assert abs(
+            df.factorization_error(eri, accel) -
+            df.factorization_error(eri, plain)) < 1.0e-4
+
+
 def test_one_norm_conventions():
     eri = _synthetic_eri(n=4, num_vectors=3, seed=9)
     factorization = df.explicit_double_factorization(eri, threshold=0.0)

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -141,6 +141,53 @@ def test_compressed_double_factorization_exact_at_true_rank(backend):
     assert _max_orthogonality_error(compressed) < 1.0e-9
 
 
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_rcdf_regularization_shrinks_cores_and_one_norm(backend):
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=7)
+    one_body = np.array([0.4, -0.3, 0.2, -0.1])
+
+    plain = df.compressed_double_factorization(eri, num_leaves=2,
+                                               max_iterations=800,
+                                               regularization=0.0,
+                                               backend=backend)
+    regularized = df.compressed_double_factorization(eri, num_leaves=2,
+                                                     max_iterations=800,
+                                                     regularization=1.0e-2,
+                                                     backend=backend)
+
+    def core_norm(factorization):
+        return sum(float(np.linalg.norm(z)) for z in factorization.leaf_cores)
+
+    # RC-DF shrinks the cores ...
+    assert core_norm(regularized) < core_norm(plain)
+    # ... lowering the Hamiltonian one-norm in both conventions ...
+    for convention in ("lcu", "burg"):
+        assert (df.double_factorization_one_norm(
+            regularized, one_body, convention=convention) <
+                df.double_factorization_one_norm(
+                    plain, one_body, convention=convention))
+    # ... at the cost of reconstruction accuracy.
+    assert (df.factorization_error(eri, regularized) >=
+            df.factorization_error(eri, plain) - 1.0e-9)
+
+
+def test_one_norm_conventions():
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=9)
+    factorization = df.explicit_double_factorization(eri, threshold=0.0)
+    one_body = np.array([0.5, -1.0, 0.25, 0.75])
+    base = float(np.sum(np.abs(one_body)))
+
+    lcu = df.double_factorization_one_norm(factorization, one_body,
+                                           convention="lcu")
+    burg = df.double_factorization_one_norm(factorization, one_body,
+                                            convention="burg")
+    assert lcu >= base
+    assert burg >= base
+    with pytest.raises(ValueError):
+        df.double_factorization_one_norm(factorization, one_body,
+                                         convention="bogus")
+
+
 def test_reconstruct_eri_matches_helper():
     eri = _synthetic_eri(n=4, num_vectors=2, seed=3)
     factorization = df.explicit_double_factorization(eri,

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -1,0 +1,145 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Tests for explicit (X-DF) and compressed (C-DF) double factorization."""
+import os
+
+import numpy as np
+import pytest
+
+import cudaq_algorithms as algorithms
+
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+
+df = algorithms.double_factorization
+
+# Run every test on the NumPy backend, plus the CuPy (GPU) backend when present.
+_BACKENDS = ["numpy"]
+if df.cupy_gpu_available():
+    _BACKENDS.append("cupy")
+
+
+def _synthetic_eri(n, num_vectors, seed):
+    """An 8-fold-symmetric chemist-notation ERI of known low rank."""
+    rng = np.random.default_rng(seed)
+    leaves = rng.standard_normal((num_vectors, n, n))
+    leaves = 0.5 * (leaves + leaves.transpose(0, 2, 1))
+    return np.einsum("xpq,xrs->pqrs", leaves, leaves)
+
+
+def _h2o_eri():
+    pytest.importorskip("pyscf")
+    from pyscf import ao2mo, gto, scf
+    mol = gto.M(atom="O 0 0 0; H 0 0 0.957; H 0 0.926 -0.24",
+                basis="sto-3g",
+                verbose=0)
+    mf = scf.RHF(mol).run()
+    n = mf.mo_coeff.shape[1]
+    return np.asarray(ao2mo.restore("s1", ao2mo.kernel(mol, mf.mo_coeff), n))
+
+
+def _max_orthogonality_error(factorization):
+    return max((float(
+        np.linalg.norm(u.T @ u - np.eye(u.shape[0])))
+                for u in factorization.leaf_rotations),
+               default=0.0)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_explicit_double_factorization_is_exact_at_full_rank(backend):
+    eri = _h2o_eri()
+    factorization = df.explicit_double_factorization(eri,
+                                                     eigenvalue_threshold=0.0,
+                                                     backend=backend)
+    assert factorization.method == "X-DF"
+    assert df.factorization_error(eri, factorization) < 1.0e-9
+    assert _max_orthogonality_error(factorization) < 1.0e-10
+    # Cores are symmetric.
+    for core in factorization.leaf_cores:
+        assert np.allclose(core, core.T, atol=1.0e-12)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_explicit_double_factorization_truncation_monotone(backend):
+    eri = _h2o_eri()
+    full = df.explicit_double_factorization(eri, eigenvalue_threshold=0.0,
+                                            backend=backend)
+    coarse = df.explicit_double_factorization(eri, eigenvalue_threshold=1.0e-2,
+                                              backend=backend)
+    fine = df.explicit_double_factorization(eri, eigenvalue_threshold=1.0e-4,
+                                            backend=backend)
+    # More aggressive truncation -> fewer leaves and larger (or equal) error.
+    assert coarse.num_leaves <= fine.num_leaves <= full.num_leaves
+    assert (df.factorization_error(eri, coarse) >=
+            df.factorization_error(eri, fine) - 1.0e-12)
+    # max_num_leaves caps the leaf count.
+    capped = df.explicit_double_factorization(eri, eigenvalue_threshold=0.0,
+                                              max_num_leaves=3, backend=backend)
+    assert capped.num_leaves == 3
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_compressed_double_factorization_beats_explicit(backend):
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=7)
+    for num_leaves in (1, 2):
+        explicit = df.explicit_double_factorization(eri,
+                                                    eigenvalue_threshold=0.0,
+                                                    max_num_leaves=num_leaves,
+                                                    backend=backend)
+        compressed = df.compressed_double_factorization(eri,
+                                                        num_leaves=num_leaves,
+                                                        max_iterations=500,
+                                                        backend=backend)
+        assert compressed.method == "C-DF"
+        assert compressed.num_leaves == num_leaves
+        # Compression is never worse than the explicit factorization.
+        assert (df.factorization_error(eri, compressed) <=
+                df.factorization_error(eri, explicit) + 1.0e-6)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_compressed_double_factorization_exact_at_true_rank(backend):
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=11)
+    compressed = df.compressed_double_factorization(eri, num_leaves=3,
+                                                    max_iterations=1500,
+                                                    backend=backend)
+    assert df.factorization_error(eri, compressed) < 1.0e-4
+    assert _max_orthogonality_error(compressed) < 1.0e-9
+
+
+def test_reconstruct_eri_matches_helper():
+    eri = _synthetic_eri(n=4, num_vectors=2, seed=3)
+    factorization = df.explicit_double_factorization(eri,
+                                                     eigenvalue_threshold=0.0)
+    np.testing.assert_allclose(df.reconstruct_eri(factorization),
+                               factorization.reconstruct_eri())
+
+
+def test_modified_one_body_integrals():
+    eri = _synthetic_eri(n=4, num_vectors=2, seed=5)
+    one_body = np.diag([0.1, -0.2, 0.3, -0.4])
+    kappa = df.modified_one_body_integrals(one_body, eri)
+    expected = one_body - 0.5 * np.einsum("prqr->pq", eri)
+    np.testing.assert_allclose(kappa, expected)
+    assert np.allclose(kappa, kappa.T)
+
+
+def test_double_factorization_one_norm_nonnegative_and_additive():
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=9)
+    factorization = df.explicit_double_factorization(eri,
+                                                     eigenvalue_threshold=0.0)
+    one_body_eigenvalues = np.array([0.5, -1.0, 0.25, 0.75])
+    lam = df.double_factorization_one_norm(factorization, one_body_eigenvalues)
+    assert lam >= float(np.sum(np.abs(one_body_eigenvalues)))
+
+
+def test_invalid_inputs_raise():
+    with pytest.raises(ValueError):
+        df.explicit_double_factorization(np.zeros((3, 3)))  # not rank-4
+    with pytest.raises(ValueError):
+        df.compressed_double_factorization(_synthetic_eri(4, 2, 1),
+                                           num_leaves=0)

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -186,6 +186,44 @@ def test_rcdf_regularization_shrinks_cores_and_one_norm(backend):
             >= df.factorization_error(eri, plain) - 1.0e-9)
 
 
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_compressed_matrix_free_cg_matches_lstsq(backend):
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=11)
+    # The matrix-free conjugate-gradient inner solve (RC-DF Eqs. 25-30) is an
+    # alternative to the explicit design-matrix least squares; both must reach
+    # the same reconstruction accuracy, with and without regularization.
+    for regularization in (0.0, 1.0e-2):
+        lstsq = df.compressed_double_factorization(
+            eri,
+            num_leaves=2,
+            max_iterations=800,
+            regularization=regularization,
+            inner_solver="lstsq",
+            backend=backend)
+        cg = df.compressed_double_factorization(eri,
+                                                num_leaves=2,
+                                                max_iterations=800,
+                                                regularization=regularization,
+                                                inner_solver="cg",
+                                                backend=backend)
+        assert cg.method == "C-DF"
+        assert abs(
+            df.factorization_error(eri, cg) -
+            df.factorization_error(eri, lstsq)) < 1.0e-6
+    # CG is exact at the true rank, like the least-squares solver.
+    exact = df.compressed_double_factorization(eri,
+                                               num_leaves=3,
+                                               max_iterations=1500,
+                                               inner_solver="cg",
+                                               backend=backend)
+    assert df.factorization_error(eri, exact) < 1.0e-4
+    with pytest.raises(ValueError):
+        df.compressed_double_factorization(eri,
+                                           num_leaves=2,
+                                           inner_solver="bogus",
+                                           backend=backend)
+
+
 def test_one_norm_conventions():
     eri = _synthetic_eri(n=4, num_vectors=3, seed=9)
     factorization = df.explicit_double_factorization(eri, threshold=0.0)

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -43,8 +43,7 @@ def _h2o_eri():
 
 
 def _max_orthogonality_error(factorization):
-    return max((float(
-        np.linalg.norm(u.T @ u - np.eye(u.shape[0])))
+    return max((float(np.linalg.norm(u.T @ u - np.eye(u.shape[0])))
                 for u in factorization.leaf_rotations),
                default=0.0)
 
@@ -66,19 +65,24 @@ def test_explicit_double_factorization_is_exact_at_full_rank(backend):
 @pytest.mark.parametrize("backend", _BACKENDS)
 def test_explicit_double_factorization_truncation_monotone(backend):
     eri = _h2o_eri()
-    full = df.explicit_double_factorization(eri, threshold=0.0,
+    full = df.explicit_double_factorization(eri,
+                                            threshold=0.0,
                                             backend=backend)
-    coarse = df.explicit_double_factorization(eri, threshold=1.0e-2,
+    coarse = df.explicit_double_factorization(eri,
+                                              threshold=1.0e-2,
                                               backend=backend)
-    fine = df.explicit_double_factorization(eri, threshold=1.0e-4,
+    fine = df.explicit_double_factorization(eri,
+                                            threshold=1.0e-4,
                                             backend=backend)
     # More aggressive truncation -> fewer leaves and larger (or equal) error.
     assert coarse.num_leaves <= fine.num_leaves <= full.num_leaves
-    assert (df.factorization_error(eri, coarse) >=
-            df.factorization_error(eri, fine) - 1.0e-12)
+    assert (df.factorization_error(eri, coarse)
+            >= df.factorization_error(eri, fine) - 1.0e-12)
     # max_num_leaves caps the leaf count.
-    capped = df.explicit_double_factorization(eri, threshold=0.0,
-                                              max_num_leaves=3, backend=backend)
+    capped = df.explicit_double_factorization(eri,
+                                              threshold=0.0,
+                                              max_num_leaves=3,
+                                              backend=backend)
     assert capped.num_leaves == 3
 
 
@@ -86,7 +90,8 @@ def test_explicit_double_factorization_truncation_monotone(backend):
 def test_pivoted_cholesky_is_default_and_rank_revealing(backend):
     eri = _h2o_eri()
     n = eri.shape[0]
-    factorization = df.explicit_double_factorization(eri, threshold=1.0e-12,
+    factorization = df.explicit_double_factorization(eri,
+                                                     threshold=1.0e-12,
                                                      backend=backend)
     # Pivoted Cholesky is the default first factorization.
     assert factorization.first_factorization == "cholesky"
@@ -99,17 +104,22 @@ def test_pivoted_cholesky_is_default_and_rank_revealing(backend):
 @pytest.mark.parametrize("backend", _BACKENDS)
 def test_cholesky_and_eigendecomposition_agree(backend):
     eri = _h2o_eri()
-    cholesky = df.explicit_double_factorization(
-        eri, threshold=0.0, first_factorization="cholesky", backend=backend)
+    cholesky = df.explicit_double_factorization(eri,
+                                                threshold=0.0,
+                                                first_factorization="cholesky",
+                                                backend=backend)
     eigen = df.explicit_double_factorization(
-        eri, threshold=0.0, first_factorization="eigendecomposition",
+        eri,
+        threshold=0.0,
+        first_factorization="eigendecomposition",
         backend=backend)
     assert eigen.first_factorization == "eigendecomposition"
     # Both reconstruct the same ERI exactly, regardless of first-factor method.
     assert df.factorization_error(eri, cholesky) < 1.0e-9
     assert df.factorization_error(eri, eigen) < 1.0e-9
     np.testing.assert_allclose(cholesky.reconstruct_eri(),
-                               eigen.reconstruct_eri(), atol=1.0e-9)
+                               eigen.reconstruct_eri(),
+                               atol=1.0e-9)
 
 
 @pytest.mark.parametrize("backend", _BACKENDS)
@@ -127,14 +137,15 @@ def test_compressed_double_factorization_beats_explicit(backend):
         assert compressed.method == "C-DF"
         assert compressed.num_leaves == num_leaves
         # Compression is never worse than the explicit factorization.
-        assert (df.factorization_error(eri, compressed) <=
-                df.factorization_error(eri, explicit) + 1.0e-6)
+        assert (df.factorization_error(eri, compressed)
+                <= df.factorization_error(eri, explicit) + 1.0e-6)
 
 
 @pytest.mark.parametrize("backend", _BACKENDS)
 def test_compressed_double_factorization_exact_at_true_rank(backend):
     eri = _synthetic_eri(n=4, num_vectors=3, seed=11)
-    compressed = df.compressed_double_factorization(eri, num_leaves=3,
+    compressed = df.compressed_double_factorization(eri,
+                                                    num_leaves=3,
                                                     max_iterations=1500,
                                                     backend=backend)
     assert df.factorization_error(eri, compressed) < 1.0e-4
@@ -146,11 +157,13 @@ def test_rcdf_regularization_shrinks_cores_and_one_norm(backend):
     eri = _synthetic_eri(n=4, num_vectors=3, seed=7)
     one_body = np.array([0.4, -0.3, 0.2, -0.1])
 
-    plain = df.compressed_double_factorization(eri, num_leaves=2,
+    plain = df.compressed_double_factorization(eri,
+                                               num_leaves=2,
                                                max_iterations=800,
                                                regularization=0.0,
                                                backend=backend)
-    regularized = df.compressed_double_factorization(eri, num_leaves=2,
+    regularized = df.compressed_double_factorization(eri,
+                                                     num_leaves=2,
                                                      max_iterations=800,
                                                      regularization=1.0e-2,
                                                      backend=backend)
@@ -162,13 +175,15 @@ def test_rcdf_regularization_shrinks_cores_and_one_norm(backend):
     assert core_norm(regularized) < core_norm(plain)
     # ... lowering the Hamiltonian one-norm in both conventions ...
     for convention in ("lcu", "burg"):
-        assert (df.double_factorization_one_norm(
-            regularized, one_body, convention=convention) <
-                df.double_factorization_one_norm(
-                    plain, one_body, convention=convention))
+        assert (df.double_factorization_one_norm(regularized,
+                                                 one_body,
+                                                 convention=convention)
+                < df.double_factorization_one_norm(plain,
+                                                   one_body,
+                                                   convention=convention))
     # ... at the cost of reconstruction accuracy.
-    assert (df.factorization_error(eri, regularized) >=
-            df.factorization_error(eri, plain) - 1.0e-9)
+    assert (df.factorization_error(eri, regularized)
+            >= df.factorization_error(eri, plain) - 1.0e-9)
 
 
 def test_one_norm_conventions():
@@ -177,21 +192,23 @@ def test_one_norm_conventions():
     one_body = np.array([0.5, -1.0, 0.25, 0.75])
     base = float(np.sum(np.abs(one_body)))
 
-    lcu = df.double_factorization_one_norm(factorization, one_body,
+    lcu = df.double_factorization_one_norm(factorization,
+                                           one_body,
                                            convention="lcu")
-    burg = df.double_factorization_one_norm(factorization, one_body,
+    burg = df.double_factorization_one_norm(factorization,
+                                            one_body,
                                             convention="burg")
     assert lcu >= base
     assert burg >= base
     with pytest.raises(ValueError):
-        df.double_factorization_one_norm(factorization, one_body,
+        df.double_factorization_one_norm(factorization,
+                                         one_body,
                                          convention="bogus")
 
 
 def test_reconstruct_eri_matches_helper():
     eri = _synthetic_eri(n=4, num_vectors=2, seed=3)
-    factorization = df.explicit_double_factorization(eri,
-                                                     threshold=0.0)
+    factorization = df.explicit_double_factorization(eri, threshold=0.0)
     np.testing.assert_allclose(df.reconstruct_eri(factorization),
                                factorization.reconstruct_eri())
 
@@ -207,8 +224,7 @@ def test_modified_one_body_integrals():
 
 def test_double_factorization_one_norm_nonnegative_and_additive():
     eri = _synthetic_eri(n=4, num_vectors=3, seed=9)
-    factorization = df.explicit_double_factorization(eri,
-                                                     threshold=0.0)
+    factorization = df.explicit_double_factorization(eri, threshold=0.0)
     one_body_eigenvalues = np.array([0.5, -1.0, 0.25, 0.75])
     lam = df.double_factorization_one_norm(factorization, one_body_eigenvalues)
     assert lam >= float(np.sum(np.abs(one_body_eigenvalues)))
@@ -262,8 +278,8 @@ def test_explicit_double_factorization_matches_openfermion_reference():
     factorize = _openfermion_factorize()
     eri = _h2o_eri()
     n = eri.shape[0]
-    reference_eri, _factors, rank, _num_eigenvectors = factorize(eri,
-                                                                 thresh=1.0e-13)
+    reference_eri, _factors, rank, _num_eigenvectors = factorize(
+        eri, thresh=1.0e-13)
 
     # The reference reconstructs the ERI, and its first-factor rank cannot exceed
     # the symmetric-pair dimension n(n+1)/2.

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -143,3 +143,57 @@ def test_invalid_inputs_raise():
     with pytest.raises(ValueError):
         df.compressed_double_factorization(_synthetic_eri(4, 2, 1),
                                            num_leaves=0)
+
+
+def _openfermion_factorize():
+    """OpenFermion's explicit-DF ``factorize``, or skip if unavailable.
+
+    The public ``openfermion.resource_estimates.df`` API is gated behind an
+    optional ``jax`` dependency, but the factorization itself only needs NumPy,
+    so fall back to loading the module file directly when the gate blocks the
+    normal import.
+    """
+    pytest.importorskip("openfermion")
+    try:
+        from openfermion.resource_estimates import df as of_df
+        if hasattr(of_df, "factorize"):
+            return of_df.factorize
+    except Exception:
+        pass
+    import importlib.util
+    import openfermion
+    path = os.path.join(os.path.dirname(openfermion.__file__),
+                        "resource_estimates", "df", "factorize_df.py")
+    if not os.path.exists(path):
+        pytest.skip("OpenFermion explicit-DF reference is not available")
+    spec = importlib.util.spec_from_file_location("_of_factorize_df", path)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        pytest.skip("OpenFermion explicit-DF reference could not be loaded")
+    return module.factorize
+
+
+def test_explicit_double_factorization_matches_openfermion_reference():
+    """Cross-check X-DF against OpenFermion's independent explicit-DF reference.
+
+    Compared on the reconstructed ERI tensor (convention-independent), since the
+    two implementations store leaves differently and apply different second-factor
+    truncation conventions.
+    """
+    factorize = _openfermion_factorize()
+    eri = _h2o_eri()
+    n = eri.shape[0]
+    reference_eri, _factors, rank, _num_eigenvectors = factorize(eri,
+                                                                 thresh=1.0e-13)
+
+    # The reference reconstructs the ERI, and its first-factor rank cannot exceed
+    # the symmetric-pair dimension n(n+1)/2.
+    assert np.linalg.norm(reference_eri - eri) < 1.0e-9
+    assert rank <= n * (n + 1) // 2
+
+    mine = df.explicit_double_factorization(eri, eigenvalue_threshold=0.0)
+    np.testing.assert_allclose(mine.reconstruct_eri(),
+                               reference_eri,
+                               atol=1.0e-9)

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -252,6 +252,20 @@ def test_cg_accelerators_preserve_accuracy(backend):
             df.factorization_error(eri, plain)) < 1.0e-4
 
 
+def test_auto_backend_is_size_aware():
+    from cudaq_algorithms.double_factorization._backend import resolve_backend
+    # Explicit choices are honored regardless of size.
+    assert resolve_backend("numpy")[1] == "numpy"
+    # A tiny problem under the GPU threshold always resolves to NumPy (whether or
+    # not a GPU is present): below the crossover the GPU loses.
+    assert resolve_backend("auto", problem_size=4, gpu_min_size=1000)[1] \
+        == "numpy"
+    # A large problem resolves to CuPy when a GPU is present, else NumPy.
+    expected = "cupy" if df.cupy_gpu_available() else "numpy"
+    assert resolve_backend("auto", problem_size=10000, gpu_min_size=1)[1] \
+        == expected
+
+
 def test_one_norm_conventions():
     eri = _synthetic_eri(n=4, num_vectors=3, seed=9)
     factorization = df.explicit_double_factorization(eri, threshold=0.0)

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -53,7 +53,7 @@ def _max_orthogonality_error(factorization):
 def test_explicit_double_factorization_is_exact_at_full_rank(backend):
     eri = _h2o_eri()
     factorization = df.explicit_double_factorization(eri,
-                                                     eigenvalue_threshold=0.0,
+                                                     threshold=0.0,
                                                      backend=backend)
     assert factorization.method == "X-DF"
     assert df.factorization_error(eri, factorization) < 1.0e-9
@@ -66,20 +66,50 @@ def test_explicit_double_factorization_is_exact_at_full_rank(backend):
 @pytest.mark.parametrize("backend", _BACKENDS)
 def test_explicit_double_factorization_truncation_monotone(backend):
     eri = _h2o_eri()
-    full = df.explicit_double_factorization(eri, eigenvalue_threshold=0.0,
+    full = df.explicit_double_factorization(eri, threshold=0.0,
                                             backend=backend)
-    coarse = df.explicit_double_factorization(eri, eigenvalue_threshold=1.0e-2,
+    coarse = df.explicit_double_factorization(eri, threshold=1.0e-2,
                                               backend=backend)
-    fine = df.explicit_double_factorization(eri, eigenvalue_threshold=1.0e-4,
+    fine = df.explicit_double_factorization(eri, threshold=1.0e-4,
                                             backend=backend)
     # More aggressive truncation -> fewer leaves and larger (or equal) error.
     assert coarse.num_leaves <= fine.num_leaves <= full.num_leaves
     assert (df.factorization_error(eri, coarse) >=
             df.factorization_error(eri, fine) - 1.0e-12)
     # max_num_leaves caps the leaf count.
-    capped = df.explicit_double_factorization(eri, eigenvalue_threshold=0.0,
+    capped = df.explicit_double_factorization(eri, threshold=0.0,
                                               max_num_leaves=3, backend=backend)
     assert capped.num_leaves == 3
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_pivoted_cholesky_is_default_and_rank_revealing(backend):
+    eri = _h2o_eri()
+    n = eri.shape[0]
+    factorization = df.explicit_double_factorization(eri, threshold=1.0e-12,
+                                                     backend=backend)
+    # Pivoted Cholesky is the default first factorization.
+    assert factorization.first_factorization == "cholesky"
+    # The ERI supermatrix is PSD, so Cholesky stops at the true rank
+    # (<= the symmetric-pair dimension n(n+1)/2), not n^2.
+    assert factorization.num_leaves <= n * (n + 1) // 2
+    assert df.factorization_error(eri, factorization) < 1.0e-8
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_cholesky_and_eigendecomposition_agree(backend):
+    eri = _h2o_eri()
+    cholesky = df.explicit_double_factorization(
+        eri, threshold=0.0, first_factorization="cholesky", backend=backend)
+    eigen = df.explicit_double_factorization(
+        eri, threshold=0.0, first_factorization="eigendecomposition",
+        backend=backend)
+    assert eigen.first_factorization == "eigendecomposition"
+    # Both reconstruct the same ERI exactly, regardless of first-factor method.
+    assert df.factorization_error(eri, cholesky) < 1.0e-9
+    assert df.factorization_error(eri, eigen) < 1.0e-9
+    np.testing.assert_allclose(cholesky.reconstruct_eri(),
+                               eigen.reconstruct_eri(), atol=1.0e-9)
 
 
 @pytest.mark.parametrize("backend", _BACKENDS)
@@ -87,7 +117,7 @@ def test_compressed_double_factorization_beats_explicit(backend):
     eri = _synthetic_eri(n=4, num_vectors=3, seed=7)
     for num_leaves in (1, 2):
         explicit = df.explicit_double_factorization(eri,
-                                                    eigenvalue_threshold=0.0,
+                                                    threshold=0.0,
                                                     max_num_leaves=num_leaves,
                                                     backend=backend)
         compressed = df.compressed_double_factorization(eri,
@@ -114,7 +144,7 @@ def test_compressed_double_factorization_exact_at_true_rank(backend):
 def test_reconstruct_eri_matches_helper():
     eri = _synthetic_eri(n=4, num_vectors=2, seed=3)
     factorization = df.explicit_double_factorization(eri,
-                                                     eigenvalue_threshold=0.0)
+                                                     threshold=0.0)
     np.testing.assert_allclose(df.reconstruct_eri(factorization),
                                factorization.reconstruct_eri())
 
@@ -131,7 +161,7 @@ def test_modified_one_body_integrals():
 def test_double_factorization_one_norm_nonnegative_and_additive():
     eri = _synthetic_eri(n=4, num_vectors=3, seed=9)
     factorization = df.explicit_double_factorization(eri,
-                                                     eigenvalue_threshold=0.0)
+                                                     threshold=0.0)
     one_body_eigenvalues = np.array([0.5, -1.0, 0.25, 0.75])
     lam = df.double_factorization_one_norm(factorization, one_body_eigenvalues)
     assert lam >= float(np.sum(np.abs(one_body_eigenvalues)))
@@ -193,7 +223,7 @@ def test_explicit_double_factorization_matches_openfermion_reference():
     assert np.linalg.norm(reference_eri - eri) < 1.0e-9
     assert rank <= n * (n + 1) // 2
 
-    mine = df.explicit_double_factorization(eri, eigenvalue_threshold=0.0)
+    mine = df.explicit_double_factorization(eri, threshold=0.0)
     np.testing.assert_allclose(mine.reconstruct_eri(),
                                reference_eri,
                                atol=1.0e-9)


### PR DESCRIPTION
## Summary

Adds `cudaq_algorithms.double_factorization`, a pure-Python module implementing **explicit (X-DF)** and **compressed (C-DF)** double factorization of the two-electron integrals, following Cohn, Motta, and Parrish, *Quantum Filter Diagonalization with Compressed Double-Factorized Hamiltonians*, PRX Quantum **2**, 040352 (2021) ([arXiv:2104.08957](https://arxiv.org/abs/2104.08957)).

Double factorization rewrites the ERI tensor as a sum of low-rank, diagonalizable pieces — the representation used by double-factorized block encodings, qubitization, and measurement schemes:

```
(pq|rs) ~= sum_t sum_kl U^t_pk U^t_qk Z^t_kl U^t_rl U^t_sl
```

with orthogonal leaf rotations `U^t` (a Givens-rotation fabric) and symmetric cores `Z^t`.

## What's implemented

- **X-DF (`explicit_double_factorization`)** — exact nested eigendecompositions (rank-one cores), with eigenvalue/leaf-count truncation. Exact at full rank.
- **C-DF (`compressed_double_factorization`)** — least-squares optimization over a fixed leaf budget. Two-step scheme from the paper: leaf rotations `U^t = exp(X^t)` optimized with L-BFGS (warm-started from X-DF), symmetric cores solved in closed form each step. Uses an **analytic gradient** (envelope theorem + matrix-exponential Fréchet derivative); optional RC-DF L2 regularization.
- Helpers: `reconstruct_eri`, `factorization_error`, `modified_one_body_integrals` (the `kappa = h - 1/2 sum_r (pr|qr)` correction), `double_factorization_one_norm`.

Inputs are chemist-notation `(pq|rs)` over real spatial orbitals (e.g. `pyscf.ao2mo.restore("s1", ...)`).

## NVIDIA math libraries

Heavy linear algebra (eigendecompositions, tensor contractions, least squares) runs on **cuSOLVER/cuBLAS via CuPy** when a GPU is present, with automatic **NumPy/SciPy** fallback. Selectable via `backend="auto"` (default) / `"cupy"` / `"numpy"`.

## Validation

- **X-DF** is exact at full rank (~1e-14 on H2O/STO-3G) and **cross-checked against OpenFermion's independent explicit-DF reference** (`resource_estimates.df.factorize`) — reconstructed ERIs agree to ~1e-9.
- **C-DF** has no public reference implementation (the paper released none), so it is validated by properties: lower reconstruction error than X-DF at equal leaf count (e.g. H2O, 4 leaves: 2.6% vs 8.8%), machine-precision recovery at the true rank, and an analytic gradient verified against finite differences to ~5e-10.

## Tests / docs / example

- `tests/python/test_double_factorization.py` — 13 tests, parametrized across the NumPy **and** GPU/CuPy backends, plus the guarded OpenFermion cross-check (skips cleanly if OpenFermion is unavailable; no new hard test dependency).
- `examples/double_factorization/double_factorization.py` — H2O/STO-3G X-DF vs C-DF comparison.
- `docs/double_factorization.md` — API, conventions, and X-DF/C-DF overview.

## Notes

- This factorizes the two-body ERIs (the DF object). Assembling the full DF *Hamiltonian* (folding the one-body term, wiring into qubitization) is supported via the helpers and left as a follow-on.
- Implementation is entirely Python — double factorization is classical preprocessing (dense linear algebra on integral tensors), so no C++/`__qpu__` kernels are needed.
- **Formatting:** new Python files were hand-formatted; please normalize with the CI-pinned `yapf 0.43.0` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
