### PR TITLE
Add the Suzuki-Trotter Hamiltonian simulation primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ dependency):
 - Pauli LCU block encoding (`PauliLCU`, plus prepare/select/apply kernels)
 - qubitization walks and Chebyshev moment measurement (`Walk`)
 - QSVT phase sequences (`QSVT`, `PhaseSequence`)
+- Suzuki-Trotter product formulas (`trotter.make_trotter_plan`, orders 1/2/4)
 
 Simulation-only helpers (statevector access) are isolated in
 `cudaq_algorithms.sim_utils`; everything else is hardware-shaped. See
-[docs/pauli_lcu_qsvt.md](docs/pauli_lcu_qsvt.md) and
-[examples/pauli_lcu_qsvt/](examples/pauli_lcu_qsvt/).
+[docs/pauli_lcu_qsvt.md](docs/pauli_lcu_qsvt.md),
+[docs/trotter.md](docs/trotter.md),
+[examples/pauli_lcu_qsvt/](examples/pauli_lcu_qsvt/), and
+[examples/hamiltonian_simulation/](examples/hamiltonian_simulation/).
 
 ## Chemistry Inputs
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dependency):
 - Pauli LCU block encoding (`PauliLCU`, plus prepare/select/apply kernels)
 - qubitization walks and Chebyshev moment measurement (`Walk`)
 - QSVT phase sequences (`QSVT`, `PhaseSequence`)
-- Suzuki-Trotter product formulas (`trotter.make_trotter_plan`, orders 1/2/4)
+- Suzuki-Trotter product formulas (`trotter.Trotter`, orders 1/2/4)
 
 Simulation-only helpers (statevector access) are isolated in
 `cudaq_algorithms.sim_utils`; everything else is hardware-shaped. See

--- a/docs/trotter.md
+++ b/docs/trotter.md
@@ -55,6 +55,11 @@ The Forest-Ruth weights (`w1 = 1/(2 - 2^(1/3))`, `w0 = 1 - 2*w1`) are
 precomputed private module constants: CUDA-Q kernels cannot call host-only
 math such as cube roots, so the kernel consumes the constants directly.
 
+Circuit-level optimization deliberately deferred (documented, not
+implemented): merging the back-to-back half-rotations at sweep and step
+boundaries of the order-2/4 formulas (~1/num_terms of all rotations, each
+a CX ladder on hardware); no effect on simulator results.
+
 ### Composing inside user kernels
 
 The flattened primitive is the escape hatch for composition with state
@@ -96,21 +101,15 @@ evolved = sim_utils.evolve(evolution, ket, time=0.8, steps=4, order=2)
 # approximates exp(-i H t)|ket>, identity phase included
 ```
 
-`evolve` delegates to `Trotter.state_kernel(time, steps, order)` — a
-`@cudaq.kernel(state)` factory sharing the same validation and marshaling
-as `Trotter.kernel` — and raises `ValueError` for invalid parameters.
-
-Circuit-level optimization deliberately deferred (documented, not
-implemented): merging the back-to-back half-rotations at sweep and step
-boundaries of the order-2/4 formulas (~1/num_terms of all rotations, each
-a CX ladder on hardware); no effect on simulator results.
-
-```python
-```
 
 Unlike the circuit primitive, `evolve` reintroduces the identity phase by
 default (`include_identity_phase=True`), so the result approximates the
 full `exp(-i H t)|ket>`.
+
+`evolve` delegates to `Trotter.state_kernel(time, steps, order)` — a
+`@cudaq.kernel(state)` factory sharing the same validation and marshaling
+as `Trotter.kernel` — and raises `ValueError` for invalid parameters
+(including a ket whose dimension does not match `num_qubits`).
 
 ## Testing
 

--- a/docs/trotter.md
+++ b/docs/trotter.md
@@ -60,6 +60,27 @@ implemented): merging the back-to-back half-rotations at sweep and step
 boundaries of the order-2/4 formulas (~1/num_terms of all rotations, each
 a CX ladder on hardware); no effect on simulator results.
 
+### State preparation injection
+
+`kernel()` takes an optional `state_prep` kernel with signature
+`(qubits: cudaq.qview)`: the returned circuit allocates the register in
+|0...0>, runs `state_prep` on it, then evolves — still zero-argument and
+directly sampleable, with no statevector anywhere:
+
+```python
+@cudaq.kernel
+def my_prep(qubits: cudaq.qview):
+    rx(0.37, qubits[0])
+    ry(-0.52, qubits[1])
+
+kernel = evolution.kernel(time=0.8, steps=4, order=2, state_prep=my_prep)
+counts = cudaq.sample(kernel)
+```
+
+`state_prep` must act only on the register it is handed (width
+`num_qubits`). The same parameter exists on the LCU/qubitization/QSVT
+factories.
+
 ### Composing inside user kernels
 
 The flattened primitive is the escape hatch for composition with state

--- a/docs/trotter.md
+++ b/docs/trotter.md
@@ -1,0 +1,119 @@
+# Suzuki-Trotter Hamiltonian simulation
+
+Product-formula time evolution for Hamiltonians expressed as sums of Pauli
+strings, implemented as a pure-Python peer of the LCU/QSVT primitives:
+term extraction, host-side planning and ordering, resource estimation, and
+the circuit primitive itself. Requires only the `cudaq` Python package.
+
+```
+python/cudaq_algorithms/trotter.py     term extraction, plans, resources,
+                                       apply_trotter kernel
+python/cudaq_algorithms/sim_utils.py   shared simulation-only helpers
+                                       (evolve lives here)
+tests/python/test_trotter.py           dense-reference test suite
+examples/hamiltonian_simulation/
+  trotter_chemistry.py                 chemistry-style end-to-end example
+```
+
+## Using the primitive
+
+```python
+from cudaq_algorithms import trotter
+
+# Flexible Hamiltonian input: SpinOperator, single spin term,
+# {"XZI...": coeff} mapping, or (coeff, word) pairs.
+plan = trotter.make_trotter_plan(
+    hamiltonian, time=0.8, steps=4, order=2,
+    ordering=trotter.TrotterOrdering.COEFFICIENT_MAGNITUDE_DESCENDING)
+
+plan.kernel()       # ready @cudaq.kernel(): |0...0> -> evolved state
+plan.resources()    # TrotterResourceEstimate (rotations, CNOT proxy, ...)
+plan.num_terms, plan.identity_coefficient, plan.words, plan.coefficients
+```
+
+`make_trotter_plan` extracts and validates the Pauli terms on the host
+(dropping identity terms into `identity_coefficient`), applies the
+requested term ordering, and returns a frozen `TrotterPlan` whose
+`kernel()` factory captures the flattened coefficient/word arrays.
+
+### Product-formula orders
+
+- `order=1` — first-order Trotter: one `exp(-i c_i t/steps P_i)` sweep per
+  step; error O(t^2 / steps).
+- `order=2` (default) — symmetric second-order (Strang) splitting: a
+  half-angle forward sweep followed by a half-angle reverse sweep; error
+  O(t^3 / steps^2).
+- `order=4` — Forest-Ruth fourth-order formula: three symmetric
+  second-order sub-steps with time fractions `FOREST_RUTH_W1`,
+  `FOREST_RUTH_W0`, `FOREST_RUTH_W1`; error O(t^5 / steps^4).
+
+The Forest-Ruth weights (`w1 = 1/(2 - 2^(1/3))`, `w0 = 1 - 2*w1`) are
+precomputed module constants: CUDA-Q kernels cannot call host-only math
+such as cube roots, so the kernel consumes the constants directly.
+
+### Composing inside user kernels
+
+The flattened primitive is the escape hatch for composition with state
+preparation or measurement in a custom kernel:
+
+```python
+import cudaq
+from cudaq_algorithms import trotter
+
+@cudaq.kernel
+def my_kernel(coeffs: list[float], words: list[cudaq.pauli_word],
+              t: float, steps: int, order: int):
+    q = cudaq.qvector(4)
+    # ... state preparation ...
+    trotter.apply_trotter(coeffs, words, t, steps, order, q)
+```
+
+`plan.coefficients` / `plan.words` supply the flattened arrays.
+
+### Identity terms and the global phase
+
+For `H = c I + H'`, the circuit applies the product formula for `H'` only;
+`exp(-i c t)` cannot be realized as a circuit on the evolved register. The
+phase is an unobservable global phase for a single unconditioned evolution
+but a real relative phase for controlled or interference-based algorithms —
+`plan.identity_coefficient` reports it so callers can account for it.
+
+## Simulation-only helper
+
+Statevector conveniences live in the shared `cudaq_algorithms.sim_utils`
+module (simulation-only: it uses `cudaq.get_state`, which does not exist on
+hardware targets). The Trotter-specific helper is `evolve`:
+
+```python
+from cudaq_algorithms import sim_utils
+
+evolved = sim_utils.evolve(plan, ket)   # approximates exp(-i H t)|ket>,
+                                        # identity phase included
+```
+
+Unlike the circuit primitive, `evolve` reintroduces the identity phase by
+default (`include_identity_phase=True`), so the result approximates the
+full `exp(-i H t)|ket>`.
+
+## Testing
+
+`tests/python/test_trotter.py` pins correctness against independent dense
+references: exact matrix exponentials via diagonalization, and an explicit
+Pauli-rotation simulator for per-order product formulas. Coverage includes
+kernel interop with flattened arguments, invalid-input handling, per-order
+error thresholds, asymptotic error-scaling slope fits (order-p error ~
+dt^p), exactness for commuting Hamiltonians, a 14-term 4-qubit
+chemistry-style Hamiltonian, identity/global-phase handling, and every
+accepted input form of the term-extraction front end.
+
+## Known CUDA-Q Python constraints
+
+Two upstream compiler behaviors shape the implementation:
+
+- `return` inside a Python kernel is silently ignored
+  ([cuda-quantum#4845](https://github.com/NVIDIA/cuda-quantum/issues/4845));
+  the `apply_trotter` body is a single positively-guarded block instead of
+  early-return guards.
+- Captured empty lists cannot be marshaled
+  ([cuda-quantum#4847](https://github.com/NVIDIA/cuda-quantum/issues/4847));
+  identity-only plans special-case their kernel factory.

--- a/docs/trotter.md
+++ b/docs/trotter.md
@@ -6,7 +6,8 @@ term extraction, host-side planning and ordering, resource estimation, and
 the circuit primitive itself. Requires only the `cudaq` Python package.
 
 ```
-python/cudaq_algorithms/trotter.py     term extraction, plans, resources,
+python/cudaq_algorithms/trotter.py     term extraction, ordering,
+                                       resources,
                                        apply_trotter kernel
 python/cudaq_algorithms/sim_utils.py   shared simulation-only helpers
                                        (evolve lives here)
@@ -47,12 +48,12 @@ primitives (`Walk.kernel(power=...)`, `QSVT.kernel(sequence)`).
   half-angle forward sweep followed by a half-angle reverse sweep; error
   O(t^3 / steps^2).
 - `order=4` — Forest-Ruth fourth-order formula: three symmetric
-  second-order sub-steps with time fractions `FOREST_RUTH_W1`,
-  `FOREST_RUTH_W0`, `FOREST_RUTH_W1`; error O(t^5 / steps^4).
+  second-order sub-steps with time fractions `w1`, `w0`, `w1`; error
+  O(t^5 / steps^4).
 
 The Forest-Ruth weights (`w1 = 1/(2 - 2^(1/3))`, `w0 = 1 - 2*w1`) are
-precomputed module constants: CUDA-Q kernels cannot call host-only math
-such as cube roots, so the kernel consumes the constants directly.
+precomputed private module constants: CUDA-Q kernels cannot call host-only
+math such as cube roots, so the kernel consumes the constants directly.
 
 ### Composing inside user kernels
 
@@ -95,6 +96,18 @@ evolved = sim_utils.evolve(evolution, ket, time=0.8, steps=4, order=2)
 # approximates exp(-i H t)|ket>, identity phase included
 ```
 
+`evolve` delegates to `Trotter.state_kernel(time, steps, order)` — a
+`@cudaq.kernel(state)` factory sharing the same validation and marshaling
+as `Trotter.kernel` — and raises `ValueError` for invalid parameters.
+
+Circuit-level optimization deliberately deferred (documented, not
+implemented): merging the back-to-back half-rotations at sweep and step
+boundaries of the order-2/4 formulas (~1/num_terms of all rotations, each
+a CX ladder on hardware); no effect on simulator results.
+
+```python
+```
+
 Unlike the circuit primitive, `evolve` reintroduces the identity phase by
 default (`include_identity_phase=True`), so the result approximates the
 full `exp(-i H t)|ket>`.
@@ -120,4 +133,4 @@ Two upstream compiler behaviors shape the implementation:
   early-return guards.
 - Captured empty lists cannot be marshaled
   ([cuda-quantum#4847](https://github.com/NVIDIA/cuda-quantum/issues/4847));
-  identity-only plans special-case their kernel factory.
+  identity-only Hamiltonians special-case the kernel factories.

--- a/docs/trotter.md
+++ b/docs/trotter.md
@@ -22,19 +22,22 @@ from cudaq_algorithms import trotter
 
 # Flexible Hamiltonian input: SpinOperator, single spin term,
 # {"XZI...": coeff} mapping, or (coeff, word) pairs.
-plan = trotter.make_trotter_plan(
-    hamiltonian, time=0.8, steps=4, order=2,
+evolution = trotter.Trotter(
+    hamiltonian,
     ordering=trotter.TrotterOrdering.COEFFICIENT_MAGNITUDE_DESCENDING)
 
-plan.kernel()       # ready @cudaq.kernel(): |0...0> -> evolved state
-plan.resources()    # TrotterResourceEstimate (rotations, CNOT proxy, ...)
-plan.num_terms, plan.identity_coefficient, plan.words, plan.coefficients
+evolution.kernel(time=0.8, steps=4, order=2)   # ready @cudaq.kernel():
+                                               # |0...0> -> evolved state
+evolution.resources(steps=4, order=2)  # TrotterResourceEstimate
+evolution.num_terms, evolution.identity_coefficient
+evolution.words, evolution.coefficients
 ```
 
-`make_trotter_plan` extracts and validates the Pauli terms on the host
-(dropping identity terms into `identity_coefficient`), applies the
-requested term ordering, and returns a frozen `TrotterPlan` whose
-`kernel()` factory captures the flattened coefficient/word arrays.
+`Trotter` extracts and validates the Pauli terms on the host once at
+construction (dropping identity terms into `identity_coefficient`) and
+applies the requested term ordering; the evolution parameters `time`,
+`steps`, and `order` are supplied per kernel request, mirroring the other
+primitives (`Walk.kernel(power=...)`, `QSVT.kernel(sequence)`).
 
 ### Product-formula orders
 
