### PR TITLE
Enable pr-copy-bot

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,1 @@
+enabled: true


### PR DESCRIPTION
Add the necessary file to enable `copy-pr-bot`, so that NVIDIA runners can be used on PRs from untrusted users. Needed for external contributions, once repo is made public. File is identical to the one in NVIDIA/cudaqx.