@@ -68,7 +71,7 @@ def my_kernel(coeffs: list[float], words: list[cudaq.pauli_word],
     trotter.apply_trotter(coeffs, words, t, steps, order, q)
 ```
 
-`plan.coefficients` / `plan.words` supply the flattened arrays.
+`evolution.coefficients` / `evolution.words` supply the flattened arrays.
 
 ### Identity terms and the global phase
 
@@ -76,7 +79,8 @@ For `H = c I + H'`, the circuit applies the product formula for `H'` only;
 `exp(-i c t)` cannot be realized as a circuit on the evolved register. The
 phase is an unobservable global phase for a single unconditioned evolution
 but a real relative phase for controlled or interference-based algorithms —
-`plan.identity_coefficient` reports it so callers can account for it.
+`identity_coefficient` is reported on the `Trotter` object so callers
+can account for it.
 
 ## Simulation-only helper
 
@@ -87,8 +91,8 @@ hardware targets). The Trotter-specific helper is `evolve`:
 ```python
 from cudaq_algorithms import sim_utils
 
-evolved = sim_utils.evolve(plan, ket)   # approximates exp(-i H t)|ket>,
-                                        # identity phase included
+evolved = sim_utils.evolve(evolution, ket, time=0.8, steps=4, order=2)
+# approximates exp(-i H t)|ket>, identity phase included
 ```
 
 Unlike the circuit primitive, `evolve` reintroduces the identity phase by

--- a/examples/hamiltonian_simulation/trotter_chemistry.py
+++ b/examples/hamiltonian_simulation/trotter_chemistry.py
@@ -11,8 +11,8 @@
 The Hamiltonian is hard-coded as Pauli terms to keep the example focused
 on the algorithm primitives. Two ways to run the same evolution are shown:
 
-1. ``sim_utils.evolve(plan, ket)`` — one call, identity phase included
-   (simulation helper).
+1. ``sim_utils.evolve(evolution, ket, time, ...)`` — one call, identity
+   phase included (simulation helper).
 2. A user kernel composing ``trotter.apply_trotter`` with state
    preparation — the hardware-shaped composition path.
 

--- a/examples/hamiltonian_simulation/trotter_chemistry.py
+++ b/examples/hamiltonian_simulation/trotter_chemistry.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Suzuki-Trotter simulation of a chemistry-style Hamiltonian.
+
+The Hamiltonian is hard-coded as Pauli terms to keep the example focused
+on the algorithm primitives. Two ways to run the same evolution are shown:
+
+1. ``sim_utils.evolve(plan, ket)`` — one call, identity phase included
+   (simulation helper).
+2. A user kernel composing ``trotter.apply_trotter`` with state
+   preparation — the hardware-shaped composition path.
+
+Run with:  python3 trotter_chemistry.py
+"""
+
+import os
+
+import numpy as np
+
+
+import cudaq
+
+from cudaq_algorithms import sim_utils, trotter
+
+# A four-qubit molecular-style Pauli Hamiltonian. In a production chemistry
+# workflow these terms would come from a fermion-to-qubit mapping.
+HAMILTONIAN = {
+    "IIII": -0.81054798,
+    "ZIII": 0.17218393,
+    "IZII": -0.22575349,
+    "IIZI": 0.17218393,
+    "IIIZ": -0.22575349,
+    "ZZII": 0.12091263,
+    "ZIZI": 0.16892754,
+    "ZIIZ": 0.16614543,
+    "YYYY": 0.04523280,
+    "XXYY": 0.04523280,
+    "YYXX": 0.04523280,
+    "XXXX": 0.04523280,
+    "IZZI": 0.16614543,
+    "IZIZ": 0.17464343,
+    "IIZZ": 0.12091263,
+}
+TIME = 0.6
+STEPS = 4
+ORDER = 2
+
+
+@cudaq.kernel
+def prepare_state(q: cudaq.qview):
+    """Small product-state superposition so non-commuting terms have
+    visible effect in the output amplitudes."""
+    ry(0.31, q[0])
+    rx(-0.27, q[1])
+    ry(0.19, q[2])
+    rx(0.23, q[3])
+
+
+def pauli_matrix(word):
+    dim = 2**len(word)
+    matrix = np.zeros((dim, dim), dtype=np.complex128)
+    for basis in range(dim):
+        target_col = np.zeros(dim, dtype=np.complex128)
+        target_col[basis] = 1.0
+        result = np.zeros(dim, dtype=np.complex128)
+        for b, amplitude in enumerate(target_col):
+            if amplitude == 0.0:
+                continue
+            target, phase = b, 1.0 + 0.0j
+            for qubit, op in enumerate(word):
+                bit = (b >> qubit) & 1
+                if op == "X":
+                    target ^= 1 << qubit
+                elif op == "Y":
+                    target ^= 1 << qubit
+                    phase *= -1.0j if bit else 1.0j
+                elif op == "Z":
+                    phase *= -1.0 if bit else 1.0
+            result[target] += phase * amplitude
+        matrix[:, basis] = result
+    return matrix
+
+
+def exact_evolve(plan, ket):
+    matrix = plan.identity_coefficient * np.eye(ket.size, dtype=np.complex128)
+    for coefficient, word in zip(plan.coefficients, plan.words):
+        matrix += coefficient * pauli_matrix(str(word))
+    eigenvalues, eigenvectors = np.linalg.eigh(matrix)
+    return eigenvectors @ (np.exp(-1.0j * plan.time * eigenvalues) *
+                           (eigenvectors.conj().T @ ket))
+
+
+def main():
+    cudaq.set_target(os.environ.get("CUDAQ_DEFAULT_SIMULATOR", "qpp-cpu"))
+
+    plan = trotter.make_trotter_plan(
+        HAMILTONIAN,
+        time=TIME,
+        steps=STEPS,
+        order=ORDER,
+        ordering=trotter.TrotterOrdering.COEFFICIENT_MAGNITUDE_DESCENDING)
+    resources = plan.resources()
+
+    @cudaq.kernel
+    def prepare_only():
+        q = cudaq.qvector(4)
+        prepare_state(q)
+
+    ket0 = np.asarray(cudaq.get_state(prepare_only), dtype=np.complex128)
+
+    # Path 1: the one-call simulation helper (identity phase included).
+    evolved = sim_utils.evolve(plan, ket0)
+    exact = exact_evolve(plan, ket0)
+    direct_error = float(np.linalg.norm(evolved - exact))
+
+    # Path 2: the escape hatch — compose apply_trotter in a user kernel.
+    coefficients, words = plan.coefficients, [str(w) for w in plan.words]
+
+    @cudaq.kernel
+    def evolve_kernel(coeffs: list[float], paulis: list[cudaq.pauli_word],
+                      t: float, n_steps: int, formula_order: int):
+        q = cudaq.qvector(4)
+        prepare_state(q)
+        trotter.apply_trotter(coeffs, paulis, t, n_steps, formula_order, q)
+
+    kernel_state = np.asarray(cudaq.get_state(evolve_kernel, coefficients,
+                                              words, TIME, STEPS, ORDER),
+                              dtype=np.complex128)
+    # The kernel path omits the identity phase; reintroduce it for comparison.
+    kernel_state = kernel_state * np.exp(
+        -1.0j * plan.identity_coefficient * TIME)
+    paths_agree = float(np.linalg.norm(kernel_state - evolved))
+
+    print("Suzuki-Trotter chemistry-style example")
+    print("=" * 62)
+    print(f"num_qubits:           {plan.num_qubits}")
+    print(f"num_terms:            {resources.num_terms}")
+    print(f"identity_coefficient: {plan.identity_coefficient:+.8f}")
+    print(f"order:                {plan.order}")
+    print(f"steps:                {plan.steps}")
+    print(f"pauli_rotations:      {resources.pauli_rotations}")
+    print(f"estimated_cx_count:   {resources.estimated_cx_count}")
+    print(f"l2_error_vs_exact:    {direct_error:.6e}   (identity phase "
+          f"included -> no phase alignment needed)")
+    print(f"kernel_vs_evolve:     {paths_agree:.6e}")
+    print("first four amplitudes:")
+    for idx, amplitude in enumerate(evolved[:4]):
+        print(f"  |{idx:04b}> {amplitude.real:+.8f}{amplitude.imag:+.8f}j")
+
+    if direct_error > 5e-3 or paths_agree > 1e-12:
+        raise SystemExit("Trotter example exceeded tolerance")
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/hamiltonian_simulation/trotter_chemistry.py
+++ b/examples/hamiltonian_simulation/trotter_chemistry.py
@@ -87,25 +87,23 @@ def pauli_matrix(word):
     return matrix
 
 
-def exact_evolve(plan, ket):
-    matrix = plan.identity_coefficient * np.eye(ket.size, dtype=np.complex128)
-    for coefficient, word in zip(plan.coefficients, plan.words):
+def exact_evolve(evolution, time, ket):
+    matrix = evolution.identity_coefficient * np.eye(ket.size,
+                                                     dtype=np.complex128)
+    for coefficient, word in zip(evolution.coefficients, evolution.words):
         matrix += coefficient * pauli_matrix(str(word))
     eigenvalues, eigenvectors = np.linalg.eigh(matrix)
-    return eigenvectors @ (np.exp(-1.0j * plan.time * eigenvalues) *
+    return eigenvectors @ (np.exp(-1.0j * time * eigenvalues) *
                            (eigenvectors.conj().T @ ket))
 
 
 def main():
     cudaq.set_target(os.environ.get("CUDAQ_DEFAULT_SIMULATOR", "qpp-cpu"))
 
-    plan = trotter.make_trotter_plan(
+    evolution = trotter.Trotter(
         HAMILTONIAN,
-        time=TIME,
-        steps=STEPS,
-        order=ORDER,
         ordering=trotter.TrotterOrdering.COEFFICIENT_MAGNITUDE_DESCENDING)
-    resources = plan.resources()
+    resources = evolution.resources(steps=STEPS, order=ORDER)
 
     @cudaq.kernel
     def prepare_only():
@@ -115,12 +113,14 @@ def main():
     ket0 = np.asarray(cudaq.get_state(prepare_only), dtype=np.complex128)
 
     # Path 1: the one-call simulation helper (identity phase included).
-    evolved = sim_utils.evolve(plan, ket0)
-    exact = exact_evolve(plan, ket0)
+    evolved = sim_utils.evolve(evolution, ket0, time=TIME, steps=STEPS,
+                               order=ORDER)
+    exact = exact_evolve(evolution, TIME, ket0)
     direct_error = float(np.linalg.norm(evolved - exact))
 
     # Path 2: the escape hatch — compose apply_trotter in a user kernel.
-    coefficients, words = plan.coefficients, [str(w) for w in plan.words]
+    coefficients = evolution.coefficients
+    words = [str(w) for w in evolution.words]
 
     @cudaq.kernel
     def evolve_kernel(coeffs: list[float], paulis: list[cudaq.pauli_word],
@@ -134,16 +134,16 @@ def main():
                               dtype=np.complex128)
     # The kernel path omits the identity phase; reintroduce it for comparison.
     kernel_state = kernel_state * np.exp(
-        -1.0j * plan.identity_coefficient * TIME)
+        -1.0j * evolution.identity_coefficient * TIME)
     paths_agree = float(np.linalg.norm(kernel_state - evolved))
 
     print("Suzuki-Trotter chemistry-style example")
     print("=" * 62)
-    print(f"num_qubits:           {plan.num_qubits}")
+    print(f"num_qubits:           {evolution.num_qubits}")
     print(f"num_terms:            {resources.num_terms}")
-    print(f"identity_coefficient: {plan.identity_coefficient:+.8f}")
-    print(f"order:                {plan.order}")
-    print(f"steps:                {plan.steps}")
+    print(f"identity_coefficient: {evolution.identity_coefficient:+.8f}")
+    print(f"order:                {resources.order}")
+    print(f"steps:                {resources.steps}")
     print(f"pauli_rotations:      {resources.pauli_rotations}")
     print(f"estimated_cx_count:   {resources.estimated_cx_count}")
     print(f"l2_error_vs_exact:    {direct_error:.6e}   (identity phase "

--- a/examples/hamiltonian_simulation/trotter_chemistry.py
+++ b/examples/hamiltonian_simulation/trotter_chemistry.py
@@ -23,7 +23,6 @@ import os
 
 import numpy as np
 
-
 import cudaq
 
 from cudaq_algorithms import sim_utils, trotter
@@ -113,7 +112,10 @@ def main():
     ket0 = np.asarray(cudaq.get_state(prepare_only), dtype=np.complex128)
 
     # Path 1: the one-call simulation helper (identity phase included).
-    evolved = sim_utils.evolve(evolution, ket0, time=TIME, steps=STEPS,
+    evolved = sim_utils.evolve(evolution,
+                               ket0,
+                               time=TIME,
+                               steps=STEPS,
                                order=ORDER)
     exact = exact_evolve(evolution, TIME, ket0)
     direct_error = float(np.linalg.norm(evolved - exact))

--- a/python/cudaq_algorithms/__init__.py
+++ b/python/cudaq_algorithms/__init__.py
@@ -45,9 +45,7 @@ from .pauli_lcu import PauliLCU, select_observable
 from .qsvt import (ADJOINT, FORWARD, PhaseSequence, QSVT,
                    recover_real_time_evolution)
 from .qubitization import Walk, reflection_observable
-from .trotter import (Trotter, TrotterOrdering, TrotterResourceEstimate,
-                      apply_trotter, estimate_trotter_resources,
-                      make_trotter_terms)
+from .trotter import Trotter, TrotterOrdering, TrotterResourceEstimate
 
 # The composable device kernels keep their module namespaces
 # (cudaq_algorithms.pauli_lcu.prepare, .select, .apply_phase_sequence, ...;

--- a/python/cudaq_algorithms/__init__.py
+++ b/python/cudaq_algorithms/__init__.py
@@ -13,8 +13,8 @@ The package has two kinds of components:
   fermion and state-preparation utilities. These require the native
   extension built against CUDA-Q.
 - Pure-Python modules (:mod:`.pauli_lcu`, :mod:`.qubitization`, :mod:`.qsvt`,
-  :mod:`.sim_utils`): quantum primitives implemented as CUDA-Q Python
-  kernels. These only require the ``cudaq`` Python package.
+  :mod:`.trotter`, :mod:`.sim_utils`): quantum primitives implemented as
+  CUDA-Q Python kernels. These only require the ``cudaq`` Python package.
 
 The native extension is optional: if it is not present (for example in a
 source checkout without a build), the pure-Python APIs below still import
@@ -38,13 +38,16 @@ except ModuleNotFoundError as exc:
 
 # Pure-Python quantum primitives (no compiled-extension dependency).
 from . import (block_encoding, common_kernels, pauli_lcu, qsvt, qubitization,
-               sim_utils)
+               sim_utils, trotter)
 from .block_encoding import BlockEncoding
 from .common_kernels import state_from
 from .pauli_lcu import PauliLCU, select_observable
 from .qsvt import (ADJOINT, FORWARD, PhaseSequence, QSVT,
                    recover_real_time_evolution)
 from .qubitization import Walk, reflection_observable
+from .trotter import (TrotterOrdering, TrotterPlan, TrotterResourceEstimate,
+                      apply_trotter, estimate_trotter_resources,
+                      make_trotter_plan, make_trotter_terms)
 
 # The composable device kernels keep their module namespaces
 # (cudaq_algorithms.pauli_lcu.prepare, .select, .apply_phase_sequence, ...;

--- a/python/cudaq_algorithms/__init__.py
+++ b/python/cudaq_algorithms/__init__.py
@@ -45,9 +45,9 @@ from .pauli_lcu import PauliLCU, select_observable
 from .qsvt import (ADJOINT, FORWARD, PhaseSequence, QSVT,
                    recover_real_time_evolution)
 from .qubitization import Walk, reflection_observable
-from .trotter import (TrotterOrdering, TrotterPlan, TrotterResourceEstimate,
+from .trotter import (Trotter, TrotterOrdering, TrotterResourceEstimate,
                       apply_trotter, estimate_trotter_resources,
-                      make_trotter_plan, make_trotter_terms)
+                      make_trotter_terms)
 
 # The composable device kernels keep their module namespaces
 # (cudaq_algorithms.pauli_lcu.prepare, .select, .apply_phase_sequence, ...;

--- a/python/cudaq_algorithms/common_kernels.py
+++ b/python/cudaq_algorithms/common_kernels.py
@@ -39,6 +39,19 @@ def state_from(ket) -> cudaq.State:
     return cudaq.State.from_data(np.asarray(ket, dtype=cudaq.complex()))
 
 
+def _real_coefficient(value) -> float:
+    """Coerce a Hamiltonian coefficient to float, rejecting complex values.
+
+    One validation for every input form across the package (PauliLCU and
+    Trotter both route through it), so a complex coefficient raises the
+    same ValueError everywhere.
+    """
+    coefficient = complex(value)
+    if abs(coefficient.imag) > 1e-10:
+        raise ValueError("complex Hamiltonian coefficients are not supported")
+    return float(coefficient.real)
+
+
 def _validate_control_state(control_state: int) -> int:
     """Require control_state to be exactly 0 or 1 (no silent coercion)."""
     if control_state not in (0, 1):

--- a/python/cudaq_algorithms/pauli_lcu.py
+++ b/python/cudaq_algorithms/pauli_lcu.py
@@ -36,8 +36,8 @@ from typing import TYPE_CHECKING, TypeAlias, Union
 
 import cudaq
 
-from .common_kernels import (_bit_projector, _validate_power,
-                             controlled_reflect_about_zero,
+from .common_kernels import (_bit_projector, _real_coefficient,
+                             _validate_power, controlled_reflect_about_zero,
                              controlled_signal_phase, reflect_about_zero,
                              signal_phase, state_from)
 
@@ -349,19 +349,6 @@ def apply_controlled_phase_sequence(
 # ============================================================================
 
 
-def _real_coefficient(value) -> float:
-    """Coerce a Hamiltonian coefficient to float, rejecting complex values.
-
-    One validation for every input form, so a complex coefficient raises
-    the same ValueError whether it arrives in a mapping, a pair list, or a
-    ``cudaq.SpinOperator``.
-    """
-    coefficient = complex(value)
-    if abs(coefficient.imag) > 1e-10:
-        raise ValueError("complex Hamiltonian coefficients are not supported")
-    return float(coefficient.real)
-
-
 def _terms_from_input(
         hamiltonian: HamiltonianLike,
         num_qubits: int | None) -> tuple[list[tuple[float, str]], int]:
@@ -378,7 +365,8 @@ def _terms_from_input(
             hamiltonian.qubit_count)
         pairs = [(_real_coefficient(term.evaluate_coefficient()),
                   str(term.get_pauli_word(width))) for term in hamiltonian]
-    elif isinstance(hamiltonian, Iterable):
+    elif isinstance(hamiltonian, Iterable) and not isinstance(
+            hamiltonian, (str, bytes, bytearray, memoryview)):
         pairs = [(_real_coefficient(c), str(w)) for c, w in hamiltonian]
     else:
         raise TypeError(

--- a/python/cudaq_algorithms/pauli_lcu.py
+++ b/python/cudaq_algorithms/pauli_lcu.py
@@ -50,8 +50,8 @@ if TYPE_CHECKING:
 # ``{"XZI...": coefficient}`` mapping, or an iterable of
 # ``(coefficient, word)`` pairs.
 HamiltonianLike: TypeAlias = Union[cudaq.SpinOperator, cudaq.SpinOperatorTerm,
-                                   Mapping[str, float], Iterable[tuple[float,
-                                                                       str]]]
+                                   Mapping[str, complex],
+                                   Iterable[tuple[complex, str]]]
 
 # The flattened arrays that cross the kernel boundary, in the order the
 # module-level kernels take them:

--- a/python/cudaq_algorithms/sim_utils.py
+++ b/python/cudaq_algorithms/sim_utils.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING
 import cudaq
 
 # Re-exported: precision-aware initial-state construction.
-from .pauli_lcu import state_from
+from .common_kernels import state_from
 from .trotter import SECOND_ORDER_TROTTER, Trotter
 
 if TYPE_CHECKING:
@@ -91,31 +91,24 @@ def evolve(evolution: Trotter,
     ``exp(-i * identity_coefficient * time)`` (on by default), so the
     result approximates the full ``exp(-i H t)|ket>``.
 
-    ``Trotter.kernel`` prepares |0...0> and evolves; to evolve an arbitrary
-    ``ket``, the input state is loaded through ``cudaq.get_state``'s
-    initial-state support via a state-taking wrapper kernel.
+    Delegates to ``Trotter.state_kernel`` — the same validation (finite
+    time, positive integral steps, order in {1, 2, 4}) and marshaling as
+    ``Trotter.kernel``, raising ``ValueError`` for invalid parameters
+    instead of silently returning an unevolved state.
     """
     import numpy as np
 
-    coefficients = [float(c) for c in evolution.coefficients]
-    words = [cudaq.pauli_word(str(w)) for w in evolution.words]
-    time = float(time)
-    steps = int(steps)
-    order = int(order)
+    ket_array = np.asarray(ket, dtype=np.complex128)
+    if ket_array.size != (1 << evolution.num_qubits):
+        raise ValueError(
+            f"ket has dimension {ket_array.size}; the evolution acts on "
+            f"{evolution.num_qubits} qubit(s) "
+            f"(dimension {1 << evolution.num_qubits})")
 
-    if words:
-        from .trotter import apply_trotter
-
-        @cudaq.kernel
-        def evolve_state(state: cudaq.State):
-            qubits = cudaq.qvector(state)
-            apply_trotter(coefficients, words, time, steps, order, qubits)
-
-        state = np.asarray(cudaq.get_state(evolve_state, state_from(ket)),
-                           dtype=np.complex128)
-    else:
-        state = np.asarray(ket, dtype=np.complex128).copy()
-
+    kernel = evolution.state_kernel(time, steps, order)
+    state = np.asarray(cudaq.get_state(kernel, state_from(ket_array)),
+                       dtype=np.complex128)
     if include_identity_phase and evolution.identity_coefficient != 0.0:
-        state = state * np.exp(-1.0j * evolution.identity_coefficient * time)
+        state = state * np.exp(
+            -1.0j * evolution.identity_coefficient * float(time))
     return state

--- a/python/cudaq_algorithms/sim_utils.py
+++ b/python/cudaq_algorithms/sim_utils.py
@@ -99,11 +99,11 @@ def evolve(evolution: Trotter,
     import numpy as np
 
     ket_array = np.asarray(ket, dtype=np.complex128)
-    if ket_array.size != (1 << evolution.num_qubits):
+    if ket_array.ndim != 1 or ket_array.size != (1 << evolution.num_qubits):
         raise ValueError(
-            f"ket has dimension {ket_array.size}; the evolution acts on "
-            f"{evolution.num_qubits} qubit(s) "
-            f"(dimension {1 << evolution.num_qubits})")
+            f"ket must be a 1-D statevector of dimension "
+            f"{1 << evolution.num_qubits} for {evolution.num_qubits} "
+            f"qubit(s); got shape {ket_array.shape}")
 
     kernel = evolution.state_kernel(time, steps, order)
     state = np.asarray(cudaq.get_state(kernel, state_from(ket_array)),

--- a/python/cudaq_algorithms/sim_utils.py
+++ b/python/cudaq_algorithms/sim_utils.py
@@ -117,6 +117,5 @@ def evolve(evolution: Trotter,
         state = np.asarray(ket, dtype=np.complex128).copy()
 
     if include_identity_phase and evolution.identity_coefficient != 0.0:
-        state = state * np.exp(
-            -1.0j * evolution.identity_coefficient * time)
+        state = state * np.exp(-1.0j * evolution.identity_coefficient * time)
     return state

--- a/python/cudaq_algorithms/sim_utils.py
+++ b/python/cudaq_algorithms/sim_utils.py
@@ -24,6 +24,7 @@ import cudaq
 
 # Re-exported: precision-aware initial-state construction.
 from .pauli_lcu import state_from
+from .trotter import TrotterPlan
 
 if TYPE_CHECKING:
     import numpy as np
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
     from .pauli_lcu import PauliLCU
     from .qsvt import PhaseSequence, QSVT
 
-__all__ = ["state_from", "good_subspace", "action", "transform"]
+__all__ = ["state_from", "good_subspace", "action", "transform", "evolve"]
 
 
 def good_subspace(encoding: PauliLCU,
@@ -76,3 +77,40 @@ def transform(transformer: QSVT,
     state = cudaq.get_state(transformer.kernel(sequence, convention),
                             state_from(ket))
     return good_subspace(transformer.encoding, state)
+
+
+def evolve(plan: TrotterPlan, ket, include_identity_phase: bool = True):
+    """Simulate a Trotter plan on ``ket`` and return the evolved statevector.
+
+    Unlike the circuit primitive, this can reintroduce the identity phase
+    ``exp(-i * identity_coefficient * time)`` (on by default), so the
+    result approximates the full ``exp(-i H t)|ket>``.
+
+    The plan's kernel prepares |0...0> and evolves; to evolve an arbitrary
+    ``ket``, the input state is loaded through ``cudaq.get_state``'s
+    initial-state support via a state-taking wrapper kernel.
+    """
+    import numpy as np
+
+    coefficients = [float(c) for c in plan.coefficients]
+    words = [cudaq.pauli_word(str(w)) for w in plan.words]
+    time = float(plan.time)
+    steps = int(plan.steps)
+    order = int(plan.order)
+
+    if words:
+        from .trotter import apply_trotter
+
+        @cudaq.kernel
+        def evolve_state(state: cudaq.State):
+            qubits = cudaq.qvector(state)
+            apply_trotter(coefficients, words, time, steps, order, qubits)
+
+        state = np.asarray(cudaq.get_state(evolve_state, state_from(ket)),
+                           dtype=np.complex128)
+    else:
+        state = np.asarray(ket, dtype=np.complex128).copy()
+
+    if include_identity_phase and plan.identity_coefficient != 0.0:
+        state = state * np.exp(-1.0j * plan.identity_coefficient * time)
+    return state

--- a/python/cudaq_algorithms/sim_utils.py
+++ b/python/cudaq_algorithms/sim_utils.py
@@ -79,7 +79,9 @@ def transform(transformer: QSVT,
     return good_subspace(transformer.encoding, state)
 
 
-def evolve(plan: TrotterPlan, ket, include_identity_phase: bool = True):
+def evolve(plan: TrotterPlan,
+           ket: ArrayLike,
+           include_identity_phase: bool = True) -> NDArray[np.complex128]:
     """Simulate a Trotter plan on ``ket`` and return the evolved statevector.
 
     Unlike the circuit primitive, this can reintroduce the identity phase

--- a/python/cudaq_algorithms/sim_utils.py
+++ b/python/cudaq_algorithms/sim_utils.py
@@ -24,7 +24,7 @@ import cudaq
 
 # Re-exported: precision-aware initial-state construction.
 from .pauli_lcu import state_from
-from .trotter import TrotterPlan
+from .trotter import SECOND_ORDER_TROTTER, Trotter
 
 if TYPE_CHECKING:
     import numpy as np
@@ -79,26 +79,29 @@ def transform(transformer: QSVT,
     return good_subspace(transformer.encoding, state)
 
 
-def evolve(plan: TrotterPlan,
+def evolve(evolution: Trotter,
            ket: ArrayLike,
+           time: float,
+           steps: int = 1,
+           order: int = SECOND_ORDER_TROTTER,
            include_identity_phase: bool = True) -> NDArray[np.complex128]:
-    """Simulate a Trotter plan on ``ket`` and return the evolved statevector.
+    """Simulate a Trotter evolution on ``ket``; return the evolved statevector.
 
     Unlike the circuit primitive, this can reintroduce the identity phase
     ``exp(-i * identity_coefficient * time)`` (on by default), so the
     result approximates the full ``exp(-i H t)|ket>``.
 
-    The plan's kernel prepares |0...0> and evolves; to evolve an arbitrary
+    ``Trotter.kernel`` prepares |0...0> and evolves; to evolve an arbitrary
     ``ket``, the input state is loaded through ``cudaq.get_state``'s
     initial-state support via a state-taking wrapper kernel.
     """
     import numpy as np
 
-    coefficients = [float(c) for c in plan.coefficients]
-    words = [cudaq.pauli_word(str(w)) for w in plan.words]
-    time = float(plan.time)
-    steps = int(plan.steps)
-    order = int(plan.order)
+    coefficients = [float(c) for c in evolution.coefficients]
+    words = [cudaq.pauli_word(str(w)) for w in evolution.words]
+    time = float(time)
+    steps = int(steps)
+    order = int(order)
 
     if words:
         from .trotter import apply_trotter
@@ -113,6 +116,7 @@ def evolve(plan: TrotterPlan,
     else:
         state = np.asarray(ket, dtype=np.complex128).copy()
 
-    if include_identity_phase and plan.identity_coefficient != 0.0:
-        state = state * np.exp(-1.0j * plan.identity_coefficient * time)
+    if include_identity_phase and evolution.identity_coefficient != 0.0:
+        state = state * np.exp(
+            -1.0j * evolution.identity_coefficient * time)
     return state

--- a/python/cudaq_algorithms/trotter.py
+++ b/python/cudaq_algorithms/trotter.py
@@ -362,8 +362,11 @@ class TrotterPlan:
         """Number of retained non-identity terms."""
         return len(self.coefficients)
 
-    def kernel(self):
+    def kernel(self) -> Any:
         """Return a ``@cudaq.kernel()`` applying this plan's evolution.
+
+        (``Any`` because CUDA-Q exposes no stable public Python type for
+        compiled kernel objects.)
 
         The kernel allocates ``num_qubits`` qubits in |0...0> and applies
         the product formula. The identity phase is not included (it cannot

--- a/python/cudaq_algorithms/trotter.py
+++ b/python/cudaq_algorithms/trotter.py
@@ -58,7 +58,6 @@ FOREST_RUTH_W0: float = -1.7024143839193153
 #: ``(coefficient, word)`` pairs.
 HamiltonianLike = Union[Mapping[str, complex], Iterable[tuple], Any]
 
-
 # ============================================================================
 # Device kernel (module level, composable from user kernels)
 # ============================================================================
@@ -121,7 +120,6 @@ def apply_trotter(coefficients: list[float], words: list[cudaq.pauli_word],
 
 # state_from lives with the block-encoding module; re-exported here since
 # Trotter workflows need the same precision-aware state construction.
-
 
 # ============================================================================
 # Host-side term extraction
@@ -213,8 +211,8 @@ def _word_pairs_from_input(
 
 
 def make_trotter_terms(
-        hamiltonian: HamiltonianLike,
-        coefficient_tolerance: float = 1e-12
+    hamiltonian: HamiltonianLike,
+    coefficient_tolerance: float = 1e-12
 ) -> tuple[list[float], list[str], float, int]:
     """Return flattened terms for the Suzuki-Trotter circuit primitive.
 
@@ -295,9 +293,8 @@ def _coerce_ordering(ordering: TrotterOrdering | str) -> TrotterOrdering:
         raise ValueError(f"unsupported Trotter ordering: {ordering}") from exc
 
 
-def _ordered_terms(
-        coefficients: list[float], words: list[str],
-        ordering: TrotterOrdering) -> tuple[list[float], list[str]]:
+def _ordered_terms(coefficients: list[float], words: list[str],
+                   ordering: TrotterOrdering) -> tuple[list[float], list[str]]:
     """Apply the ordering strategy to parallel coefficient/word lists."""
     coefficients = list(coefficients)
     words = list(words)
@@ -355,8 +352,8 @@ class Trotter:
 
     def __init__(self,
                  hamiltonian: HamiltonianLike,
-                 ordering: TrotterOrdering | str = (
-                     TrotterOrdering.PRESERVE_INPUT),
+                 ordering: TrotterOrdering
+                 | str = (TrotterOrdering.PRESERVE_INPUT),
                  *,
                  coefficient_tolerance: float = 1e-12) -> None:
         ordering = _coerce_ordering(ordering)
@@ -441,13 +438,16 @@ class Trotter:
 
         return evolve
 
-    def resources(self,
-                  steps: int = 1,
-                  order: int = SECOND_ORDER_TROTTER) -> TrotterResourceEstimate:
+    def resources(
+            self,
+            steps: int = 1,
+            order: int = SECOND_ORDER_TROTTER) -> TrotterResourceEstimate:
         """Resource estimate for ``steps`` steps of the ``order`` formula."""
-        return estimate_trotter_resources(
-            self._coefficients, self._words, steps=steps, order=order,
-            identity_coefficient=self._identity)
+        return estimate_trotter_resources(self._coefficients,
+                                          self._words,
+                                          steps=steps,
+                                          order=order,
+                                          identity_coefficient=self._identity)
 
 
 def estimate_trotter_resources(

--- a/python/cudaq_algorithms/trotter.py
+++ b/python/cudaq_algorithms/trotter.py
@@ -409,20 +409,44 @@ class Trotter:
     def kernel(self,
                time: float,
                steps: int = 1,
-               order: int = SECOND_ORDER_TROTTER) -> Any:
+               order: int = SECOND_ORDER_TROTTER,
+               state_prep: Any | None = None) -> Any:
         """Return a ``@cudaq.kernel()`` applying the product formula.
 
         (``Any`` because CUDA-Q exposes no stable public Python type for
         compiled kernel objects.)
 
-        The kernel allocates ``num_qubits`` qubits in |0...0> and applies
-        the ``order``-order formula for ``time`` over ``steps`` steps. The
+        The kernel allocates ``num_qubits`` qubits in |0...0>, optionally
+        runs ``state_prep`` (a kernel with signature
+        ``(qubits: cudaq.qview)``) on them, and applies the
+        ``order``-order formula for ``time`` over ``steps`` steps — with
+        or without ``state_prep`` the result takes no arguments and is
+        directly sampleable. ``state_prep`` must act only on the register
+        it is handed (width ``num_qubits``, arriving in |0...0>). The
         identity phase is not included (it cannot be, in a circuit); track
         ``identity_coefficient`` when it matters.
         """
         time, steps, order, coefficients, words = self._prepared_args(
             time, steps, order)
         num_qubits = self._num_qubits
+
+        if state_prep is not None:
+            if not words:
+
+                @cudaq.kernel
+                def prep_identity():
+                    qubits = cudaq.qvector(num_qubits)
+                    state_prep(qubits)
+
+                return prep_identity
+
+            @cudaq.kernel
+            def prep_evolve():
+                qubits = cudaq.qvector(num_qubits)
+                state_prep(qubits)
+                apply_trotter(coefficients, words, time, steps, order, qubits)
+
+            return prep_evolve
 
         if not words:
             # Identity-only Hamiltonian: the circuit is the identity.

--- a/python/cudaq_algorithms/trotter.py
+++ b/python/cudaq_algorithms/trotter.py
@@ -11,9 +11,10 @@ Product-formula time evolution for Hamiltonians expressed as sums of Pauli
 strings: term extraction, host-side planning and ordering, resource
 estimation, and the circuit primitive itself.
 
-The typical workflow builds a validated plan on the host and either uses
-its kernel factory or composes the ``apply_trotter`` primitive inside a
-custom kernel::
+The typical workflow constructs a ``Trotter`` object (term extraction,
+validation, and ordering happen once) and either uses its kernel
+factories or composes the ``apply_trotter`` primitive inside a custom
+kernel::
 
     from cudaq_algorithms import trotter
 
@@ -40,23 +41,27 @@ from typing import Any, Union
 
 import cudaq
 
-from .pauli_lcu import state_from
+from .pauli_lcu import _real_coefficient
 
 #: Supported product-formula orders.
 FIRST_ORDER_TROTTER: int = 1
 SECOND_ORDER_TROTTER: int = 2
 FOURTH_ORDER_TROTTER: int = 4
 
-#: Forest-Ruth fourth-order splitting weights: the order-4 step is the
-#: symmetric second-order step applied with time fractions w1, w0, w1,
-#: where w1 = 1/(2 - 2**(1/3)) and w0 = 1 - 2*w1.
-FOREST_RUTH_W1: float = 1.3512071919596578
-FOREST_RUTH_W0: float = -1.7024143839193153
+# Forest-Ruth fourth-order splitting weights: the order-4 step is the
+# symmetric second-order step applied with time fractions w1, w0, w1,
+# where w1 = 1/(2 - 2**(1/3)) and w0 = 1 - 2*w1 (the invariant binding
+# them). Private: they are internals of this particular order-4 scheme,
+# precomputed as module constants because kernels cannot compute cube
+# roots (host-only math).
+_FOREST_RUTH_W1: float = 1.3512071919596578
+_FOREST_RUTH_W0: float = -1.7024143839193153
 
 #: Accepted Hamiltonian input forms: a ``cudaq.SpinOperator`` (or a single
-#: spin term), a ``{"XZI...": coefficient}`` mapping, or an iterable of
-#: ``(coefficient, word)`` pairs.
-HamiltonianLike = Union[Mapping[str, complex], Iterable[tuple], Any]
+#: ``cudaq.SpinOperatorTerm`` product), a ``{"XZI...": coefficient}``
+#: mapping, or an iterable of ``(coefficient, word)`` pairs.
+HamiltonianLike = Union[cudaq.SpinOperator, cudaq.SpinOperatorTerm,
+                        Mapping[str, complex], Iterable[tuple]]
 
 # ============================================================================
 # Device kernel (module level, composable from user kernels)
@@ -90,25 +95,25 @@ def apply_trotter(coefficients: list[float], words: list[cudaq.pauli_word],
                 # Forest-Ruth: symmetric second-order steps with time
                 # fractions w1, w0, w1.
                 for i in range(n):
-                    exp_pauli(-0.5 * FOREST_RUTH_W1 * dt * coefficients[i],
+                    exp_pauli(-0.5 * _FOREST_RUTH_W1 * dt * coefficients[i],
                               qubits, words[i])
                 for j in range(n):
                     i = n - 1 - j
-                    exp_pauli(-0.5 * FOREST_RUTH_W1 * dt * coefficients[i],
+                    exp_pauli(-0.5 * _FOREST_RUTH_W1 * dt * coefficients[i],
                               qubits, words[i])
                 for i in range(n):
-                    exp_pauli(-0.5 * FOREST_RUTH_W0 * dt * coefficients[i],
+                    exp_pauli(-0.5 * _FOREST_RUTH_W0 * dt * coefficients[i],
                               qubits, words[i])
                 for j in range(n):
                     i = n - 1 - j
-                    exp_pauli(-0.5 * FOREST_RUTH_W0 * dt * coefficients[i],
+                    exp_pauli(-0.5 * _FOREST_RUTH_W0 * dt * coefficients[i],
                               qubits, words[i])
                 for i in range(n):
-                    exp_pauli(-0.5 * FOREST_RUTH_W1 * dt * coefficients[i],
+                    exp_pauli(-0.5 * _FOREST_RUTH_W1 * dt * coefficients[i],
                               qubits, words[i])
                 for j in range(n):
                     i = n - 1 - j
-                    exp_pauli(-0.5 * FOREST_RUTH_W1 * dt * coefficients[i],
+                    exp_pauli(-0.5 * _FOREST_RUTH_W1 * dt * coefficients[i],
                               qubits, words[i])
             else:
                 for i in range(n):
@@ -117,9 +122,6 @@ def apply_trotter(coefficients: list[float], words: list[cudaq.pauli_word],
                     i = n - 1 - j
                     exp_pauli(-0.5 * dt * coefficients[i], qubits, words[i])
 
-
-# state_from lives with the block-encoding module; re-exported here since
-# Trotter workflows need the same precision-aware state construction.
 
 # ============================================================================
 # Host-side term extraction
@@ -131,35 +133,14 @@ def _maybe_call(value: Any) -> Any:
     return value() if callable(value) else value
 
 
-def _is_spin_like(value: Any) -> bool:
-    """Return True for cudaq spin operators and spin terms (duck-typed)."""
-    return (hasattr(value, "evaluate_coefficient")
-            or hasattr(value, "term_count")
-            or hasattr(value, "get_term_count"))
-
-
 def _term_qubit_extent(term: Any) -> int:
     """Number of qubits a spin term touches (max degree + 1)."""
     max_degree = _maybe_call(getattr(term, "max_degree", -1))
     return max_degree + 1 if max_degree >= 0 else 0
 
 
-def _real_coefficient(coefficient: complex, tolerance: float) -> float:
-    """Coerce a coefficient to its real part, rejecting imaginary content.
-
-    Raises ``ValueError`` if the imaginary part exceeds ``tolerance``.
-    """
-    coefficient = complex(coefficient)
-    if abs(coefficient.imag) > tolerance:
-        raise ValueError(
-            "trotter error - only real Hamiltonian coefficients are "
-            "supported.")
-    return float(coefficient.real)
-
-
 def _word_pairs_from_input(
-        hamiltonian: HamiltonianLike,
-        tolerance: float) -> tuple[list[tuple[float, str]], int]:
+        hamiltonian: HamiltonianLike) -> tuple[list[tuple[float, str]], int]:
     """Normalize any accepted Hamiltonian form to ``(coefficient, word)``
     pairs plus the register width.
 
@@ -172,16 +153,19 @@ def _word_pairs_from_input(
     * an iterable of ``(coefficient, word)`` pairs.
 
     Every word is validated to contain only I/X/Y/Z, all words must share
-    one width, and coefficients must be real to within ``tolerance``.
+    one width, and coefficients must be real (validated by the same
+    ``_real_coefficient`` used across the package). Unlike ``PauliLCU``
+    (which requires uniform-width words), mapping and pair inputs here may
+    mix widths only if explicitly padded — the width is the longest word.
 
     Returns ``(pairs, num_qubits)`` where ``pairs`` is a list of
     ``(float, str)`` and ``num_qubits`` is the common word width.
     """
     if isinstance(hamiltonian, Mapping):
-        pairs = [(_real_coefficient(c, tolerance), str(w))
+        pairs = [(_real_coefficient(c), str(w))
                  for w, c in hamiltonian.items()]
         width = max((len(w) for _, w in pairs), default=0)
-    elif _is_spin_like(hamiltonian):
+    elif isinstance(hamiltonian, (cudaq.SpinOperator, cudaq.SpinOperatorTerm)):
         # Wrapping canonicalizes: elementary products and full operators
         # both become a SpinOperator whose iteration yields terms with
         # evaluate_coefficient() and get_pauli_word().
@@ -191,22 +175,26 @@ def _word_pairs_from_input(
         width = 0
         for term in terms:
             width = max(width, _term_qubit_extent(term))
-        pairs = [(_real_coefficient(term.evaluate_coefficient(), tolerance),
+        pairs = [(_real_coefficient(term.evaluate_coefficient()),
                   str(term.get_pauli_word(width))) for term in terms]
-    elif isinstance(hamiltonian, Iterable):
-        pairs = [(_real_coefficient(c, tolerance), str(w))
-                 for c, w in hamiltonian]
+    elif isinstance(hamiltonian,
+                    Iterable) and not isinstance(hamiltonian, (str, bytes)):
+        pairs = [(_real_coefficient(c), str(w)) for c, w in hamiltonian]
         width = max((len(w) for _, w in pairs), default=0)
     else:
         raise TypeError(
             "hamiltonian must be a cudaq spin operator or term, a "
             "{word: coeff} mapping, or an iterable of (coeff, word) pairs")
 
+    if not pairs:
+        raise ValueError("hamiltonian has no terms")
     for _, word in pairs:
         if len(word) != width:
             raise ValueError("all Pauli words must have the same length")
         if any(ch not in "IXYZ" for ch in word):
             raise ValueError(f"unsupported Pauli word: {word!r}")
+    if width == 0:
+        raise ValueError("hamiltonian must act on at least one qubit")
     return pairs, width
 
 
@@ -226,13 +214,16 @@ def make_trotter_terms(
         raise ValueError(
             "trotter error - coefficient tolerance must be non-negative.")
 
-    pairs, num_qubits = _word_pairs_from_input(hamiltonian,
-                                               coefficient_tolerance)
+    pairs, num_qubits = _word_pairs_from_input(hamiltonian)
 
     coefficients: list[float] = []
     words: list[str] = []
     identity_coefficient = 0.0
     for coefficient, word in pairs:
+        if abs(coefficient) < coefficient_tolerance:
+            # Below-threshold (including exactly-zero) terms would emit
+            # zero-angle rotations and inflate resource estimates.
+            continue
         if set(word) <= {"I"}:
             identity_coefficient += coefficient
             continue
@@ -243,7 +234,7 @@ def make_trotter_terms(
 
 
 # ============================================================================
-# Planning, ordering, resources
+# Term ordering, validation, resources
 # ============================================================================
 
 
@@ -268,11 +259,11 @@ def _validate_order(order: int) -> int:
 
 
 def _validate_steps(steps: int) -> int:
-    """Validate and return a positive Trotter step count."""
-    steps = int(steps)
-    if steps < 1:
-        raise ValueError("steps must be greater than zero")
-    return steps
+    """Require a positive integral step count (no silent truncation)."""
+    count = int(steps)
+    if count != steps or count < 1:
+        raise ValueError("steps must be a positive integer")
+    return count
 
 
 def _validate_time(time: float) -> float:
@@ -416,9 +407,9 @@ class Trotter:
         time = _validate_time(time)
         steps = _validate_steps(steps)
         order = _validate_order(order)
-        coefficients = [float(c) for c in self._coefficients]
-        words = [cudaq.pauli_word(str(w)) for w in self._words]
-        num_qubits = int(self._num_qubits)
+        coefficients = list(self._coefficients)
+        words = [cudaq.pauli_word(w) for w in self._words]
+        num_qubits = self._num_qubits
 
         if not words:
             # Identity-only Hamiltonian: the circuit is the identity.
@@ -438,11 +429,45 @@ class Trotter:
 
         return evolve
 
-    def resources(
-            self,
-            steps: int = 1,
-            order: int = SECOND_ORDER_TROTTER) -> TrotterResourceEstimate:
-        """Resource estimate for ``steps`` steps of the ``order`` formula."""
+    def state_kernel(self,
+                     time: float,
+                     steps: int = 1,
+                     order: int = SECOND_ORDER_TROTTER) -> Any:
+        """Return a ``@cudaq.kernel(state)`` evolving an arbitrary state.
+
+        Same validated product formula as :meth:`kernel`, but the register
+        is allocated from a ``cudaq.State`` argument instead of |0...0> —
+        the input-loading path ``sim_utils.evolve`` uses. Validation,
+        marshaling, and the identity-only special case
+        (cuda-quantum#4847) live here so every entry point shares them.
+        """
+        time = _validate_time(time)
+        steps = _validate_steps(steps)
+        order = _validate_order(order)
+        coefficients = list(self._coefficients)
+        words = [cudaq.pauli_word(w) for w in self._words]
+
+        if not words:
+
+            @cudaq.kernel
+            def evolve_identity_state(state: cudaq.State):
+                cudaq.qvector(state)
+
+            return evolve_identity_state
+
+        @cudaq.kernel
+        def evolve_state(state: cudaq.State):
+            qubits = cudaq.qvector(state)
+            apply_trotter(coefficients, words, time, steps, order, qubits)
+
+        return evolve_state
+
+    def resources(self, steps: int, order: int) -> TrotterResourceEstimate:
+        """Resource estimate for ``steps`` steps of the ``order`` formula.
+
+        Both parameters are required so the estimate can never silently
+        describe a different circuit than the kernel you built.
+        """
         return estimate_trotter_resources(self._coefficients,
                                           self._words,
                                           steps=steps,
@@ -453,8 +478,8 @@ class Trotter:
 def estimate_trotter_resources(
         coefficients: list[float],
         words: list[str],
-        steps: int = 1,
-        order: int = SECOND_ORDER_TROTTER,
+        steps: int,
+        order: int,
         identity_coefficient: float = 0.0) -> TrotterResourceEstimate:
     """Return a lightweight resource estimate for a Trotter sequence."""
     coefficients = list(coefficients)
@@ -483,8 +508,6 @@ __all__ = [
     "FIRST_ORDER_TROTTER",
     "SECOND_ORDER_TROTTER",
     "FOURTH_ORDER_TROTTER",
-    "FOREST_RUTH_W1",
-    "FOREST_RUTH_W0",
     "HamiltonianLike",
     "Trotter",
     "TrotterOrdering",
@@ -492,5 +515,4 @@ __all__ = [
     "apply_trotter",
     "estimate_trotter_resources",
     "make_trotter_terms",
-    "state_from",
 ]

--- a/python/cudaq_algorithms/trotter.py
+++ b/python/cudaq_algorithms/trotter.py
@@ -1,0 +1,486 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                        #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Suzuki-Trotter Hamiltonian simulation.
+
+Product-formula time evolution for Hamiltonians expressed as sums of Pauli
+strings: term extraction, host-side planning and ordering, resource
+estimation, and the circuit primitive itself.
+
+The typical workflow builds a validated plan on the host and either uses
+its kernel factory or composes the ``apply_trotter`` primitive inside a
+custom kernel::
+
+    from cudaq.algorithms import trotter
+
+    plan = trotter.make_trotter_plan(hamiltonian, time=0.8, steps=4, order=2)
+    kernel = plan.kernel()          # ready @cudaq.kernel()
+    resources = plan.resources()
+
+Identity terms: for ``H = c I + H'``, ``apply_trotter`` implements the
+product formula for ``H'`` only. The omitted ``exp(-i c t)`` is an
+unobservable global phase for one unconditioned evolution but a real
+relative phase for controlled or interference-based algorithms;
+``identity_coefficient`` is reported on the plan so callers can account
+for it (the simulation helper ``sim_utils.evolve`` reintroduces it
+host-side).
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Union
+
+import cudaq
+
+from .pauli_lcu import state_from
+
+#: Supported product-formula orders.
+FIRST_ORDER_TROTTER: int = 1
+SECOND_ORDER_TROTTER: int = 2
+FOURTH_ORDER_TROTTER: int = 4
+
+#: Forest-Ruth fourth-order splitting weights: the order-4 step is the
+#: symmetric second-order step applied with time fractions w1, w0, w1,
+#: where w1 = 1/(2 - 2**(1/3)) and w0 = 1 - 2*w1.
+FOREST_RUTH_W1: float = 1.3512071919596578
+FOREST_RUTH_W0: float = -1.7024143839193153
+
+#: Accepted Hamiltonian input forms: a ``cudaq.SpinOperator`` (or a single
+#: spin term), a ``{"XZI...": coefficient}`` mapping, or an iterable of
+#: ``(coefficient, word)`` pairs.
+HamiltonianLike = Union[Mapping[str, complex], Iterable[tuple], Any]
+
+
+# ============================================================================
+# Device kernel (module level, composable from user kernels)
+# ============================================================================
+
+
+@cudaq.kernel
+def apply_trotter(coefficients: list[float], words: list[cudaq.pauli_word],
+                  time: float, steps: int, order: int, qubits: cudaq.qview):
+    """Apply Suzuki-Trotter evolution exp(-i H' t) to a live register.
+
+    Identity terms are intentionally omitted (see the module docstring).
+    Invalid runtime inputs are no-ops: zero steps, mismatched
+    coefficient/word lengths, or an unsupported order leave the register
+    unchanged.
+
+    NOTE: the whole body is one positively-guarded if-block rather than
+    early-return guards because ``return`` inside a Python ``@cudaq.kernel``
+    is silently ignored by the compiler (gates after it still execute); see
+    https://github.com/NVIDIA/cuda-quantum/issues/4845.
+    """
+    valid_order = order == 1 or order == 2 or order == 4
+    if steps > 0 and len(coefficients) == len(words) and valid_order:
+        n = len(words)
+        dt = time / steps
+        for _ in range(steps):
+            if order == 1:
+                for i in range(n):
+                    exp_pauli(-dt * coefficients[i], qubits, words[i])
+            elif order == 4:
+                # Forest-Ruth: symmetric second-order steps with time
+                # fractions w1, w0, w1.
+                for i in range(n):
+                    exp_pauli(-0.5 * FOREST_RUTH_W1 * dt * coefficients[i],
+                              qubits, words[i])
+                for j in range(n):
+                    i = n - 1 - j
+                    exp_pauli(-0.5 * FOREST_RUTH_W1 * dt * coefficients[i],
+                              qubits, words[i])
+                for i in range(n):
+                    exp_pauli(-0.5 * FOREST_RUTH_W0 * dt * coefficients[i],
+                              qubits, words[i])
+                for j in range(n):
+                    i = n - 1 - j
+                    exp_pauli(-0.5 * FOREST_RUTH_W0 * dt * coefficients[i],
+                              qubits, words[i])
+                for i in range(n):
+                    exp_pauli(-0.5 * FOREST_RUTH_W1 * dt * coefficients[i],
+                              qubits, words[i])
+                for j in range(n):
+                    i = n - 1 - j
+                    exp_pauli(-0.5 * FOREST_RUTH_W1 * dt * coefficients[i],
+                              qubits, words[i])
+            else:
+                for i in range(n):
+                    exp_pauli(-0.5 * dt * coefficients[i], qubits, words[i])
+                for j in range(n):
+                    i = n - 1 - j
+                    exp_pauli(-0.5 * dt * coefficients[i], qubits, words[i])
+
+
+# state_from lives with the block-encoding module; re-exported here since
+# Trotter workflows need the same precision-aware state construction.
+
+
+# ============================================================================
+# Host-side term extraction
+# ============================================================================
+
+
+def _maybe_call(value: Any) -> Any:
+    """Return ``value()`` if callable (property-vs-method API tolerance)."""
+    return value() if callable(value) else value
+
+
+def _is_spin_like(value: Any) -> bool:
+    """Return True for cudaq spin operators and spin terms (duck-typed)."""
+    return (hasattr(value, "evaluate_coefficient")
+            or hasattr(value, "term_count")
+            or hasattr(value, "get_term_count"))
+
+
+def _term_qubit_extent(term: Any) -> int:
+    """Number of qubits a spin term touches (max degree + 1)."""
+    max_degree = _maybe_call(getattr(term, "max_degree", -1))
+    return max_degree + 1 if max_degree >= 0 else 0
+
+
+def _real_coefficient(coefficient: complex, tolerance: float) -> float:
+    """Coerce a coefficient to its real part, rejecting imaginary content.
+
+    Raises ``ValueError`` if the imaginary part exceeds ``tolerance``.
+    """
+    coefficient = complex(coefficient)
+    if abs(coefficient.imag) > tolerance:
+        raise ValueError(
+            "trotter error - only real Hamiltonian coefficients are "
+            "supported.")
+    return float(coefficient.real)
+
+
+def _word_pairs_from_input(
+        hamiltonian: HamiltonianLike,
+        tolerance: float) -> tuple[list[tuple[float, str]], int]:
+    """Normalize any accepted Hamiltonian form to ``(coefficient, word)``
+    pairs plus the register width.
+
+    Accepted forms:
+
+    * a mapping ``{"XZI...": coefficient}``;
+    * a ``cudaq.SpinOperator`` or a single spin term (wrapped via
+      ``cudaq.SpinOperator`` so elementary products normalize the same
+      way);
+    * an iterable of ``(coefficient, word)`` pairs.
+
+    Every word is validated to contain only I/X/Y/Z, all words must share
+    one width, and coefficients must be real to within ``tolerance``.
+
+    Returns ``(pairs, num_qubits)`` where ``pairs`` is a list of
+    ``(float, str)`` and ``num_qubits`` is the common word width.
+    """
+    if isinstance(hamiltonian, Mapping):
+        pairs = [(_real_coefficient(c, tolerance), str(w))
+                 for w, c in hamiltonian.items()]
+        width = max((len(w) for _, w in pairs), default=0)
+    elif _is_spin_like(hamiltonian):
+        # Wrapping canonicalizes: elementary products and full operators
+        # both become a SpinOperator whose iteration yields terms with
+        # evaluate_coefficient() and get_pauli_word().
+        terms = list(cudaq.SpinOperator(hamiltonian))
+        # Fix the register width once so every word is padded to the same
+        # length.
+        width = 0
+        for term in terms:
+            width = max(width, _term_qubit_extent(term))
+        pairs = [(_real_coefficient(term.evaluate_coefficient(), tolerance),
+                  str(term.get_pauli_word(width))) for term in terms]
+    elif isinstance(hamiltonian, Iterable):
+        pairs = [(_real_coefficient(c, tolerance), str(w))
+                 for c, w in hamiltonian]
+        width = max((len(w) for _, w in pairs), default=0)
+    else:
+        raise TypeError(
+            "hamiltonian must be a cudaq spin operator or term, a "
+            "{word: coeff} mapping, or an iterable of (coeff, word) pairs")
+
+    for _, word in pairs:
+        if len(word) != width:
+            raise ValueError("all Pauli words must have the same length")
+        if any(ch not in "IXYZ" for ch in word):
+            raise ValueError(f"unsupported Pauli word: {word!r}")
+    return pairs, width
+
+
+def make_trotter_terms(
+        hamiltonian: HamiltonianLike,
+        coefficient_tolerance: float = 1e-12
+) -> tuple[list[float], list[str], float, int]:
+    """Return flattened terms for the Suzuki-Trotter circuit primitive.
+
+    Returns ``(coefficients, words, identity_coefficient, num_qubits)``
+    where ``words`` are padded plain strings: readable, comparable, and
+    accepted directly as ``list[cudaq.pauli_word]`` kernel arguments.
+    (Only kernel-captured words need explicit ``cudaq.pauli_word``
+    conversion, which ``TrotterPlan.kernel`` performs internally.)
+    """
+    if coefficient_tolerance < 0.0:
+        raise ValueError(
+            "trotter error - coefficient tolerance must be non-negative.")
+
+    pairs, num_qubits = _word_pairs_from_input(hamiltonian,
+                                               coefficient_tolerance)
+
+    coefficients: list[float] = []
+    words: list[str] = []
+    identity_coefficient = 0.0
+    for coefficient, word in pairs:
+        if set(word) <= {"I"}:
+            identity_coefficient += coefficient
+            continue
+        coefficients.append(coefficient)
+        words.append(word)
+
+    return coefficients, words, identity_coefficient, num_qubits
+
+
+# ============================================================================
+# Planning, ordering, resources
+# ============================================================================
+
+
+class TrotterOrdering(Enum):
+    """Term-ordering strategies for the product formula.
+
+    ``PRESERVE_INPUT`` keeps the extraction order;
+    ``COEFFICIENT_MAGNITUDE_DESCENDING`` applies the largest-magnitude
+    terms first, a common heuristic for reducing Trotter error.
+    """
+
+    PRESERVE_INPUT = "preserve_input"
+    COEFFICIENT_MAGNITUDE_DESCENDING = "coefficient_magnitude_descending"
+
+
+def _validate_order(order: int) -> int:
+    """Validate and return a supported product-formula order (1, 2, or 4)."""
+    if order not in (FIRST_ORDER_TROTTER, SECOND_ORDER_TROTTER,
+                     FOURTH_ORDER_TROTTER):
+        raise ValueError("order must be one of {1, 2, 4}")
+    return int(order)
+
+
+def _validate_steps(steps: int) -> int:
+    """Validate and return a positive Trotter step count."""
+    steps = int(steps)
+    if steps < 1:
+        raise ValueError("steps must be greater than zero")
+    return steps
+
+
+def _validate_time(time: float) -> float:
+    """Validate and return a finite evolution time."""
+    time = float(time)
+    if not math.isfinite(time):
+        raise ValueError("time must be a finite number")
+    return time
+
+
+def _coerce_ordering(ordering: TrotterOrdering | str) -> TrotterOrdering:
+    """Coerce a ``TrotterOrdering`` or its string value to the enum."""
+    if isinstance(ordering, TrotterOrdering):
+        return ordering
+    try:
+        return TrotterOrdering(str(ordering))
+    except ValueError as exc:
+        raise ValueError(f"unsupported Trotter ordering: {ordering}") from exc
+
+
+def _ordered_terms(
+        coefficients: list[float], words: list[str],
+        ordering: TrotterOrdering) -> tuple[list[float], list[str]]:
+    """Apply the ordering strategy to parallel coefficient/word lists."""
+    coefficients = list(coefficients)
+    words = list(words)
+    if ordering == TrotterOrdering.PRESERVE_INPUT:
+        return coefficients, words
+    ordered = sorted(zip(coefficients, words),
+                     key=lambda item: abs(item[0]),
+                     reverse=True)
+    if not ordered:
+        return [], []
+    ordered_coefficients, ordered_words = zip(*ordered)
+    return list(ordered_coefficients), list(ordered_words)
+
+
+def _pauli_weight(word: str) -> int:
+    """Number of non-identity Paulis in a word."""
+    return sum(1 for op in str(word) if op != "I")
+
+
+def _rotations_per_step(order: int) -> int:
+    """Pauli rotations each term contributes per Trotter step."""
+    return {1: 1, 2: 2, 4: 6}[_validate_order(order)]
+
+
+@dataclass(frozen=True)
+class TrotterResourceEstimate:
+    """Lightweight circuit-cost summary for a Trotter sequence.
+
+    ``estimated_cx_count`` is a decomposition proxy: two CNOTs per
+    additional non-identity Pauli in each rotation.
+    """
+
+    num_terms: int
+    steps: int
+    order: int
+    pauli_rotations: int
+    estimated_cx_count: int
+    identity_coefficient: float
+
+
+@dataclass(frozen=True)
+class TrotterPlan:
+    """Validated host-side plan for Suzuki-Trotter evolution.
+
+    Carries the flattened data ``apply_trotter`` consumes plus a kernel
+    factory, so no caller has to thread the arrays by hand. The plan is
+    hardware-shaped: nothing here executes a simulator-only API (see
+    ``sim_utils.evolve`` for statevector-based evolution).
+    """
+
+    coefficients: list[float]
+    words: list[str] = field(repr=False)
+    identity_coefficient: float = 0.0
+    num_qubits: int = 0
+    time: float = 0.0
+    steps: int = 1
+    order: int = SECOND_ORDER_TROTTER
+    ordering: TrotterOrdering = TrotterOrdering.PRESERVE_INPUT
+
+    @property
+    def num_terms(self) -> int:
+        """Number of retained non-identity terms."""
+        return len(self.coefficients)
+
+    def kernel(self):
+        """Return a ``@cudaq.kernel()`` applying this plan's evolution.
+
+        The kernel allocates ``num_qubits`` qubits in |0...0> and applies
+        the product formula. The identity phase is not included (it cannot
+        be, in a circuit); track ``identity_coefficient`` when it matters.
+        """
+        coefficients = [float(c) for c in self.coefficients]
+        words = [cudaq.pauli_word(str(w)) for w in self.words]
+        time = float(self.time)
+        steps = int(self.steps)
+        order = int(self.order)
+        num_qubits = int(self.num_qubits)
+
+        if not words:
+            # Identity-only Hamiltonian: the circuit is the identity.
+            # Special-cased because captured empty lists cannot be
+            # marshaled across the kernel boundary
+            # (https://github.com/NVIDIA/cuda-quantum/issues/4847).
+            @cudaq.kernel
+            def evolve_identity():
+                cudaq.qvector(num_qubits)
+
+            return evolve_identity
+
+        @cudaq.kernel
+        def evolve():
+            qubits = cudaq.qvector(num_qubits)
+            apply_trotter(coefficients, words, time, steps, order, qubits)
+
+        return evolve
+
+    def resources(self) -> TrotterResourceEstimate:
+        """Return the resource estimate for this plan."""
+        return estimate_trotter_resources(self)
+
+
+def make_trotter_plan(hamiltonian: HamiltonianLike,
+                      time: float,
+                      steps: int = 1,
+                      order: int = SECOND_ORDER_TROTTER,
+                      ordering: TrotterOrdering | str = (
+                          TrotterOrdering.PRESERVE_INPUT),
+                      coefficient_tolerance: float = 1e-12) -> TrotterPlan:
+    """Build a validated host-side plan for Suzuki-Trotter evolution.
+
+    ``hamiltonian`` accepts any :data:`HamiltonianLike` form. ``order``
+    must be 1, 2, or 4; ``steps`` positive; ``time`` finite.
+    """
+    time = _validate_time(time)
+    steps = _validate_steps(steps)
+    order = _validate_order(order)
+    ordering = _coerce_ordering(ordering)
+    coefficients, words, identity, num_qubits = make_trotter_terms(
+        hamiltonian, coefficient_tolerance)
+    coefficients, words = _ordered_terms(coefficients, words, ordering)
+    return TrotterPlan(coefficients=coefficients,
+                       words=words,
+                       identity_coefficient=identity,
+                       num_qubits=num_qubits,
+                       time=time,
+                       steps=steps,
+                       order=order,
+                       ordering=ordering)
+
+
+def estimate_trotter_resources(
+        plan_or_coefficients: TrotterPlan | list[float],
+        words: list[str] | None = None,
+        steps: int | None = None,
+        order: int | None = None,
+        identity_coefficient: float = 0.0) -> TrotterResourceEstimate:
+    """Return a lightweight resource estimate for a Trotter sequence.
+
+    Accepts either a :class:`TrotterPlan` or the flattened
+    ``(coefficients, words, steps, order)`` data directly.
+    """
+    if isinstance(plan_or_coefficients, TrotterPlan):
+        coefficients = plan_or_coefficients.coefficients
+        words = plan_or_coefficients.words
+        steps = plan_or_coefficients.steps
+        order = plan_or_coefficients.order
+        identity_coefficient = plan_or_coefficients.identity_coefficient
+    else:
+        coefficients = list(plan_or_coefficients)
+        words = list(words)
+        steps = _validate_steps(steps)
+        order = _validate_order(order)
+
+    if len(coefficients) != len(words):
+        raise ValueError("coefficients and words must have equal length")
+
+    rotations = len(words) * steps * _rotations_per_step(order)
+    cx_per_ordered_step = sum(
+        max(0, 2 * (_pauli_weight(word) - 1)) for word in words)
+    estimated_cx_count = cx_per_ordered_step * steps * _rotations_per_step(
+        order)
+    return TrotterResourceEstimate(
+        num_terms=len(words),
+        steps=steps,
+        order=order,
+        pauli_rotations=rotations,
+        estimated_cx_count=estimated_cx_count,
+        identity_coefficient=float(identity_coefficient))
+
+
+__all__ = [
+    "FIRST_ORDER_TROTTER",
+    "SECOND_ORDER_TROTTER",
+    "FOURTH_ORDER_TROTTER",
+    "FOREST_RUTH_W1",
+    "FOREST_RUTH_W0",
+    "HamiltonianLike",
+    "TrotterOrdering",
+    "TrotterPlan",
+    "TrotterResourceEstimate",
+    "apply_trotter",
+    "estimate_trotter_resources",
+    "make_trotter_plan",
+    "make_trotter_terms",
+    "state_from",
+]

--- a/python/cudaq_algorithms/trotter.py
+++ b/python/cudaq_algorithms/trotter.py
@@ -61,7 +61,7 @@ _FOREST_RUTH_W0: float = -1.7024143839193153
 #: ``cudaq.SpinOperatorTerm`` product), a ``{"XZI...": coefficient}``
 #: mapping, or an iterable of ``(coefficient, word)`` pairs.
 HamiltonianLike = Union[cudaq.SpinOperator, cudaq.SpinOperatorTerm,
-                        Mapping[str, complex], Iterable[tuple]]
+                        Mapping[str, complex], Iterable[tuple[complex, str]]]
 
 # ============================================================================
 # Device kernel (module level, composable from user kernels)

--- a/python/cudaq_algorithms/trotter.py
+++ b/python/cudaq_algorithms/trotter.py
@@ -15,26 +15,26 @@ The typical workflow builds a validated plan on the host and either uses
 its kernel factory or composes the ``apply_trotter`` primitive inside a
 custom kernel::
 
-    from cudaq.algorithms import trotter
+    from cudaq_algorithms import trotter
 
-    plan = trotter.make_trotter_plan(hamiltonian, time=0.8, steps=4, order=2)
-    kernel = plan.kernel()          # ready @cudaq.kernel()
-    resources = plan.resources()
+    evolution = trotter.Trotter(hamiltonian)
+    kernel = evolution.kernel(time=0.8, steps=4, order=2)  # @cudaq.kernel()
+    resources = evolution.resources(steps=4, order=2)
 
 Identity terms: for ``H = c I + H'``, ``apply_trotter`` implements the
 product formula for ``H'`` only. The omitted ``exp(-i c t)`` is an
 unobservable global phase for one unconditioned evolution but a real
 relative phase for controlled or interference-based algorithms;
-``identity_coefficient`` is reported on the plan so callers can account
-for it (the simulation helper ``sim_utils.evolve`` reintroduces it
-host-side).
+``identity_coefficient`` is reported on the ``Trotter`` object so callers
+can account for it (the simulation helper ``sim_utils.evolve``
+reintroduces it host-side).
 """
 
 from __future__ import annotations
 
 import math
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Union
 
@@ -222,7 +222,7 @@ def make_trotter_terms(
     where ``words`` are padded plain strings: readable, comparable, and
     accepted directly as ``list[cudaq.pauli_word]`` kernel arguments.
     (Only kernel-captured words need explicit ``cudaq.pauli_word``
-    conversion, which ``TrotterPlan.kernel`` performs internally.)
+    conversion, which ``Trotter.kernel`` performs internally.)
     """
     if coefficient_tolerance < 0.0:
         raise ValueError(
@@ -338,46 +338,90 @@ class TrotterResourceEstimate:
     identity_coefficient: float
 
 
-@dataclass(frozen=True)
-class TrotterPlan:
-    """Validated host-side plan for Suzuki-Trotter evolution.
+class Trotter:
+    """Suzuki-Trotter product formulas for a Pauli-sum Hamiltonian.
 
-    Carries the flattened data ``apply_trotter`` consumes plus a kernel
-    factory, so no caller has to thread the arrays by hand. The plan is
-    hardware-shaped: nothing here executes a simulator-only API (see
-    ``sim_utils.evolve`` for statevector-based evolution).
+    Term extraction, validation, and ordering happen once at
+    construction (identity terms are split off into
+    ``identity_coefficient``); the evolution parameters ``time``,
+    ``steps``, and ``order`` are supplied per kernel request, mirroring
+    the other primitives (``Walk.kernel(power=...)``,
+    ``QSVT.kernel(sequence)``).
+
+    The object is hardware-shaped: nothing here executes a
+    simulator-only API (see ``sim_utils.evolve`` for statevector-based
+    evolution).
     """
 
-    coefficients: list[float]
-    words: list[str] = field(repr=False)
-    identity_coefficient: float = 0.0
-    num_qubits: int = 0
-    time: float = 0.0
-    steps: int = 1
-    order: int = SECOND_ORDER_TROTTER
-    ordering: TrotterOrdering = TrotterOrdering.PRESERVE_INPUT
+    def __init__(self,
+                 hamiltonian: HamiltonianLike,
+                 ordering: TrotterOrdering | str = (
+                     TrotterOrdering.PRESERVE_INPUT),
+                 *,
+                 coefficient_tolerance: float = 1e-12) -> None:
+        ordering = _coerce_ordering(ordering)
+        coefficients, words, identity, num_qubits = make_trotter_terms(
+            hamiltonian, coefficient_tolerance)
+        coefficients, words = _ordered_terms(coefficients, words, ordering)
+        self._coefficients = coefficients
+        self._words = words
+        self._identity = identity
+        self._num_qubits = num_qubits
+        self._ordering = ordering
+
+    @property
+    def coefficients(self) -> list[float]:
+        """Retained non-identity coefficients, in application order."""
+        return list(self._coefficients)
+
+    @property
+    def words(self) -> list[str]:
+        """Retained Pauli words, parallel to ``coefficients``."""
+        return list(self._words)
+
+    @property
+    def identity_coefficient(self) -> float:
+        """Sum of identity-term coefficients (not realizable in circuit)."""
+        return self._identity
+
+    @property
+    def num_qubits(self) -> int:
+        return self._num_qubits
 
     @property
     def num_terms(self) -> int:
         """Number of retained non-identity terms."""
-        return len(self.coefficients)
+        return len(self._coefficients)
 
-    def kernel(self) -> Any:
-        """Return a ``@cudaq.kernel()`` applying this plan's evolution.
+    @property
+    def ordering(self) -> TrotterOrdering:
+        return self._ordering
+
+    def __repr__(self) -> str:
+        return (f"Trotter(terms={self.num_terms}, "
+                f"qubits={self.num_qubits}, "
+                f"identity_coefficient={self.identity_coefficient:.6g})")
+
+    def kernel(self,
+               time: float,
+               steps: int = 1,
+               order: int = SECOND_ORDER_TROTTER) -> Any:
+        """Return a ``@cudaq.kernel()`` applying the product formula.
 
         (``Any`` because CUDA-Q exposes no stable public Python type for
         compiled kernel objects.)
 
         The kernel allocates ``num_qubits`` qubits in |0...0> and applies
-        the product formula. The identity phase is not included (it cannot
-        be, in a circuit); track ``identity_coefficient`` when it matters.
+        the ``order``-order formula for ``time`` over ``steps`` steps. The
+        identity phase is not included (it cannot be, in a circuit); track
+        ``identity_coefficient`` when it matters.
         """
-        coefficients = [float(c) for c in self.coefficients]
-        words = [cudaq.pauli_word(str(w)) for w in self.words]
-        time = float(self.time)
-        steps = int(self.steps)
-        order = int(self.order)
-        num_qubits = int(self.num_qubits)
+        time = _validate_time(time)
+        steps = _validate_steps(steps)
+        order = _validate_order(order)
+        coefficients = [float(c) for c in self._coefficients]
+        words = [cudaq.pauli_word(str(w)) for w in self._words]
+        num_qubits = int(self._num_qubits)
 
         if not words:
             # Identity-only Hamiltonian: the circuit is the identity.
@@ -397,62 +441,26 @@ class TrotterPlan:
 
         return evolve
 
-    def resources(self) -> TrotterResourceEstimate:
-        """Return the resource estimate for this plan."""
-        return estimate_trotter_resources(self)
-
-
-def make_trotter_plan(hamiltonian: HamiltonianLike,
-                      time: float,
-                      steps: int = 1,
-                      order: int = SECOND_ORDER_TROTTER,
-                      ordering: TrotterOrdering | str = (
-                          TrotterOrdering.PRESERVE_INPUT),
-                      coefficient_tolerance: float = 1e-12) -> TrotterPlan:
-    """Build a validated host-side plan for Suzuki-Trotter evolution.
-
-    ``hamiltonian`` accepts any :data:`HamiltonianLike` form. ``order``
-    must be 1, 2, or 4; ``steps`` positive; ``time`` finite.
-    """
-    time = _validate_time(time)
-    steps = _validate_steps(steps)
-    order = _validate_order(order)
-    ordering = _coerce_ordering(ordering)
-    coefficients, words, identity, num_qubits = make_trotter_terms(
-        hamiltonian, coefficient_tolerance)
-    coefficients, words = _ordered_terms(coefficients, words, ordering)
-    return TrotterPlan(coefficients=coefficients,
-                       words=words,
-                       identity_coefficient=identity,
-                       num_qubits=num_qubits,
-                       time=time,
-                       steps=steps,
-                       order=order,
-                       ordering=ordering)
+    def resources(self,
+                  steps: int = 1,
+                  order: int = SECOND_ORDER_TROTTER) -> TrotterResourceEstimate:
+        """Resource estimate for ``steps`` steps of the ``order`` formula."""
+        return estimate_trotter_resources(
+            self._coefficients, self._words, steps=steps, order=order,
+            identity_coefficient=self._identity)
 
 
 def estimate_trotter_resources(
-        plan_or_coefficients: TrotterPlan | list[float],
-        words: list[str] | None = None,
-        steps: int | None = None,
-        order: int | None = None,
+        coefficients: list[float],
+        words: list[str],
+        steps: int = 1,
+        order: int = SECOND_ORDER_TROTTER,
         identity_coefficient: float = 0.0) -> TrotterResourceEstimate:
-    """Return a lightweight resource estimate for a Trotter sequence.
-
-    Accepts either a :class:`TrotterPlan` or the flattened
-    ``(coefficients, words, steps, order)`` data directly.
-    """
-    if isinstance(plan_or_coefficients, TrotterPlan):
-        coefficients = plan_or_coefficients.coefficients
-        words = plan_or_coefficients.words
-        steps = plan_or_coefficients.steps
-        order = plan_or_coefficients.order
-        identity_coefficient = plan_or_coefficients.identity_coefficient
-    else:
-        coefficients = list(plan_or_coefficients)
-        words = list(words)
-        steps = _validate_steps(steps)
-        order = _validate_order(order)
+    """Return a lightweight resource estimate for a Trotter sequence."""
+    coefficients = list(coefficients)
+    words = list(words)
+    steps = _validate_steps(steps)
+    order = _validate_order(order)
 
     if len(coefficients) != len(words):
         raise ValueError("coefficients and words must have equal length")
@@ -478,12 +486,11 @@ __all__ = [
     "FOREST_RUTH_W1",
     "FOREST_RUTH_W0",
     "HamiltonianLike",
+    "Trotter",
     "TrotterOrdering",
-    "TrotterPlan",
     "TrotterResourceEstimate",
     "apply_trotter",
     "estimate_trotter_resources",
-    "make_trotter_plan",
     "make_trotter_terms",
     "state_from",
 ]

--- a/python/cudaq_algorithms/trotter.py
+++ b/python/cudaq_algorithms/trotter.py
@@ -41,7 +41,7 @@ from typing import Any, Union
 
 import cudaq
 
-from .pauli_lcu import _real_coefficient
+from .common_kernels import _real_coefficient
 
 #: Supported product-formula orders.
 FIRST_ORDER_TROTTER: int = 1
@@ -152,11 +152,14 @@ def _word_pairs_from_input(
       way);
     * an iterable of ``(coefficient, word)`` pairs.
 
-    Every word is validated to contain only I/X/Y/Z, all words must share
-    one width, and coefficients must be real (validated by the same
-    ``_real_coefficient`` used across the package). Unlike ``PauliLCU``
-    (which requires uniform-width words), mapping and pair inputs here may
-    mix widths only if explicitly padded — the width is the longest word.
+    Every word is validated to contain only I/X/Y/Z, all words in mapping
+    and pair inputs must share one width (exactly as in ``PauliLCU``), and
+    coefficients must be real (validated by the shared
+    ``_real_coefficient``). Spin-operator inputs are the one padding path:
+    their words are rendered at the widest term's extent. Deliberate
+    divergences from ``pauli_lcu._terms_from_input``: string-like inputs
+    are rejected with the TypeError below, and zero-width Hamiltonians are
+    rejected after extraction.
 
     Returns ``(pairs, num_qubits)`` where ``pairs`` is a list of
     ``(float, str)`` and ``num_qubits`` is the common word width.
@@ -177,8 +180,8 @@ def _word_pairs_from_input(
             width = max(width, _term_qubit_extent(term))
         pairs = [(_real_coefficient(term.evaluate_coefficient()),
                   str(term.get_pauli_word(width))) for term in terms]
-    elif isinstance(hamiltonian,
-                    Iterable) and not isinstance(hamiltonian, (str, bytes)):
+    elif isinstance(hamiltonian, Iterable) and not isinstance(
+            hamiltonian, (str, bytes, bytearray, memoryview)):
         pairs = [(_real_coefficient(c), str(w)) for c, w in hamiltonian]
         width = max((len(w) for _, w in pairs), default=0)
     else:
@@ -209,6 +212,12 @@ def make_trotter_terms(
     accepted directly as ``list[cudaq.pauli_word]`` kernel arguments.
     (Only kernel-captured words need explicit ``cudaq.pauli_word``
     conversion, which ``Trotter.kernel`` performs internally.)
+
+    ``coefficient_tolerance`` filters term magnitudes only: terms with
+    ``|coefficient|`` below it (and exactly-zero terms regardless of it)
+    are dropped — they would emit zero-angle rotations and inflate
+    resource estimates. It does not affect complex-coefficient
+    validation, which is fixed package-wide (see ``_real_coefficient``).
     """
     if coefficient_tolerance < 0.0:
         raise ValueError(
@@ -220,9 +229,10 @@ def make_trotter_terms(
     words: list[str] = []
     identity_coefficient = 0.0
     for coefficient, word in pairs:
-        if abs(coefficient) < coefficient_tolerance:
-            # Below-threshold (including exactly-zero) terms would emit
-            # zero-angle rotations and inflate resource estimates.
+        if coefficient == 0.0 or abs(coefficient) < coefficient_tolerance:
+            # Exactly-zero terms are always dead weight (even with
+            # tolerance 0); below-threshold terms would emit zero-angle
+            # rotations and inflate resource estimates.
             continue
         if set(word) <= {"I"}:
             identity_coefficient += coefficient
@@ -390,6 +400,12 @@ class Trotter:
                 f"qubits={self.num_qubits}, "
                 f"identity_coefficient={self.identity_coefficient:.6g})")
 
+    def _prepared_args(self, time: float, steps: int, order: int):
+        """Validated, kernel-ready arguments shared by both kernel factories."""
+        return (_validate_time(time), _validate_steps(steps),
+                _validate_order(order), list(self._coefficients),
+                [cudaq.pauli_word(w) for w in self._words])
+
     def kernel(self,
                time: float,
                steps: int = 1,
@@ -404,11 +420,8 @@ class Trotter:
         identity phase is not included (it cannot be, in a circuit); track
         ``identity_coefficient`` when it matters.
         """
-        time = _validate_time(time)
-        steps = _validate_steps(steps)
-        order = _validate_order(order)
-        coefficients = list(self._coefficients)
-        words = [cudaq.pauli_word(w) for w in self._words]
+        time, steps, order, coefficients, words = self._prepared_args(
+            time, steps, order)
         num_qubits = self._num_qubits
 
         if not words:
@@ -437,15 +450,16 @@ class Trotter:
 
         Same validated product formula as :meth:`kernel`, but the register
         is allocated from a ``cudaq.State`` argument instead of |0...0> —
-        the input-loading path ``sim_utils.evolve`` uses. Validation,
-        marshaling, and the identity-only special case
-        (cuda-quantum#4847) live here so every entry point shares them.
+        the input-loading path ``sim_utils.evolve`` uses. Both factories
+        share validation and marshaling through ``_prepared_args``.
+
+        The supplied state must have dimension ``2**num_qubits``:
+        ``sim_utils.evolve`` checks this; direct callers are responsible
+        for it themselves (the identity-only variant cannot detect a
+        mismatch).
         """
-        time = _validate_time(time)
-        steps = _validate_steps(steps)
-        order = _validate_order(order)
-        coefficients = list(self._coefficients)
-        words = [cudaq.pauli_word(w) for w in self._words]
+        time, steps, order, coefficients, words = self._prepared_args(
+            time, steps, order)
 
         if not words:
 

--- a/tests/python/test_pauli_lcu.py
+++ b/tests/python/test_pauli_lcu.py
@@ -273,3 +273,10 @@ def test_prepare_angles_keep_tiny_sibling_terms():
     assert angles[1] == pytest.approx(2.0 * math.asin(math.sqrt(0.5)))
     # Exact-zero padding subtrees still produce zero rotations.
     assert _prepare_angles([0.5, 0.5, 0.0, 0.0])[2] == 0.0
+
+
+def test_string_hamiltonian_rejected_with_type_error():
+    # Parity with Trotter: string-like inputs must get the intended
+    # TypeError, not a misleading unpack error from the pair branch.
+    with pytest.raises(TypeError, match="SpinOperator"):
+        PauliLCU("XZ")

--- a/tests/python/test_trotter.py
+++ b/tests/python/test_trotter.py
@@ -1,0 +1,593 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Tests for the Suzuki-Trotter module.
+
+Product-formula correctness is pinned against independent dense references
+(matrix exponentials and an explicit Pauli-rotation simulator), and the
+host-side extraction, planning, and resource machinery is covered for
+every accepted input form.
+"""
+
+import numpy as np
+import pytest
+
+import cudaq
+from cudaq import spin
+
+from cudaq_algorithms import sim_utils, trotter
+
+FOREST_RUTH_W1 = 1.3512071919596578
+FOREST_RUTH_W0 = -1.7024143839193153
+
+
+# ----------------------------------------------------------------------------
+# Dense references (ported verbatim from the upstream test file)
+# ----------------------------------------------------------------------------
+
+
+def _apply_pauli_to_vector(word, vector):
+    word = str(word)
+    result = np.zeros_like(vector, dtype=np.complex128)
+    for basis, amplitude in enumerate(vector):
+        target = basis
+        phase = 1.0 + 0.0j
+        for qubit, op in enumerate(word):
+            bit = (basis >> qubit) & 1
+            if op == "I":
+                continue
+            if op == "X":
+                target ^= 1 << qubit
+            elif op == "Y":
+                target ^= 1 << qubit
+                phase *= -1.0j if bit else 1.0j
+            elif op == "Z":
+                phase *= -1.0 if bit else 1.0
+            else:
+                raise ValueError(op)
+        result[target] += phase * amplitude
+    return result
+
+
+def _apply_pauli_rotation(vector, word, angle):
+    return (np.cos(angle) * vector -
+            1.0j * np.sin(angle) * _apply_pauli_to_vector(word, vector))
+
+
+def _second_order_step(vector, coefficients, words, tau):
+    state = vector
+    for coefficient, word in zip(coefficients, words):
+        state = _apply_pauli_rotation(state, word, 0.5 * tau * coefficient)
+    for coefficient, word in reversed(list(zip(coefficients, words))):
+        state = _apply_pauli_rotation(state, word, 0.5 * tau * coefficient)
+    return state
+
+
+def _simulate_trotter(coefficients, words, identity, num_qubits, time, steps,
+                      order, ket, include_identity=True):
+    state = np.array(ket, dtype=np.complex128, copy=True)
+    dt = time / steps
+    for _ in range(steps):
+        if order == 1:
+            for coefficient, word in zip(coefficients, words):
+                state = _apply_pauli_rotation(state, word, dt * coefficient)
+        elif order == 2:
+            state = _second_order_step(state, coefficients, words, dt)
+        else:
+            state = _second_order_step(state, coefficients, words,
+                                       FOREST_RUTH_W1 * dt)
+            state = _second_order_step(state, coefficients, words,
+                                       FOREST_RUTH_W0 * dt)
+            state = _second_order_step(state, coefficients, words,
+                                       FOREST_RUTH_W1 * dt)
+    if include_identity and identity != 0.0:
+        state *= np.exp(-1.0j * identity * time)
+    return state
+
+
+def _pauli_matrix(word):
+    dim = 2**len(str(word))
+    matrix = np.zeros((dim, dim), dtype=np.complex128)
+    for basis in range(dim):
+        vector = np.zeros(dim, dtype=np.complex128)
+        vector[basis] = 1.0
+        matrix[:, basis] = _apply_pauli_to_vector(word, vector)
+    return matrix
+
+
+def _exact_evolve(coefficients, words, identity, time, ket):
+    matrix = identity * np.eye(ket.size, dtype=np.complex128)
+    for coefficient, word in zip(coefficients, words):
+        matrix += coefficient * _pauli_matrix(str(word))
+    eigenvalues, eigenvectors = np.linalg.eigh(matrix)
+    return eigenvectors @ (np.exp(-1.0j * time * eigenvalues) *
+                           (eigenvectors.conj().T @ ket))
+
+
+def _two_qubit_product_state(rx_angle, ry_angle):
+    q0 = np.array([np.cos(0.5 * rx_angle), -1.0j * np.sin(0.5 * rx_angle)],
+                  dtype=np.complex128)
+    q1 = np.array([np.cos(0.5 * ry_angle),
+                   np.sin(0.5 * ry_angle)],
+                  dtype=np.complex128)
+    return np.array(
+        [q0[basis & 1] * q1[(basis >> 1) & 1] for basis in range(4)],
+        dtype=np.complex128)
+
+
+def _phase_align_error(actual, expected):
+    overlap = np.vdot(expected, actual)
+    if abs(overlap) > 0.0:
+        actual = actual * np.exp(-1.0j * np.angle(overlap))
+    return np.linalg.norm(actual - expected)
+
+
+# ----------------------------------------------------------------------------
+# Term extraction
+# ----------------------------------------------------------------------------
+
+
+def test_make_trotter_terms_extracts_spin_operator():
+    hamiltonian = (0.7 * spin.x(0) + 0.4 * spin.z(1) -
+                   0.2 * cudaq.SpinOperator.from_word("II"))
+    coefficients, words, identity, num_qubits = trotter.make_trotter_terms(
+        hamiltonian)
+
+    by_word = {
+        str(word): coefficient
+        for coefficient, word in zip(coefficients, words)
+    }
+    assert num_qubits == 2
+    assert identity == pytest.approx(-0.2)
+    assert by_word["XI"] == pytest.approx(0.7)
+    assert by_word["IZ"] == pytest.approx(0.4)
+
+
+def test_make_trotter_terms_accepts_single_spin_term():
+    coefficients, words, identity, num_qubits = trotter.make_trotter_terms(
+        0.5 * spin.y(2))
+    assert coefficients == pytest.approx([0.5])
+    assert [str(word) for word in words] == ["IIY"]
+    assert identity == pytest.approx(0.0)
+    assert num_qubits == 3
+
+
+def test_make_trotter_terms_accepts_dict_and_pairs():
+    from_dict = trotter.make_trotter_terms({
+        "XI": 0.7,
+        "IZ": 0.4,
+        "II": -0.2
+    })
+    from_pairs = trotter.make_trotter_terms([(0.7, "XI"), (0.4, "IZ"),
+                                             (-0.2, "II")])
+    for coefficients, words, identity, num_qubits in (from_dict, from_pairs):
+        assert num_qubits == 2
+        assert identity == pytest.approx(-0.2)
+        assert coefficients == pytest.approx([0.7, 0.4])
+        assert [str(w) for w in words] == ["XI", "IZ"]
+
+
+def test_make_trotter_terms_validation():
+    with pytest.raises(ValueError, match="non-negative"):
+        trotter.make_trotter_terms(spin.x(0), coefficient_tolerance=-1.0)
+    with pytest.raises(ValueError, match="real"):
+        trotter.make_trotter_terms({"X": 0.5 + 0.3j})
+    with pytest.raises(ValueError, match="same length"):
+        trotter.make_trotter_terms({"XI": 0.5, "X": 0.3})
+    with pytest.raises(ValueError, match="unsupported Pauli"):
+        trotter.make_trotter_terms({"XQ": 0.5})
+    with pytest.raises(TypeError):
+        trotter.make_trotter_terms(42)
+
+
+# ----------------------------------------------------------------------------
+# Product-formula reference sanity
+# ----------------------------------------------------------------------------
+
+
+def test_product_formula_reference_improves_with_order():
+    hamiltonian = (0.7 * spin.x(0) + 0.4 * spin.z(1) +
+                   0.31 * spin.x(0) * spin.z(1) + 0.23 * spin.y(0) * spin.y(1))
+    coefficients, words, identity, num_qubits = trotter.make_trotter_terms(
+        hamiltonian)
+
+    rng = np.random.default_rng(7)
+    ket = rng.normal(size=4) + 1.0j * rng.normal(size=4)
+    ket = ket / np.linalg.norm(ket)
+
+    time, steps = 0.8, 2
+    exact = _exact_evolve(coefficients, words, identity, time, ket)
+    errors = {
+        order: _phase_align_error(
+            _simulate_trotter(coefficients, words, identity, num_qubits, time,
+                              steps, order, ket), exact)
+        for order in (1, 2, 4)
+    }
+    assert errors[2] < errors[1]
+    assert errors[4] < errors[2]
+
+
+# ----------------------------------------------------------------------------
+# Planning, ordering, resources
+# ----------------------------------------------------------------------------
+
+
+def test_make_trotter_plan_orders_terms_and_estimates_resources():
+    hamiltonian = (0.1 * spin.x(0) + 0.7 * spin.z(1) +
+                   0.4 * spin.x(0) * spin.z(1) -
+                   0.2 * cudaq.SpinOperator.from_word("II"))
+    plan = trotter.make_trotter_plan(
+        hamiltonian,
+        time=0.6,
+        steps=3,
+        order=4,
+        ordering=trotter.TrotterOrdering.COEFFICIENT_MAGNITUDE_DESCENDING)
+
+    assert plan.steps == 3
+    assert plan.order == 4
+    assert plan.identity_coefficient == pytest.approx(-0.2)
+    assert plan.coefficients == pytest.approx([0.7, 0.4, 0.1])
+    assert [str(word) for word in plan.words] == ["IZ", "XZ", "XI"]
+
+    resources = plan.resources()
+    assert resources.num_terms == 3
+    assert resources.pauli_rotations == 3 * 3 * 6
+    assert resources.estimated_cx_count == 2 * 3 * 6
+
+
+def test_trotter_plan_rejects_invalid_options():
+    with pytest.raises(ValueError, match="steps"):
+        trotter.make_trotter_plan(spin.x(0), time=0.1, steps=0)
+    with pytest.raises(ValueError, match="order"):
+        trotter.make_trotter_plan(spin.x(0), time=0.1, order=3)
+    with pytest.raises(ValueError, match="unsupported"):
+        trotter.make_trotter_plan(spin.x(0), time=0.1, ordering="bogus")
+    with pytest.raises(ValueError, match="finite"):
+        trotter.make_trotter_plan(spin.x(0), time=float("nan"))
+
+
+def test_estimate_trotter_resources_accepts_flattened_terms():
+    coefficients, words, identity, _ = trotter.make_trotter_terms(
+        0.5 * spin.x(0) * spin.y(1) + 0.25 * spin.z(0))
+    resources = trotter.estimate_trotter_resources(
+        coefficients, words, steps=2, order=2, identity_coefficient=identity)
+    assert resources.num_terms == 2
+    assert resources.pauli_rotations == 8
+    assert resources.estimated_cx_count == 8
+
+
+# ----------------------------------------------------------------------------
+# Kernel behavior (escape hatch: apply_trotter inside a user kernel)
+# ----------------------------------------------------------------------------
+
+
+def test_apply_trotter_kernel_interop_with_flattened_terms():
+    coefficients, words, identity, num_qubits = trotter.make_trotter_terms(
+        spin.x(0))
+    assert identity == 0.0
+    assert num_qubits == 1
+
+    @cudaq.kernel
+    def evolve(coeffs: list[float], paulis: list[cudaq.pauli_word], t: float):
+        q = cudaq.qvector(1)
+        trotter.apply_trotter(coeffs, paulis, t, 1, 2, q)
+
+    state = np.asarray(cudaq.get_state(evolve, coefficients, words, 0.25),
+                       dtype=np.complex128)
+    expected = _simulate_trotter(coefficients, words, identity, num_qubits,
+                                 0.25, 1, 2,
+                                 np.array([1.0, 0.0], dtype=np.complex128))
+    np.testing.assert_allclose(state, expected, atol=1e-6)
+
+
+def test_apply_trotter_kernel_invalid_inputs_are_noops():
+    coefficients, words, _, _ = trotter.make_trotter_terms(spin.x(0))
+
+    @cudaq.kernel
+    def evolve(coeffs: list[float], paulis: list[cudaq.pauli_word], steps: int,
+               order: int):
+        q = cudaq.qvector(1)
+        trotter.apply_trotter(coeffs, paulis, 0.25, steps, order, q)
+
+    expected = np.array([1.0, 0.0], dtype=np.complex128)
+    for bad_coefficients, bad_words, bad_steps, bad_order in (
+        (coefficients, words, 0, 2),
+        (coefficients, words, 1, 3),
+        (coefficients, [], 1, 2),
+    ):
+        state = np.asarray(cudaq.get_state(evolve, bad_coefficients, bad_words,
+                                           bad_steps, bad_order),
+                           dtype=np.complex128)
+        np.testing.assert_allclose(state, expected, atol=1e-12)
+
+
+def test_apply_trotter_kernel_matches_reference_for_orders():
+    hamiltonian = (0.7 * spin.x(0) + 0.4 * spin.z(1) +
+                   0.31 * spin.x(0) * spin.z(1) + 0.23 * spin.y(0) * spin.y(1))
+    coefficients, words, identity, num_qubits = trotter.make_trotter_terms(
+        hamiltonian)
+    ket = np.array([1.0, 0.0, 0.0, 0.0], dtype=np.complex128)
+
+    @cudaq.kernel
+    def evolve(coeffs: list[float], paulis: list[cudaq.pauli_word], t: float,
+               steps: int, order: int):
+        q = cudaq.qvector(2)
+        trotter.apply_trotter(coeffs, paulis, t, steps, order, q)
+
+    for order in (1, 2, 4):
+        state = np.asarray(cudaq.get_state(evolve, coefficients, words, 0.8, 3,
+                                           order),
+                           dtype=np.complex128)
+        expected = _simulate_trotter(coefficients, words, identity, num_qubits,
+                                     0.8, 3, order, ket)
+        np.testing.assert_allclose(state, expected, atol=1e-6)
+
+
+def test_apply_trotter_kernel_orders_track_exact_evolution():
+    hamiltonian = (0.37 * spin.x(0) - 0.22 * spin.z(1) +
+                   0.19 * spin.x(0) * spin.x(1) +
+                   0.41 * spin.y(0) * spin.y(1) + 0.13 * spin.z(0) * spin.x(1))
+    coefficients, words, identity, num_qubits = trotter.make_trotter_terms(
+        hamiltonian)
+    assert identity == pytest.approx(0.0)
+    assert num_qubits == 2
+
+    time, steps = 0.7, 4
+    rx_angle, ry_angle = 0.37, -0.52
+    ket = _two_qubit_product_state(rx_angle, ry_angle)
+    exact = _exact_evolve(coefficients, words, identity, time, ket)
+
+    @cudaq.kernel
+    def evolve(coeffs: list[float], paulis: list[cudaq.pauli_word], t: float,
+               n_steps: int, order: int, theta0: float, theta1: float):
+        q = cudaq.qvector(2)
+        rx(theta0, q[0])
+        ry(theta1, q[1])
+        trotter.apply_trotter(coeffs, paulis, t, n_steps, order, q)
+
+    errors = {}
+    for order in (1, 2, 4):
+        state = np.asarray(cudaq.get_state(evolve, coefficients, words, time,
+                                           steps, order, rx_angle, ry_angle),
+                           dtype=np.complex128)
+        errors[order] = _phase_align_error(state, exact)
+
+    assert errors[2] < errors[1]
+    assert errors[4] < errors[2]
+    assert errors[1] < 2.0e-2
+    assert errors[2] < 6.0e-4
+    assert errors[4] < 5.0e-6
+
+
+def test_apply_trotter_kernel_error_scaling_tracks_order():
+    """Order-p Trotter error must scale ~ dt**p (fitted slope ~ -p)."""
+    hamiltonian = (0.37 * spin.x(0) - 0.22 * spin.z(1) +
+                   0.19 * spin.x(0) * spin.x(1) +
+                   0.41 * spin.y(0) * spin.y(1) + 0.13 * spin.z(0) * spin.x(1))
+    coefficients, words, identity, num_qubits = trotter.make_trotter_terms(
+        hamiltonian)
+
+    time = 0.7
+    rx_angle, ry_angle = 0.37, -0.52
+    ket = _two_qubit_product_state(rx_angle, ry_angle)
+    exact = _exact_evolve(coefficients, words, identity, time, ket)
+
+    @cudaq.kernel
+    def evolve(coeffs: list[float], paulis: list[cudaq.pauli_word], t: float,
+               n_steps: int, order: int, theta0: float, theta1: float):
+        q = cudaq.qvector(2)
+        rx(theta0, q[0])
+        ry(theta1, q[1])
+        trotter.apply_trotter(coeffs, paulis, t, n_steps, order, q)
+
+    step_counts = [1, 2, 4]
+    log_steps = np.log(np.array(step_counts, dtype=float))
+    for order in (1, 2, 4):
+        errors = []
+        for steps in step_counts:
+            state = np.asarray(cudaq.get_state(evolve, coefficients, words,
+                                               time, steps, order, rx_angle,
+                                               ry_angle),
+                               dtype=np.complex128)
+            errors.append(_phase_align_error(state, exact))
+        slope = np.polyfit(log_steps, np.log(np.array(errors)), 1)[0]
+        assert slope == pytest.approx(
+            -order,
+            abs=0.4), (f"order {order}: fitted scaling slope {slope:.3f} "
+                       f"is not close to -{order}")
+
+
+def test_apply_trotter_kernel_exact_for_commuting_hamiltonian():
+    """All-Z terms commute: every order/step count must be exact."""
+    hamiltonian = (0.5 * spin.z(0) + 0.4 * spin.z(1) +
+                   0.3 * spin.z(0) * spin.z(1))
+    coefficients, words, identity, num_qubits = trotter.make_trotter_terms(
+        hamiltonian)
+    assert identity == pytest.approx(0.0)
+
+    time = 0.7
+    rx_angle, ry_angle = 0.41, -0.33
+    ket = _two_qubit_product_state(rx_angle, ry_angle)
+    exact = _exact_evolve(coefficients, words, identity, time, ket)
+
+    @cudaq.kernel
+    def evolve(coeffs: list[float], paulis: list[cudaq.pauli_word], t: float,
+               n_steps: int, order: int, theta0: float, theta1: float):
+        q = cudaq.qvector(2)
+        rx(theta0, q[0])
+        ry(theta1, q[1])
+        trotter.apply_trotter(coeffs, paulis, t, n_steps, order, q)
+
+    for order in (1, 2, 4):
+        for steps in (1, 3):
+            state = np.asarray(cudaq.get_state(evolve, coefficients, words,
+                                               time, steps, order, rx_angle,
+                                               ry_angle),
+                               dtype=np.complex128)
+            assert _phase_align_error(state, exact) < 1.0e-9
+
+
+def test_apply_trotter_kernel_handles_four_qubit_hamiltonian_with_many_terms():
+    hamiltonian = (0.11 * spin.x(0) - 0.17 * spin.y(1) + 0.23 * spin.z(2) -
+                   0.29 * spin.x(3) + 0.31 * spin.x(0) * spin.x(1) +
+                   0.37 * spin.y(1) * spin.z(2) -
+                   0.41 * spin.z(0) * spin.x(3) +
+                   0.43 * spin.x(0) * spin.y(2) * spin.z(3) -
+                   0.47 * spin.y(0) * spin.y(1) * spin.x(2) +
+                   0.53 * spin.z(0) * spin.x(1) * spin.y(2) * spin.z(3))
+    coefficients, words, identity, num_qubits = trotter.make_trotter_terms(
+        hamiltonian)
+    assert num_qubits == 4
+    assert len(coefficients) > 8
+    assert len(coefficients) == len(words)
+
+    ket = np.zeros(16, dtype=np.complex128)
+    ket[0] = 1.0
+
+    @cudaq.kernel
+    def evolve(coeffs: list[float], paulis: list[cudaq.pauli_word], t: float,
+               steps: int, order: int):
+        q = cudaq.qvector(4)
+        trotter.apply_trotter(coeffs, paulis, t, steps, order, q)
+
+    state = np.asarray(cudaq.get_state(evolve, coefficients, words, 0.37, 2,
+                                       2),
+                       dtype=np.complex128)
+    expected = _simulate_trotter(coefficients, words, identity, num_qubits,
+                                 0.37, 2, 2, ket)
+    np.testing.assert_allclose(state, expected, atol=1e-6)
+
+
+# ----------------------------------------------------------------------------
+# Plan kernel factory and simulation-helper evolution
+# ----------------------------------------------------------------------------
+
+
+def test_plan_kernel_factory_evolves_the_zero_state():
+    hamiltonian = {"XI": 0.7, "IZ": 0.4, "XZ": 0.31, "YY": 0.23}
+    plan = trotter.make_trotter_plan(hamiltonian, time=0.8, steps=3, order=2)
+
+    ket0 = np.zeros(4, dtype=np.complex128)
+    ket0[0] = 1.0
+    factory_state = np.asarray(cudaq.get_state(plan.kernel()),
+                               dtype=np.complex128)
+    expected = _simulate_trotter(plan.coefficients, plan.words, 0.0,
+                                 plan.num_qubits, plan.time, plan.steps,
+                                 plan.order, ket0)
+    np.testing.assert_allclose(factory_state, expected, atol=1e-6)
+
+
+def test_sim_utils_evolve_includes_identity_phase():
+    hamiltonian = {"XI": 0.7, "IZ": 0.4, "II": -0.2}
+    plan = trotter.make_trotter_plan(hamiltonian, time=0.8, steps=64, order=2)
+
+    rng = np.random.default_rng(3)
+    ket = rng.normal(size=4) + 1.0j * rng.normal(size=4)
+    ket = (ket / np.linalg.norm(ket)).astype(np.complex128)
+
+    exact = _exact_evolve(plan.coefficients, plan.words,
+                          plan.identity_coefficient, plan.time, ket)
+    evolved = sim_utils.evolve(plan, ket)
+    # Direct comparison, NOT phase-aligned: evolve() reintroduces the
+    # identity phase the circuit primitive omits.
+    assert np.linalg.norm(evolved - exact) < 1e-3
+
+    without_phase = sim_utils.evolve(plan, ket, include_identity_phase=False)
+    assert np.linalg.norm(without_phase - exact) > 0.1
+
+
+def test_identity_only_plan_is_a_global_phase():
+    plan = trotter.make_trotter_plan({"II": -0.2}, time=0.5, steps=2)
+    assert plan.num_terms == 0
+
+    ket = np.array([0.5, 0.5, 0.5, 0.5], dtype=np.complex128)
+    evolved = sim_utils.evolve(plan, ket)
+    np.testing.assert_allclose(evolved,
+                               np.exp(0.1j) * ket,
+                               atol=1e-12)
+    np.testing.assert_allclose(sim_utils.evolve(plan, ket,
+                                                include_identity_phase=False),
+                               ket,
+                               atol=1e-12)
+
+
+# ----------------------------------------------------------------------------
+# _word_pairs_from_input: every accepted input form and every rejection
+# ----------------------------------------------------------------------------
+
+
+def test_word_pairs_from_mapping():
+    pairs, width = trotter._word_pairs_from_input(
+        {"XI": 0.7, "IZ": 0.4, "II": -0.2}, 1e-12)
+    assert width == 2
+    assert pairs == [(0.7, "XI"), (0.4, "IZ"), (-0.2, "II")]
+
+
+def test_word_pairs_from_pair_iterable():
+    pairs, width = trotter._word_pairs_from_input(
+        [(0.7, "XI"), (0.4, "IZ")], 1e-12)
+    assert width == 2
+    assert pairs == [(0.7, "XI"), (0.4, "IZ")]
+
+    # Tuples and generators normalize identically.
+    pairs_gen, width_gen = trotter._word_pairs_from_input(
+        ((c, w) for c, w in [(0.7, "XI"), (0.4, "IZ")]), 1e-12)
+    assert (pairs_gen, width_gen) == (pairs, width)
+
+
+def test_word_pairs_from_spin_operator():
+    hamiltonian = (0.7 * spin.x(0) + 0.4 * spin.z(1) -
+                   0.2 * cudaq.SpinOperator.from_word("II"))
+    pairs, width = trotter._word_pairs_from_input(hamiltonian, 1e-12)
+    assert width == 2
+    assert {word: coeff for coeff, word in pairs} == pytest.approx({
+        "XI": 0.7,
+        "IZ": 0.4,
+        "II": -0.2,
+    })
+
+
+def test_word_pairs_from_single_spin_term():
+    # An elementary product is not a full SpinOperator; it must be
+    # canonicalized to the same (coefficient, padded word) form.
+    pairs, width = trotter._word_pairs_from_input(0.5 * spin.y(2), 1e-12)
+    assert width == 3
+    assert pairs == [(0.5, "IIY")]
+
+
+def test_word_pairs_padding_uses_widest_term():
+    # A spin operator whose terms touch different qubit counts pads every
+    # word to the widest extent.
+    hamiltonian = 0.3 * spin.x(0) + 0.2 * spin.z(3)
+    pairs, width = trotter._word_pairs_from_input(hamiltonian, 1e-12)
+    assert width == 4
+    assert sorted(word for _, word in pairs) == ["IIIZ", "XIII"]
+
+
+def test_word_pairs_accepts_complex_within_tolerance():
+    pairs, _ = trotter._word_pairs_from_input({"X": 0.5 + 1e-14j}, 1e-12)
+    assert pairs == [(0.5, "X")]
+
+
+def test_word_pairs_rejections():
+    with pytest.raises(ValueError, match="real"):
+        trotter._word_pairs_from_input({"X": 0.5 + 0.3j}, 1e-12)
+    with pytest.raises(ValueError, match="real"):
+        trotter._word_pairs_from_input([(0.5j, "X")], 1e-12)
+    with pytest.raises(ValueError, match="real"):
+        trotter._word_pairs_from_input(0.5j * spin.x(0), 1e-12)
+    with pytest.raises(ValueError, match="same length"):
+        trotter._word_pairs_from_input({"XI": 0.5, "X": 0.3}, 1e-12)
+    with pytest.raises(ValueError, match="unsupported Pauli"):
+        trotter._word_pairs_from_input({"XQ": 0.5}, 1e-12)
+    with pytest.raises(TypeError):
+        trotter._word_pairs_from_input(42, 1e-12)
+
+
+def test_word_pairs_empty_mapping():
+    pairs, width = trotter._word_pairs_from_input({}, 1e-12)
+    assert pairs == [] and width == 0

--- a/tests/python/test_trotter.py
+++ b/tests/python/test_trotter.py
@@ -434,6 +434,36 @@ def test_apply_trotter_kernel_handles_four_qubit_hamiltonian_with_many_terms():
 # ----------------------------------------------------------------------------
 
 
+@cudaq.kernel
+def _product_prep(qubits: cudaq.qview):
+    rx(0.37, qubits[0])
+    ry(-0.52, qubits[1])
+
+
+def test_kernel_factory_accepts_state_prep_injection():
+    # With state_prep the factory returns a zero-argument, fully
+    # hardware-shaped circuit; pin it against state_kernel fed the same
+    # prepared state as data.
+    evolution = trotter.Trotter({"XI": 0.7, "IZ": 0.4, "XZ": 0.31})
+    ket = _two_qubit_product_state(0.37, -0.52)
+
+    via_prep = np.asarray(cudaq.get_state(
+        evolution.kernel(time=0.8, steps=3, order=2,
+                         state_prep=_product_prep)),
+                          dtype=np.complex128)
+    via_state = np.asarray(cudaq.get_state(
+        evolution.state_kernel(time=0.8, steps=3, order=2),
+        sim_utils.state_from(ket)),
+                           dtype=np.complex128)
+    np.testing.assert_allclose(via_prep, via_state, atol=1e-12)
+
+    counts = cudaq.sample(evolution.kernel(time=0.8,
+                                           steps=1,
+                                           state_prep=_product_prep),
+                          shots_count=100)
+    assert sum(counts.values()) == 100
+
+
 def test_kernel_factory_evolves_the_zero_state():
     hamiltonian = {"XI": 0.7, "IZ": 0.4, "XZ": 0.31, "YY": 0.23}
     evolution = trotter.Trotter(hamiltonian)

--- a/tests/python/test_trotter.py
+++ b/tests/python/test_trotter.py
@@ -21,6 +21,8 @@ from cudaq import spin
 
 from cudaq_algorithms import sim_utils, trotter
 
+from dense_references import dense_matrix, random_ket
+
 FOREST_RUTH_W1 = 1.3512071919596578
 FOREST_RUTH_W0 = -1.7024143839193153
 
@@ -95,20 +97,12 @@ def _simulate_trotter(coefficients,
     return state
 
 
-def _pauli_matrix(word):
-    dim = 2**len(str(word))
-    matrix = np.zeros((dim, dim), dtype=np.complex128)
-    for basis in range(dim):
-        vector = np.zeros(dim, dtype=np.complex128)
-        vector[basis] = 1.0
-        matrix[:, basis] = _apply_pauli_to_vector(word, vector)
-    return matrix
-
-
 def _exact_evolve(coefficients, words, identity, time, ket):
+    # Dense Pauli-sum reference shared with the other suites.
     matrix = identity * np.eye(ket.size, dtype=np.complex128)
-    for coefficient, word in zip(coefficients, words):
-        matrix += coefficient * _pauli_matrix(str(word))
+    if words:
+        matrix = matrix + dense_matrix(list(zip(coefficients, words)),
+                                       len(str(words[0])))
     eigenvalues, eigenvectors = np.linalg.eigh(matrix)
     return eigenvectors @ (np.exp(-1.0j * time * eigenvalues) *
                            (eigenvectors.conj().T @ ket))
@@ -123,6 +117,16 @@ def _two_qubit_product_state(rx_angle, ry_angle):
     return np.array(
         [q0[basis & 1] * q1[(basis >> 1) & 1] for basis in range(4)],
         dtype=np.complex128)
+
+
+@cudaq.kernel
+def _evolve_prepared(coeffs: list[float], paulis: list[cudaq.pauli_word],
+                     t: float, n_steps: int, order: int, theta0: float,
+                     theta1: float):
+    q = cudaq.qvector(2)
+    rx(theta0, q[0])
+    ry(theta1, q[1])
+    trotter.apply_trotter(coeffs, paulis, t, n_steps, order, q)
 
 
 def _phase_align_error(actual, expected):
@@ -176,7 +180,7 @@ def test_make_trotter_terms_accepts_dict_and_pairs():
 def test_make_trotter_terms_validation():
     with pytest.raises(ValueError, match="non-negative"):
         trotter.make_trotter_terms(spin.x(0), coefficient_tolerance=-1.0)
-    with pytest.raises(ValueError, match="real"):
+    with pytest.raises(ValueError, match="complex"):
         trotter.make_trotter_terms({"X": 0.5 + 0.3j})
     with pytest.raises(ValueError, match="same length"):
         trotter.make_trotter_terms({"XI": 0.5, "X": 0.3})
@@ -328,42 +332,6 @@ def test_apply_trotter_kernel_matches_reference_for_orders():
         np.testing.assert_allclose(state, expected, atol=1e-6)
 
 
-def test_apply_trotter_kernel_orders_track_exact_evolution():
-    hamiltonian = (0.37 * spin.x(0) - 0.22 * spin.z(1) +
-                   0.19 * spin.x(0) * spin.x(1) +
-                   0.41 * spin.y(0) * spin.y(1) + 0.13 * spin.z(0) * spin.x(1))
-    coefficients, words, identity, num_qubits = trotter.make_trotter_terms(
-        hamiltonian)
-    assert identity == pytest.approx(0.0)
-    assert num_qubits == 2
-
-    time, steps = 0.7, 4
-    rx_angle, ry_angle = 0.37, -0.52
-    ket = _two_qubit_product_state(rx_angle, ry_angle)
-    exact = _exact_evolve(coefficients, words, identity, time, ket)
-
-    @cudaq.kernel
-    def evolve(coeffs: list[float], paulis: list[cudaq.pauli_word], t: float,
-               n_steps: int, order: int, theta0: float, theta1: float):
-        q = cudaq.qvector(2)
-        rx(theta0, q[0])
-        ry(theta1, q[1])
-        trotter.apply_trotter(coeffs, paulis, t, n_steps, order, q)
-
-    errors = {}
-    for order in (1, 2, 4):
-        state = np.asarray(cudaq.get_state(evolve, coefficients, words, time,
-                                           steps, order, rx_angle, ry_angle),
-                           dtype=np.complex128)
-        errors[order] = _phase_align_error(state, exact)
-
-    assert errors[2] < errors[1]
-    assert errors[4] < errors[2]
-    assert errors[1] < 2.0e-2
-    assert errors[2] < 6.0e-4
-    assert errors[4] < 5.0e-6
-
-
 def test_apply_trotter_kernel_error_scaling_tracks_order():
     """Order-p Trotter error must scale ~ dt**p (fitted slope ~ -p)."""
     hamiltonian = (0.37 * spin.x(0) - 0.22 * spin.z(1) +
@@ -377,29 +345,31 @@ def test_apply_trotter_kernel_error_scaling_tracks_order():
     ket = _two_qubit_product_state(rx_angle, ry_angle)
     exact = _exact_evolve(coefficients, words, identity, time, ket)
 
-    @cudaq.kernel
-    def evolve(coeffs: list[float], paulis: list[cudaq.pauli_word], t: float,
-               n_steps: int, order: int, theta0: float, theta1: float):
-        q = cudaq.qvector(2)
-        rx(theta0, q[0])
-        ry(theta1, q[1])
-        trotter.apply_trotter(coeffs, paulis, t, n_steps, order, q)
-
     step_counts = [1, 2, 4]
     log_steps = np.log(np.array(step_counts, dtype=float))
+    error_at_four_steps = {}
     for order in (1, 2, 4):
         errors = []
         for steps in step_counts:
-            state = np.asarray(cudaq.get_state(evolve, coefficients, words,
-                                               time, steps, order, rx_angle,
-                                               ry_angle),
+            state = np.asarray(cudaq.get_state(_evolve_prepared, coefficients,
+                                               words, time, steps, order,
+                                               rx_angle, ry_angle),
                                dtype=np.complex128)
             errors.append(_phase_align_error(state, exact))
+        error_at_four_steps[order] = errors[-1]
         slope = np.polyfit(log_steps, np.log(np.array(errors)), 1)[0]
         assert slope == pytest.approx(
             -order,
             abs=0.4), (f"order {order}: fitted scaling slope {slope:.3f} "
                        f"is not close to -{order}")
+
+    # Fixed-tolerance checks at steps=4 (folded from a separate test that
+    # re-ran these exact launches): higher order strictly wins.
+    assert error_at_four_steps[2] < error_at_four_steps[1]
+    assert error_at_four_steps[4] < error_at_four_steps[2]
+    assert error_at_four_steps[1] < 2.0e-2
+    assert error_at_four_steps[2] < 6.0e-4
+    assert error_at_four_steps[4] < 5.0e-6
 
 
 def test_apply_trotter_kernel_exact_for_commuting_hamiltonian():
@@ -415,19 +385,11 @@ def test_apply_trotter_kernel_exact_for_commuting_hamiltonian():
     ket = _two_qubit_product_state(rx_angle, ry_angle)
     exact = _exact_evolve(coefficients, words, identity, time, ket)
 
-    @cudaq.kernel
-    def evolve(coeffs: list[float], paulis: list[cudaq.pauli_word], t: float,
-               n_steps: int, order: int, theta0: float, theta1: float):
-        q = cudaq.qvector(2)
-        rx(theta0, q[0])
-        ry(theta1, q[1])
-        trotter.apply_trotter(coeffs, paulis, t, n_steps, order, q)
-
     for order in (1, 2, 4):
         for steps in (1, 3):
-            state = np.asarray(cudaq.get_state(evolve, coefficients, words,
-                                               time, steps, order, rx_angle,
-                                               ry_angle),
+            state = np.asarray(cudaq.get_state(_evolve_prepared, coefficients,
+                                               words, time, steps, order,
+                                               rx_angle, ry_angle),
                                dtype=np.complex128)
             assert _phase_align_error(state, exact) < 1.0e-9
 
@@ -486,9 +448,7 @@ def test_sim_utils_evolve_includes_identity_phase():
     hamiltonian = {"XI": 0.7, "IZ": 0.4, "II": -0.2}
     evolution = trotter.Trotter(hamiltonian)
 
-    rng = np.random.default_rng(3)
-    ket = rng.normal(size=4) + 1.0j * rng.normal(size=4)
-    ket = (ket / np.linalg.norm(ket)).astype(np.complex128)
+    ket = random_ket(2, seed=3)
 
     exact = _exact_evolve(evolution.coefficients, evolution.words,
                           evolution.identity_coefficient, 0.8, ket)
@@ -523,85 +483,92 @@ def test_identity_only_hamiltonian_is_a_global_phase():
 
 
 # ----------------------------------------------------------------------------
-# _word_pairs_from_input: every accepted input form and every rejection
+# Input forms, degenerate inputs, and validation (public API)
 # ----------------------------------------------------------------------------
 
 
-def test_word_pairs_from_mapping():
-    pairs, width = trotter._word_pairs_from_input(
-        {
-            "XI": 0.7,
-            "IZ": 0.4,
-            "II": -0.2
-        }, 1e-12)
-    assert width == 2
-    assert pairs == [(0.7, "XI"), (0.4, "IZ"), (-0.2, "II")]
+def test_generator_input_normalizes_like_pairs():
+    via_list = trotter.make_trotter_terms([(0.7, "XI"), (0.4, "IZ")])
+    via_generator = trotter.make_trotter_terms(
+        (c, w) for c, w in [(0.7, "XI"), (0.4, "IZ")])
+    assert via_generator == via_list
 
 
-def test_word_pairs_from_pair_iterable():
-    pairs, width = trotter._word_pairs_from_input([(0.7, "XI"), (0.4, "IZ")],
-                                                  1e-12)
-    assert width == 2
-    assert pairs == [(0.7, "XI"), (0.4, "IZ")]
-
-    # Tuples and generators normalize identically.
-    pairs_gen, width_gen = trotter._word_pairs_from_input(
-        ((c, w) for c, w in [(0.7, "XI"), (0.4, "IZ")]), 1e-12)
-    assert (pairs_gen, width_gen) == (pairs, width)
+def test_spin_operator_padding_uses_widest_term():
+    coefficients, words, _, num_qubits = trotter.make_trotter_terms(
+        0.3 * spin.x(0) + 0.2 * spin.z(3))
+    assert num_qubits == 4
+    assert sorted(words) == ["IIIZ", "XIII"]
 
 
-def test_word_pairs_from_spin_operator():
-    hamiltonian = (0.7 * spin.x(0) + 0.4 * spin.z(1) -
-                   0.2 * cudaq.SpinOperator.from_word("II"))
-    pairs, width = trotter._word_pairs_from_input(hamiltonian, 1e-12)
-    assert width == 2
-    assert {
-        word: coeff
-        for coeff, word in pairs
-    } == pytest.approx({
-        "XI": 0.7,
-        "IZ": 0.4,
-        "II": -0.2,
+def test_complex_noise_tolerance_matches_pauli_lcu():
+    # One validation across the package: the same imaginary-noise
+    # tolerance accepts this input in both primitives.
+    from cudaq_algorithms import PauliLCU
+
+    coefficients, words, _, _ = trotter.make_trotter_terms({"X": 0.5 + 1e-11j})
+    assert coefficients == [pytest.approx(0.5)] and words == ["X"]
+    assert PauliLCU({"X": 0.5 + 1e-11j}).alpha == pytest.approx(0.5)
+
+
+def test_empty_hamiltonian_rejected():
+    # Regression: an accepted empty Hamiltonian produced a 0-qubit kernel
+    # whose launch crashed the interpreter.
+    with pytest.raises(ValueError, match="no terms"):
+        trotter.Trotter({})
+    with pytest.raises(ValueError, match="no terms"):
+        trotter.Trotter([])
+    with pytest.raises(ValueError, match="at least one qubit"):
+        trotter.Trotter({"": 0.5})
+
+
+def test_string_hamiltonian_rejected_with_type_error():
+    with pytest.raises(TypeError, match="spin operator"):
+        trotter.Trotter("XZ")
+
+
+def test_zero_coefficient_terms_dropped():
+    coefficients, words, _, _ = trotter.make_trotter_terms({
+        "XI": 0.0,
+        "IZ": 0.4
     })
+    assert words == ["IZ"]
+    resources = trotter.Trotter({
+        "XI": 0.0,
+        "IZ": 0.4
+    }).resources(steps=2, order=2)
+    assert resources.num_terms == 1
+    assert resources.pauli_rotations == 4
 
 
-def test_word_pairs_from_single_spin_term():
-    # An elementary product is not a full SpinOperator; it must be
-    # canonicalized to the same (coefficient, padded word) form.
-    pairs, width = trotter._word_pairs_from_input(0.5 * spin.y(2), 1e-12)
-    assert width == 3
-    assert pairs == [(0.5, "IIY")]
+def test_kernel_rejects_fractional_steps():
+    # Parity with Walk.kernel(power=...): no silent truncation.
+    evolution = trotter.Trotter({"XI": 0.7, "IZ": 0.4})
+    with pytest.raises(ValueError, match="steps"):
+        evolution.kernel(time=0.5, steps=2.9)
+    with pytest.raises(ValueError, match="steps"):
+        evolution.state_kernel(time=0.5, steps=2.9)
 
 
-def test_word_pairs_padding_uses_widest_term():
-    # A spin operator whose terms touch different qubit counts pads every
-    # word to the widest extent.
-    hamiltonian = 0.3 * spin.x(0) + 0.2 * spin.z(3)
-    pairs, width = trotter._word_pairs_from_input(hamiltonian, 1e-12)
-    assert width == 4
-    assert sorted(word for _, word in pairs) == ["IIIZ", "XIII"]
-
-
-def test_word_pairs_accepts_complex_within_tolerance():
-    pairs, _ = trotter._word_pairs_from_input({"X": 0.5 + 1e-14j}, 1e-12)
-    assert pairs == [(0.5, "X")]
-
-
-def test_word_pairs_rejections():
-    with pytest.raises(ValueError, match="real"):
-        trotter._word_pairs_from_input({"X": 0.5 + 0.3j}, 1e-12)
-    with pytest.raises(ValueError, match="real"):
-        trotter._word_pairs_from_input([(0.5j, "X")], 1e-12)
-    with pytest.raises(ValueError, match="real"):
-        trotter._word_pairs_from_input(0.5j * spin.x(0), 1e-12)
-    with pytest.raises(ValueError, match="same length"):
-        trotter._word_pairs_from_input({"XI": 0.5, "X": 0.3}, 1e-12)
-    with pytest.raises(ValueError, match="unsupported Pauli"):
-        trotter._word_pairs_from_input({"XQ": 0.5}, 1e-12)
+def test_resources_requires_explicit_parameters():
+    # No defaults: the estimate can never silently describe a different
+    # circuit than the kernel that was built.
+    evolution = trotter.Trotter({"XI": 0.7, "IZ": 0.4})
     with pytest.raises(TypeError):
-        trotter._word_pairs_from_input(42, 1e-12)
+        evolution.resources()
 
 
-def test_word_pairs_empty_mapping():
-    pairs, width = trotter._word_pairs_from_input({}, 1e-12)
-    assert pairs == [] and width == 0
+def test_sim_utils_evolve_validates_parameters():
+    # Regression: evolve() previously coerced silently and the kernel
+    # guard turned invalid parameters into a no-op circuit, returning the
+    # unevolved state as if it were the evolution result.
+    evolution = trotter.Trotter({"XI": 0.7, "IZ": 0.4})
+    ket = random_ket(2, seed=5)
+    with pytest.raises(ValueError, match="steps"):
+        sim_utils.evolve(evolution, ket, time=0.8, steps=0)
+    with pytest.raises(ValueError, match="order"):
+        sim_utils.evolve(evolution, ket, time=0.8, order=3)
+    with pytest.raises(ValueError, match="finite"):
+        sim_utils.evolve(evolution, ket, time=float("nan"))
+    with pytest.raises(ValueError, match="dimension"):
+        sim_utils.evolve(evolution, np.ones(8) / np.sqrt(8), time=0.8)

--- a/tests/python/test_trotter.py
+++ b/tests/python/test_trotter.py
@@ -24,7 +24,6 @@ from cudaq_algorithms import sim_utils, trotter
 FOREST_RUTH_W1 = 1.3512071919596578
 FOREST_RUTH_W0 = -1.7024143839193153
 
-
 # ----------------------------------------------------------------------------
 # Dense references (ported verbatim from the upstream test file)
 # ----------------------------------------------------------------------------
@@ -67,8 +66,15 @@ def _second_order_step(vector, coefficients, words, tau):
     return state
 
 
-def _simulate_trotter(coefficients, words, identity, num_qubits, time, steps,
-                      order, ket, include_identity=True):
+def _simulate_trotter(coefficients,
+                      words,
+                      identity,
+                      num_qubits,
+                      time,
+                      steps,
+                      order,
+                      ket,
+                      include_identity=True):
     state = np.array(ket, dtype=np.complex128, copy=True)
     dt = time / steps
     for _ in range(steps):
@@ -157,11 +163,7 @@ def test_make_trotter_terms_accepts_single_spin_term():
 
 
 def test_make_trotter_terms_accepts_dict_and_pairs():
-    from_dict = trotter.make_trotter_terms({
-        "XI": 0.7,
-        "IZ": 0.4,
-        "II": -0.2
-    })
+    from_dict = trotter.make_trotter_terms({"XI": 0.7, "IZ": 0.4, "II": -0.2})
     from_pairs = trotter.make_trotter_terms([(0.7, "XI"), (0.4, "IZ"),
                                              (-0.2, "II")])
     for coefficients, words, identity, num_qubits in (from_dict, from_pairs):
@@ -202,7 +204,8 @@ def test_product_formula_reference_improves_with_order():
     time, steps = 0.8, 2
     exact = _exact_evolve(coefficients, words, identity, time, ket)
     errors = {
-        order: _phase_align_error(
+        order:
+        _phase_align_error(
             _simulate_trotter(coefficients, words, identity, num_qubits, time,
                               steps, order, ket), exact)
         for order in (1, 2, 4)
@@ -471,11 +474,11 @@ def test_kernel_factory_evolves_the_zero_state():
 
     ket0 = np.zeros(4, dtype=np.complex128)
     ket0[0] = 1.0
-    factory_state = np.asarray(
-        cudaq.get_state(evolution.kernel(time=0.8, steps=3, order=2)),
-        dtype=np.complex128)
-    expected = _simulate_trotter(evolution.coefficients, evolution.words,
-                                 0.0, evolution.num_qubits, 0.8, 3, 2, ket0)
+    factory_state = np.asarray(cudaq.get_state(
+        evolution.kernel(time=0.8, steps=3, order=2)),
+                               dtype=np.complex128)
+    expected = _simulate_trotter(evolution.coefficients, evolution.words, 0.0,
+                                 evolution.num_qubits, 0.8, 3, 2, ket0)
     np.testing.assert_allclose(factory_state, expected, atol=1e-6)
 
 
@@ -494,8 +497,12 @@ def test_sim_utils_evolve_includes_identity_phase():
     # identity phase the circuit primitive omits.
     assert np.linalg.norm(evolved - exact) < 1e-3
 
-    without_phase = sim_utils.evolve(evolution, ket, time=0.8, steps=64,
-                                     order=2, include_identity_phase=False)
+    without_phase = sim_utils.evolve(evolution,
+                                     ket,
+                                     time=0.8,
+                                     steps=64,
+                                     order=2,
+                                     include_identity_phase=False)
     assert np.linalg.norm(without_phase - exact) > 0.1
 
 
@@ -505,10 +512,10 @@ def test_identity_only_hamiltonian_is_a_global_phase():
 
     ket = np.array([0.5, 0.5, 0.5, 0.5], dtype=np.complex128)
     evolved = sim_utils.evolve(evolution, ket, time=0.5, steps=2)
-    np.testing.assert_allclose(evolved,
-                               np.exp(0.1j) * ket,
-                               atol=1e-12)
-    np.testing.assert_allclose(sim_utils.evolve(evolution, ket, time=0.5,
+    np.testing.assert_allclose(evolved, np.exp(0.1j) * ket, atol=1e-12)
+    np.testing.assert_allclose(sim_utils.evolve(evolution,
+                                                ket,
+                                                time=0.5,
                                                 steps=2,
                                                 include_identity_phase=False),
                                ket,
@@ -522,14 +529,18 @@ def test_identity_only_hamiltonian_is_a_global_phase():
 
 def test_word_pairs_from_mapping():
     pairs, width = trotter._word_pairs_from_input(
-        {"XI": 0.7, "IZ": 0.4, "II": -0.2}, 1e-12)
+        {
+            "XI": 0.7,
+            "IZ": 0.4,
+            "II": -0.2
+        }, 1e-12)
     assert width == 2
     assert pairs == [(0.7, "XI"), (0.4, "IZ"), (-0.2, "II")]
 
 
 def test_word_pairs_from_pair_iterable():
-    pairs, width = trotter._word_pairs_from_input(
-        [(0.7, "XI"), (0.4, "IZ")], 1e-12)
+    pairs, width = trotter._word_pairs_from_input([(0.7, "XI"), (0.4, "IZ")],
+                                                  1e-12)
     assert width == 2
     assert pairs == [(0.7, "XI"), (0.4, "IZ")]
 
@@ -544,7 +555,10 @@ def test_word_pairs_from_spin_operator():
                    0.2 * cudaq.SpinOperator.from_word("II"))
     pairs, width = trotter._word_pairs_from_input(hamiltonian, 1e-12)
     assert width == 2
-    assert {word: coeff for coeff, word in pairs} == pytest.approx({
+    assert {
+        word: coeff
+        for coeff, word in pairs
+    } == pytest.approx({
         "XI": 0.7,
         "IZ": 0.4,
         "II": -0.2,

--- a/tests/python/test_trotter.py
+++ b/tests/python/test_trotter.py
@@ -516,6 +516,33 @@ def test_identity_only_hamiltonian_is_a_global_phase():
                                atol=1e-12)
 
 
+def test_identity_only_hamiltonian_kernel_factory_branches():
+    # The empty-words branches of kernel() exist as workarounds for the
+    # captured-empty-list marshaling failure
+    # (https://github.com/NVIDIA/cuda-quantum/issues/4847); execute both
+    # so a refactor cannot silently reintroduce the capture.
+    evolution = trotter.Trotter({"II": -0.2})
+
+    # Without state_prep: the circuit is the identity on |0...0> (the
+    # identity phase is documented as not included in circuits).
+    identity_kernel = evolution.kernel(time=0.5, steps=2)
+    state = np.asarray(cudaq.get_state(identity_kernel), dtype=np.complex128)
+    expected = np.zeros(4, dtype=np.complex128)
+    expected[0] = 1.0
+    np.testing.assert_allclose(state, expected, atol=1e-12)
+    counts = cudaq.sample(identity_kernel, shots_count=50)
+    assert sum(counts.values()) == 50
+
+    # With state_prep: the circuit is exactly the preparation.
+    prep_kernel = evolution.kernel(time=0.5, steps=2, state_prep=_product_prep)
+    via_prep = np.asarray(cudaq.get_state(prep_kernel), dtype=np.complex128)
+    np.testing.assert_allclose(via_prep,
+                               _two_qubit_product_state(0.37, -0.52),
+                               atol=1e-12)
+    counts = cudaq.sample(prep_kernel, shots_count=50)
+    assert sum(counts.values()) == 50
+
+
 # ----------------------------------------------------------------------------
 # Input forms, degenerate inputs, and validation (public API)
 # ----------------------------------------------------------------------------

--- a/tests/python/test_trotter.py
+++ b/tests/python/test_trotter.py
@@ -212,42 +212,40 @@ def test_product_formula_reference_improves_with_order():
 
 
 # ----------------------------------------------------------------------------
-# Planning, ordering, resources
+# Term ordering, validation, resources
 # ----------------------------------------------------------------------------
 
 
-def test_make_trotter_plan_orders_terms_and_estimates_resources():
+def test_trotter_orders_terms_and_estimates_resources():
     hamiltonian = (0.1 * spin.x(0) + 0.7 * spin.z(1) +
                    0.4 * spin.x(0) * spin.z(1) -
                    0.2 * cudaq.SpinOperator.from_word("II"))
-    plan = trotter.make_trotter_plan(
+    evolution = trotter.Trotter(
         hamiltonian,
-        time=0.6,
-        steps=3,
-        order=4,
         ordering=trotter.TrotterOrdering.COEFFICIENT_MAGNITUDE_DESCENDING)
 
-    assert plan.steps == 3
-    assert plan.order == 4
-    assert plan.identity_coefficient == pytest.approx(-0.2)
-    assert plan.coefficients == pytest.approx([0.7, 0.4, 0.1])
-    assert [str(word) for word in plan.words] == ["IZ", "XZ", "XI"]
+    assert evolution.identity_coefficient == pytest.approx(-0.2)
+    assert evolution.coefficients == pytest.approx([0.7, 0.4, 0.1])
+    assert [str(word) for word in evolution.words] == ["IZ", "XZ", "XI"]
 
-    resources = plan.resources()
+    resources = evolution.resources(steps=3, order=4)
     assert resources.num_terms == 3
+    assert resources.steps == 3
+    assert resources.order == 4
     assert resources.pauli_rotations == 3 * 3 * 6
     assert resources.estimated_cx_count == 2 * 3 * 6
 
 
-def test_trotter_plan_rejects_invalid_options():
+def test_trotter_rejects_invalid_options():
+    evolution = trotter.Trotter(spin.x(0))
     with pytest.raises(ValueError, match="steps"):
-        trotter.make_trotter_plan(spin.x(0), time=0.1, steps=0)
+        evolution.kernel(time=0.1, steps=0)
     with pytest.raises(ValueError, match="order"):
-        trotter.make_trotter_plan(spin.x(0), time=0.1, order=3)
+        evolution.kernel(time=0.1, order=3)
     with pytest.raises(ValueError, match="unsupported"):
-        trotter.make_trotter_plan(spin.x(0), time=0.1, ordering="bogus")
+        trotter.Trotter(spin.x(0), ordering="bogus")
     with pytest.raises(ValueError, match="finite"):
-        trotter.make_trotter_plan(spin.x(0), time=float("nan"))
+        evolution.kernel(time=float("nan"))
 
 
 def test_estimate_trotter_resources_accepts_flattened_terms():
@@ -463,53 +461,55 @@ def test_apply_trotter_kernel_handles_four_qubit_hamiltonian_with_many_terms():
 
 
 # ----------------------------------------------------------------------------
-# Plan kernel factory and simulation-helper evolution
+# Kernel factory and simulation-helper evolution
 # ----------------------------------------------------------------------------
 
 
-def test_plan_kernel_factory_evolves_the_zero_state():
+def test_kernel_factory_evolves_the_zero_state():
     hamiltonian = {"XI": 0.7, "IZ": 0.4, "XZ": 0.31, "YY": 0.23}
-    plan = trotter.make_trotter_plan(hamiltonian, time=0.8, steps=3, order=2)
+    evolution = trotter.Trotter(hamiltonian)
 
     ket0 = np.zeros(4, dtype=np.complex128)
     ket0[0] = 1.0
-    factory_state = np.asarray(cudaq.get_state(plan.kernel()),
-                               dtype=np.complex128)
-    expected = _simulate_trotter(plan.coefficients, plan.words, 0.0,
-                                 plan.num_qubits, plan.time, plan.steps,
-                                 plan.order, ket0)
+    factory_state = np.asarray(
+        cudaq.get_state(evolution.kernel(time=0.8, steps=3, order=2)),
+        dtype=np.complex128)
+    expected = _simulate_trotter(evolution.coefficients, evolution.words,
+                                 0.0, evolution.num_qubits, 0.8, 3, 2, ket0)
     np.testing.assert_allclose(factory_state, expected, atol=1e-6)
 
 
 def test_sim_utils_evolve_includes_identity_phase():
     hamiltonian = {"XI": 0.7, "IZ": 0.4, "II": -0.2}
-    plan = trotter.make_trotter_plan(hamiltonian, time=0.8, steps=64, order=2)
+    evolution = trotter.Trotter(hamiltonian)
 
     rng = np.random.default_rng(3)
     ket = rng.normal(size=4) + 1.0j * rng.normal(size=4)
     ket = (ket / np.linalg.norm(ket)).astype(np.complex128)
 
-    exact = _exact_evolve(plan.coefficients, plan.words,
-                          plan.identity_coefficient, plan.time, ket)
-    evolved = sim_utils.evolve(plan, ket)
+    exact = _exact_evolve(evolution.coefficients, evolution.words,
+                          evolution.identity_coefficient, 0.8, ket)
+    evolved = sim_utils.evolve(evolution, ket, time=0.8, steps=64, order=2)
     # Direct comparison, NOT phase-aligned: evolve() reintroduces the
     # identity phase the circuit primitive omits.
     assert np.linalg.norm(evolved - exact) < 1e-3
 
-    without_phase = sim_utils.evolve(plan, ket, include_identity_phase=False)
+    without_phase = sim_utils.evolve(evolution, ket, time=0.8, steps=64,
+                                     order=2, include_identity_phase=False)
     assert np.linalg.norm(without_phase - exact) > 0.1
 
 
-def test_identity_only_plan_is_a_global_phase():
-    plan = trotter.make_trotter_plan({"II": -0.2}, time=0.5, steps=2)
-    assert plan.num_terms == 0
+def test_identity_only_hamiltonian_is_a_global_phase():
+    evolution = trotter.Trotter({"II": -0.2})
+    assert evolution.num_terms == 0
 
     ket = np.array([0.5, 0.5, 0.5, 0.5], dtype=np.complex128)
-    evolved = sim_utils.evolve(plan, ket)
+    evolved = sim_utils.evolve(evolution, ket, time=0.5, steps=2)
     np.testing.assert_allclose(evolved,
                                np.exp(0.1j) * ket,
                                atol=1e-12)
-    np.testing.assert_allclose(sim_utils.evolve(plan, ket,
+    np.testing.assert_allclose(sim_utils.evolve(evolution, ket, time=0.5,
+                                                steps=2,
                                                 include_identity_phase=False),
                                ket,
                                atol=1e-12)

--- a/tests/python/test_trotter.py
+++ b/tests/python/test_trotter.py
@@ -182,6 +182,10 @@ def test_make_trotter_terms_validation():
         trotter.make_trotter_terms(spin.x(0), coefficient_tolerance=-1.0)
     with pytest.raises(ValueError, match="complex"):
         trotter.make_trotter_terms({"X": 0.5 + 0.3j})
+    with pytest.raises(ValueError, match="complex"):
+        trotter.make_trotter_terms([(0.5j, "X")])
+    with pytest.raises(ValueError, match="complex"):
+        trotter.make_trotter_terms(0.5j * spin.x(0))
     with pytest.raises(ValueError, match="same length"):
         trotter.make_trotter_terms({"XI": 0.5, "X": 0.3})
     with pytest.raises(ValueError, match="unsupported Pauli"):
@@ -525,6 +529,8 @@ def test_empty_hamiltonian_rejected():
 def test_string_hamiltonian_rejected_with_type_error():
     with pytest.raises(TypeError, match="spin operator"):
         trotter.Trotter("XZ")
+    with pytest.raises(TypeError, match="spin operator"):
+        trotter.Trotter(bytearray(b"XZ"))
 
 
 def test_zero_coefficient_terms_dropped():
@@ -533,6 +539,14 @@ def test_zero_coefficient_terms_dropped():
         "IZ": 0.4
     })
     assert words == ["IZ"]
+    # Exactly-zero terms are dropped even when the tolerance filter is
+    # disabled entirely.
+    _, words_no_tolerance, _, _ = trotter.make_trotter_terms(
+        {
+            "XI": 0.0,
+            "IZ": 0.4
+        }, coefficient_tolerance=0.0)
+    assert words_no_tolerance == ["IZ"]
     resources = trotter.Trotter({
         "XI": 0.0,
         "IZ": 0.4
@@ -572,3 +586,7 @@ def test_sim_utils_evolve_validates_parameters():
         sim_utils.evolve(evolution, ket, time=float("nan"))
     with pytest.raises(ValueError, match="dimension"):
         sim_utils.evolve(evolution, np.ones(8) / np.sqrt(8), time=0.8)
+    with pytest.raises(ValueError, match="1-D"):
+        sim_utils.evolve(evolution,
+                         np.eye(2, dtype=np.complex128) / np.sqrt(2),
+                         time=0.8)


### PR DESCRIPTION
## Summary

This PR adds **Suzuki-Trotter product formulas** as a peer primitive to the
LCU/qubitization/QSVT stack from #12: term extraction and ordering,
resource estimation, kernel factories, and the composable `apply_trotter`
device kernel, supporting first-, second- (default), and fourth-order
(Forest-Ruth) formulas.

## The primitive

```python
from cudaq_algorithms import Trotter

evolution = Trotter(hamiltonian)     # dict, SpinOperator/term, or
                                     # (coeff, word) pairs — extracted,
                                     # validated, and ordered once

kernel = evolution.kernel(time=0.8, steps=4, order=2)
# -> zero-argument @cudaq.kernel: prepares |0...0> and evolves it
# (pass directly to cudaq.sample / cudaq.observe / cudaq.get_state)

state_kernel = evolution.state_kernel(time=0.8, steps=4)
# -> @cudaq.kernel(state): evolves an arbitrary initial cudaq.State
# (the input-loading path sim_utils.evolve uses)

prepared = evolution.kernel(time=0.8, steps=4, state_prep=my_prep)
# -> zero-argument circuit composing a (qubits: qview) state-prep
#    kernel with the evolution: fully hardware-shaped, no statevector

estimate = evolution.resources(steps=4, order=2)  # TrotterResourceEstimate
evolution.words, evolution.coefficients, evolution.identity_coefficient
```

Same construction idiom as the other primitives — the object holds the
Hamiltonian, the factory calls hold the evolution choices — so
`Trotter(H).kernel(time, steps, order)` reads exactly like
`Walk(enc).kernel(power)` and `QSVT(enc).kernel(sequence)`.

- **Orders 1 / 2 / 4:** first-order sweeps, symmetric (Strang) splitting,
  and Forest-Ruth (three symmetric sub-steps with time fractions
  `w1 = 1/(2 - 2^(1/3))`, `w0 = 1 - 2*w1`, precomputed constants since
  kernels cannot evaluate cube roots).
- **Identity terms:** the circuit implements the product formula for the
  non-identity part only; `identity_coefficient` reports the omitted
  global phase (a real relative phase for controlled/interference use),
  and the simulation helper reintroduces it.
- **Term ordering:** `TrotterOrdering.PRESERVE_INPUT` (default) or
  `COEFFICIENT_MAGNITUDE_DESCENDING` (stable sort).
- **Resources:** `resources(steps, order)` — both parameters required, so
  an estimate can never silently describe a different circuit than the
  kernel that was built. Rotation counts and a CNOT-decomposition proxy,
  with no execution.
- **Composition escape hatch:** `trotter.apply_trotter(coeffs, words, t,
  steps, order, qubits)` composes inside user kernels (module namespace,
  matching the export policy from #12).
- **State-preparation injection:** `kernel(..., state_prep=my_prep)`
  composes a `(qubits: cudaq.qview)` preparation kernel with the
  evolution into one zero-argument circuit (the same parameter exists on
  the LCU/qubitization/QSVT factories).
- **Simulation helper:** `sim_utils.evolve(evolution, ket, time, steps,
  order)` delegates to `state_kernel` — one home for validation and
  marshaling — and reintroduces the identity phase.

## Testing

**27 Trotter tests** (full suite across the package: 76; with the compiled
extension: 96 + 1 skip). Coverage:

- Correctness against two independent references: exact matrix
  exponentials via diagonalization (using the shared dense-reference
  helpers), and an explicit per-order Pauli-rotation stepper.
- Per-order error thresholds and asymptotic error-scaling slope fits
  (order-p error ~ dt^p for p = 1, 2, 4).
- Exactness for commuting Hamiltonians; a 14-term 4-qubit chemistry-style
  Hamiltonian; kernel interop with flattened arguments composed in user
  kernels.
- Identity/global-phase handling through both the kernel and
  `sim_utils.evolve` paths.
- Every accepted Hamiltonian input form plus rejection tests for every
  validation rule above (including regression tests for a degenerate
  empty-Hamiltonian crash and a silently-unvalidated simulation path
  caught during pre-review hardening).

## Examples and docs

- `examples/hamiltonian_simulation/trotter_chemistry.py` — chemistry-style
  Hamiltonian evolved two ways (the one-call simulation helper, and
  `apply_trotter` composed in a user kernel with state preparation),
  validated against the exact matrix exponential.
- `docs/trotter.md` — `Trotter` usage, order semantics, identity-phase
  behavior, composition, the simulation/hardware split, and one
  deliberately deferred circuit-level optimization (merging back-to-back
  half-rotations at sweep boundaries) documented as future work.