### PR TITLE
Add state-preparation injection to the primitive kernel factories

### DIFF
--- a/docs/pauli_lcu_qsvt.md
+++ b/docs/pauli_lcu_qsvt.md
@@ -91,6 +91,31 @@ test oracle.
 Phase *generation* stays external (e.g. QSPPACK): the primitives consume
 whatever phase list they are given.
 
+## State preparation injection
+
+Every kernel factory takes an optional ``state_prep`` kernel with
+signature ``(qubits: cudaq.qview)``. Without it, factories return
+``@cudaq.kernel(state)`` circuits that load the input state as data (the
+simulation-friendly form). With it, they return **zero-argument** circuits
+— the system register is allocated in |0...0>, ``state_prep`` runs on it,
+and the operation follows — directly sampleable and fully synthesizable,
+with no statevector anywhere:
+
+```python
+@cudaq.kernel
+def my_prep(qubits: cudaq.qview):
+    rx(0.37, qubits[0])
+    ry(-0.52, qubits[1])
+
+kernel = walk.kernel(power=3, state_prep=my_prep)   # zero-arg circuit
+counts = cudaq.sample(kernel)
+moment = walk.moment(None, 3, state_prep=my_prep)   # hardware-path moment
+```
+
+Contract: ``state_prep`` acts only on the system register it is handed,
+which arrives in |0...0> with width ``num_system`` — not verifiable at
+factory time, so a mismatched prep fails at launch.
+
 ## Hardware-shaped vs. simulation-only
 
 `cudaq.get_state` is a simulator-only API, so nothing in `pauli_lcu`,

--- a/python/cudaq_algorithms/pauli_lcu.py
+++ b/python/cudaq_algorithms/pauli_lcu.py
@@ -597,14 +597,29 @@ class PauliLCU:
     # Kernel factories
     # ------------------------------------------------------------------
 
-    def encode_kernel(self) -> Kernel:
-        """A ``@cudaq.kernel(state)`` applying the full block encoding.
+    def encode_kernel(self, state_prep: Kernel | None = None) -> Kernel:
+        """A kernel applying the full block encoding.
 
-        The kernel allocates the system register from ``state`` and the
-        ancilla register (in |0...0>) after it.
+        Without ``state_prep``: a ``@cudaq.kernel(state)`` allocating the
+        system register from ``state`` and the ancilla register (in
+        |0...0>) after it. With ``state_prep`` (a ``(qubits: qview)``
+        kernel): a zero-argument kernel that allocates the system register
+        in |0...0>, runs ``state_prep`` on it, then applies the encoding.
         """
         angles, controls, ops, lengths, signs = self._kernel_data
         n_anc = self.num_ancilla
+        n_sys = self.num_system
+
+        if state_prep is not None:
+
+            @cudaq.kernel
+            def prep_encoded():
+                system = cudaq.qvector(n_sys)
+                state_prep(system)
+                ancilla = cudaq.qvector(n_anc)
+                apply(ancilla, system, angles, controls, ops, lengths, signs)
+
+            return prep_encoded
 
         @cudaq.kernel
         def encoded(state: cudaq.State):
@@ -614,15 +629,36 @@ class PauliLCU:
 
         return encoded
 
-    def walk_kernel(self, power: int = 1) -> Kernel:
-        """A ``@cudaq.kernel(state)`` running PREPARE, walk^power, UNPREPARE.
+    def walk_kernel(self,
+                    power: int = 1,
+                    state_prep: Kernel | None = None) -> Kernel:
+        """A kernel running PREPARE, walk^power, UNPREPARE.
 
-        The all-zero-ancilla block of the result is T_power(-H/alpha) applied
-        to the input state (Chebyshev polynomial of the walk block -H/alpha).
+        The all-zero-ancilla block of the result is T_power(-H/alpha)
+        applied to the input state (Chebyshev polynomial of the walk block
+        -H/alpha). Input modes as in ``encode_kernel``: a
+        ``cudaq.State``-taking kernel, or a zero-argument kernel when
+        ``state_prep`` is given.
         """
         angles, controls, ops, lengths, signs = self._kernel_data
         n_anc = self.num_ancilla
+        n_sys = self.num_system
         steps = _validate_power(power)
+
+        if state_prep is not None:
+
+            @cudaq.kernel
+            def prep_walked():
+                system = cudaq.qvector(n_sys)
+                state_prep(system)
+                ancilla = cudaq.qvector(n_anc)
+                prepare(ancilla, angles)
+                for _ in range(steps):
+                    walk(ancilla, system, angles, controls, ops, lengths,
+                         signs)
+                unprepare(ancilla, angles)
+
+            return prep_walked
 
         @cudaq.kernel
         def walked(state: cudaq.State):

--- a/python/cudaq_algorithms/qsvt.py
+++ b/python/cudaq_algorithms/qsvt.py
@@ -190,11 +190,14 @@ class QSVT:
                sequence: PhaseSequence | Iterable[float],
                convention: str | None = None,
                state_prep: Kernel | None = None) -> Kernel:
-        """A ``@cudaq.kernel(state)`` applying the phase/walk sequence.
+        """A kernel applying the phase/walk sequence.
 
         ``sequence`` may be a PhaseSequence or a plain list of phases
-        (optionally with ``convention="qsp"``). The signal register is
-        allocated in |0...0> after the system register.
+        (optionally with ``convention="qsp"``). Without ``state_prep``
+        the returned kernel takes one ``cudaq.State`` argument; with
+        ``state_prep`` — a ``(qubits: cudaq.qview)`` kernel — it takes
+        no arguments and prepares the system register itself. The signal
+        register is allocated in |0...0> after the system register.
         """
         seq = _as_sequence(sequence, convention)
         phases = seq.projector_phases
@@ -245,12 +248,15 @@ class QSVT:
                           convention: str | None = None,
                           control_state: int = 1,
                           state_prep: Kernel | None = None) -> Kernel:
-        """``@cudaq.kernel(state)`` applying the sequence controlled.
+        """A kernel applying the sequence controlled.
 
-        Allocates the system register from ``state``, then one register
-        holding [control, signal] (a CUDA-Q Python control set cannot mix a
-        bare qubit with a separate register). With control |0> the sequence
-        is the identity.
+        Input modes as in ``kernel``: a ``cudaq.State``-taking kernel, or
+        a zero-argument kernel when ``state_prep`` is given (the injected
+        prep runs on the system register only, uncontrolled). Either way
+        the system register is followed by one register holding
+        [control, signal] (a CUDA-Q Python control set cannot mix a bare
+        qubit with a separate register). With control |0> the sequence is
+        the identity.
         """
         seq = _as_sequence(sequence, convention)
         phases = seq.projector_phases

--- a/python/cudaq_algorithms/qsvt.py
+++ b/python/cudaq_algorithms/qsvt.py
@@ -188,7 +188,8 @@ class QSVT:
 
     def kernel(self,
                sequence: PhaseSequence | Iterable[float],
-               convention: str | None = None) -> Kernel:
+               convention: str | None = None,
+               state_prep: Kernel | None = None) -> Kernel:
         """A ``@cudaq.kernel(state)`` applying the phase/walk sequence.
 
         ``sequence`` may be a PhaseSequence or a plain list of phases
@@ -201,7 +202,27 @@ class QSVT:
         # empty list captures cannot be marshaled.
         directions = list(seq.walk_directions) or [FORWARD]
         n_anc = self._encoding.num_ancilla
+        n_sys = self._encoding.num_system
         u_a = self._encoding_kernel("apply_kernel")
+
+        if state_prep is not None:
+
+            @cudaq.kernel
+            def prep_qsvt_kernel():
+                system = cudaq.qvector(n_sys)
+                state_prep(system)
+                signal = cudaq.qvector(n_anc)
+                signal_phase(signal, phases[0])
+                for i in range(1, len(phases)):
+                    if directions[i - 1] == 1:
+                        reflect_about_zero(signal)
+                        u_a(signal, system)
+                    else:
+                        u_a(signal, system)
+                        reflect_about_zero(signal)
+                    signal_phase(signal, phases[i])
+
+            return prep_qsvt_kernel
 
         @cudaq.kernel
         def qsvt_kernel(state: cudaq.State):
@@ -222,7 +243,8 @@ class QSVT:
     def controlled_kernel(self,
                           sequence: PhaseSequence | Iterable[float],
                           convention: str | None = None,
-                          control_state: int = 1) -> Kernel:
+                          control_state: int = 1,
+                          state_prep: Kernel | None = None) -> Kernel:
         """``@cudaq.kernel(state)`` applying the sequence controlled.
 
         Allocates the system register from ``state``, then one register
@@ -236,6 +258,28 @@ class QSVT:
         n_anc = self._encoding.num_ancilla
         flip_control = _validate_control_state(control_state) == 1
         controlled_u_a = self._encoding_kernel("controlled_apply_kernel")
+        n_sys = self._encoding.num_system
+
+        if state_prep is not None:
+
+            @cudaq.kernel
+            def prep_controlled_qsvt_kernel():
+                system = cudaq.qvector(n_sys)
+                state_prep(system)
+                control_and_signal = cudaq.qvector(1 + n_anc)
+                if flip_control:
+                    x(control_and_signal[0])
+                controlled_signal_phase(control_and_signal, phases[0])
+                for i in range(1, len(phases)):
+                    if directions[i - 1] == 1:
+                        controlled_reflect_about_zero(control_and_signal)
+                        controlled_u_a(control_and_signal, system)
+                    else:
+                        controlled_u_a(control_and_signal, system)
+                        controlled_reflect_about_zero(control_and_signal)
+                    controlled_signal_phase(control_and_signal, phases[i])
+
+            return prep_controlled_qsvt_kernel
 
         @cudaq.kernel
         def controlled_qsvt_kernel(state: cudaq.State):

--- a/python/cudaq_algorithms/qubitization.py
+++ b/python/cudaq_algorithms/qubitization.py
@@ -103,15 +103,46 @@ class Walk:
     # Kernel factories
     # ------------------------------------------------------------------
 
-    def _factory(self, power: int, uncompute: bool, forward: bool) -> Kernel:
+    def _factory(self,
+                 power: int,
+                 uncompute: bool,
+                 forward: bool,
+                 state_prep: Kernel | None = None) -> Kernel:
         # Delegate every encoding-specific circuit to the injected encoding;
         # this factory only sequences the returned (data-free) kernels.
         n_anc = self._encoding.num_ancilla
+        n_sys = self._encoding.num_system
         steps = _validate_power(power)
         prep = self._encoding_kernel("prepare_kernel")
         unprep = self._encoding_kernel("unprepare_kernel")
         step = self._encoding_kernel(
             "walk_step_kernel" if forward else "adjoint_walk_step_kernel")
+
+        if state_prep is not None:
+            if uncompute:
+
+                @cudaq.kernel
+                def prep_walk_and_uncompute():
+                    system = cudaq.qvector(n_sys)
+                    state_prep(system)
+                    ancilla = cudaq.qvector(n_anc)
+                    prep(ancilla)
+                    for _ in range(steps):
+                        step(ancilla, system)
+                    unprep(ancilla)
+
+                return prep_walk_and_uncompute
+
+            @cudaq.kernel
+            def prep_walk():
+                system = cudaq.qvector(n_sys)
+                state_prep(system)
+                ancilla = cudaq.qvector(n_anc)
+                prep(ancilla)
+                for _ in range(steps):
+                    step(ancilla, system)
+
+            return prep_walk
 
         if uncompute:
 
@@ -136,15 +167,39 @@ class Walk:
 
         return walk_prepared
 
-    def kernel(self, power: int = 1, uncompute: bool = True) -> Kernel:
-        """``@cudaq.kernel(state)``: PREPARE, W^power, optionally UNPREPARE."""
-        return self._factory(power, uncompute, forward=True)
+    def kernel(self,
+               power: int = 1,
+               uncompute: bool = True,
+               state_prep: Kernel | None = None) -> Kernel:
+        """PREPARE, W^power, optionally UNPREPARE.
 
-    def adjoint_kernel(self, power: int = 1, uncompute: bool = True) -> Kernel:
-        """``@cudaq.kernel(state)``: PREPARE, (W†)^power, optionally UNPREPARE."""
-        return self._factory(power, uncompute, forward=False)
+        Without ``state_prep`` the returned kernel takes one
+        ``cudaq.State`` argument (the input state as data — the
+        simulation-friendly form). With ``state_prep`` — a kernel with
+        signature ``(qubits: cudaq.qview)`` — the returned kernel takes
+        no arguments: it allocates the system register in |0...0>, runs
+        ``state_prep`` on it, and applies the walks. ``state_prep`` must
+        act only on that register, whose width is ``num_system`` (a
+        documented contract; not verifiable at factory time).
+        """
+        return self._factory(power,
+                             uncompute,
+                             forward=True,
+                             state_prep=state_prep)
 
-    def roundtrip_kernel(self, power: int = 1) -> Kernel:
+    def adjoint_kernel(self,
+                       power: int = 1,
+                       uncompute: bool = True,
+                       state_prep: Kernel | None = None) -> Kernel:
+        """PREPARE, (W†)^power, optionally UNPREPARE (see ``kernel``)."""
+        return self._factory(power,
+                             uncompute,
+                             forward=False,
+                             state_prep=state_prep)
+
+    def roundtrip_kernel(self,
+                         power: int = 1,
+                         state_prep: Kernel | None = None) -> Kernel:
         """PREPARE, W^power, (W†)^power, UNPREPARE — the identity, for tests."""
         n_anc = self._encoding.num_ancilla
         steps = _validate_power(power)
@@ -152,6 +207,23 @@ class Walk:
         unprep = self._encoding_kernel("unprepare_kernel")
         step = self._encoding_kernel("walk_step_kernel")
         adjoint_step = self._encoding_kernel("adjoint_walk_step_kernel")
+
+        n_sys = self._encoding.num_system
+        if state_prep is not None:
+
+            @cudaq.kernel
+            def prep_roundtrip():
+                system = cudaq.qvector(n_sys)
+                state_prep(system)
+                ancilla = cudaq.qvector(n_anc)
+                prep(ancilla)
+                for _ in range(steps):
+                    step(ancilla, system)
+                for _ in range(steps):
+                    adjoint_step(ancilla, system)
+                unprep(ancilla)
+
+            return prep_roundtrip
 
         @cudaq.kernel
         def roundtrip(state: cudaq.State):
@@ -169,7 +241,8 @@ class Walk:
     def controlled_kernel(self,
                           power: int = 1,
                           control_state: int = 1,
-                          uncompute: bool = True) -> Kernel:
+                          uncompute: bool = True,
+                          state_prep: Kernel | None = None) -> Kernel:
         """``@cudaq.kernel(state)`` running controlled walks.
 
         Allocates the system register from ``state``, then one register
@@ -184,6 +257,37 @@ class Walk:
         prep = self._encoding_kernel("prepare_kernel")
         unprep = self._encoding_kernel("unprepare_kernel")
         controlled_step = self._encoding_kernel("controlled_walk_step_kernel")
+        n_sys = self._encoding.num_system
+
+        if state_prep is not None:
+            if uncompute:
+
+                @cudaq.kernel
+                def prep_controlled_walked():
+                    system = cudaq.qvector(n_sys)
+                    state_prep(system)
+                    control_and_ancilla = cudaq.qvector(1 + n_anc)
+                    if flip_control:
+                        x(control_and_ancilla[0])
+                    prep(control_and_ancilla.back(n_anc))
+                    for _ in range(steps):
+                        controlled_step(control_and_ancilla, system)
+                    unprep(control_and_ancilla.back(n_anc))
+
+                return prep_controlled_walked
+
+            @cudaq.kernel
+            def prep_controlled_walked_only():
+                system = cudaq.qvector(n_sys)
+                state_prep(system)
+                control_and_ancilla = cudaq.qvector(1 + n_anc)
+                if flip_control:
+                    x(control_and_ancilla[0])
+                prep(control_and_ancilla.back(n_anc))
+                for _ in range(steps):
+                    controlled_step(control_and_ancilla, system)
+
+            return prep_controlled_walked_only
 
         if uncompute:
 
@@ -212,9 +316,11 @@ class Walk:
 
         return controlled_walked_prepared
 
-    def controlled_roundtrip_kernel(self,
-                                    power: int = 1,
-                                    control_state: int = 1) -> Kernel:
+    def controlled_roundtrip_kernel(
+            self,
+            power: int = 1,
+            control_state: int = 1,
+            state_prep: Kernel | None = None) -> Kernel:
         """Controlled W^power then controlled (W dagger)^power — identity."""
         n_anc = self._encoding.num_ancilla
         steps = _validate_power(power)
@@ -224,6 +330,25 @@ class Walk:
         controlled_step = self._encoding_kernel("controlled_walk_step_kernel")
         controlled_adjoint_step = self._encoding_kernel(
             "controlled_adjoint_walk_step_kernel")
+        n_sys = self._encoding.num_system
+
+        if state_prep is not None:
+
+            @cudaq.kernel
+            def prep_controlled_roundtrip():
+                system = cudaq.qvector(n_sys)
+                state_prep(system)
+                control_and_ancilla = cudaq.qvector(1 + n_anc)
+                if flip_control:
+                    x(control_and_ancilla[0])
+                prep(control_and_ancilla.back(n_anc))
+                for _ in range(steps):
+                    controlled_step(control_and_ancilla, system)
+                for _ in range(steps):
+                    controlled_adjoint_step(control_and_ancilla, system)
+                unprep(control_and_ancilla.back(n_anc))
+
+            return prep_controlled_roundtrip
 
         @cudaq.kernel
         def controlled_roundtrip(state: cudaq.State):
@@ -245,36 +370,60 @@ class Walk:
     # the same circuits and operators run on hardware)
     # ------------------------------------------------------------------
 
-    def moment(self, ket: ArrayLike, order: int) -> float:
-        """Measure the Chebyshev moment <T_order(H/alpha)> for |ket>.
+    def moment(self,
+               ket: ArrayLike | None,
+               order: int,
+               *,
+               state_prep: Kernel | None = None) -> float:
+        """Measure the Chebyshev moment <T_order(H/alpha)>.
 
-        ``ket`` may be array-like or an already-built ``cudaq.State``.
+        The input state is given either as ``ket`` (array-like or an
+        already-built ``cudaq.State`` — the simulation-friendly form) or
+        as ``state_prep`` (a ``(qubits: cudaq.qview)`` preparation kernel
+        composed into the measured circuit — the hardware-shaped form).
+        Provide exactly one.
         """
+        if (ket is None) == (state_prep is None):
+            raise ValueError("provide exactly one of ket or state_prep")
         if int(order) != order or order < 0:
             raise ValueError("order must be a non-negative integer")
         order = int(order)
         power = order // 2
+        prep_kwargs = {"state_prep": state_prep}
         if order % 2 == 0:
             # Geometry-only (2|0..0><0..0| - I on the ancillas): derivable
             # for any zero-flagged encoding, no encoding hook needed.
-            kernel = self.kernel(power=power, uncompute=True)
+            kernel = self.kernel(power=power, uncompute=True, **prep_kwargs)
             if "reflection" not in self._observable_cache:
                 self._observable_cache["reflection"] = reflection_observable(
                     self.encoding)
             observable = self._observable_cache["reflection"]
         else:
             # Encoding-specific: delegated to the BlockEncoding hook.
-            kernel = self.kernel(power=power, uncompute=False)
+            kernel = self.kernel(power=power, uncompute=False, **prep_kwargs)
             if "select" not in self._observable_cache:
                 self._observable_cache["select"] = (
                     self._encoding.select_observable())
             observable = self._observable_cache["select"]
+        if state_prep is not None:
+            return float(cudaq.observe(kernel, observable).expectation())
         state = ket if isinstance(ket, cudaq.State) else state_from(ket)
         return float(cudaq.observe(kernel, observable, state).expectation())
 
-    def moments(self, ket: ArrayLike, count: int) -> list[float]:
-        """Measure moments <T_0>, ..., <T_{count-1}> for |ket>."""
+    def moments(self,
+                ket: ArrayLike | None,
+                count: int,
+                *,
+                state_prep: Kernel | None = None) -> list[float]:
+        """Measure moments <T_0>, ..., <T_{count-1}> (see ``moment``)."""
         if int(count) != count or count < 0:
             raise ValueError("count must be a non-negative integer")
+        if state_prep is not None:
+            if ket is not None:
+                raise ValueError("provide exactly one of ket or state_prep")
+            return [
+                self.moment(None, order, state_prep=state_prep)
+                for order in range(int(count))
+            ]
         state = ket if isinstance(ket, cudaq.State) else state_from(ket)
         return [self.moment(state, order) for order in range(int(count))]

--- a/python/cudaq_algorithms/qubitization.py
+++ b/python/cudaq_algorithms/qubitization.py
@@ -134,7 +134,7 @@ class Walk:
                 return prep_walk_and_uncompute
 
             @cudaq.kernel
-            def prep_walk():
+            def prep_walk_prepared():
                 system = cudaq.qvector(n_sys)
                 state_prep(system)
                 ancilla = cudaq.qvector(n_anc)
@@ -142,7 +142,7 @@ class Walk:
                 for _ in range(steps):
                     step(ancilla, system)
 
-            return prep_walk
+            return prep_walk_prepared
 
         if uncompute:
 
@@ -243,11 +243,15 @@ class Walk:
                           control_state: int = 1,
                           uncompute: bool = True,
                           state_prep: Kernel | None = None) -> Kernel:
-        """``@cudaq.kernel(state)`` running controlled walks.
+        """Controlled walks over the system register.
 
-        Allocates the system register from ``state``, then one register
-        holding [control, ancillas] (the control cannot share a control set
-        with a separate register in CUDA-Q Python). The control qubit is
+        Input modes as in ``kernel``: without ``state_prep`` the returned
+        kernel takes one ``cudaq.State`` argument; with ``state_prep`` it
+        takes no arguments and prepares the system register itself (the
+        injected prep runs once, uncontrolled, as in QPE). Either way the
+        system register is followed by one register holding
+        [control, ancillas] (the control cannot share a control set with
+        a separate register in CUDA-Q Python). The control qubit is
         initialized to ``control_state``; with control |0> the circuit is
         the identity up to the (cancelling) PREPARE pair.
         """
@@ -277,7 +281,7 @@ class Walk:
                 return prep_controlled_walked
 
             @cudaq.kernel
-            def prep_controlled_walked_only():
+            def prep_controlled_walked_prepared():
                 system = cudaq.qvector(n_sys)
                 state_prep(system)
                 control_and_ancilla = cudaq.qvector(1 + n_anc)
@@ -287,7 +291,7 @@ class Walk:
                 for _ in range(steps):
                     controlled_step(control_and_ancilla, system)
 
-            return prep_controlled_walked_only
+            return prep_controlled_walked_prepared
 
         if uncompute:
 
@@ -389,18 +393,21 @@ class Walk:
             raise ValueError("order must be a non-negative integer")
         order = int(order)
         power = order // 2
-        prep_kwargs = {"state_prep": state_prep}
         if order % 2 == 0:
             # Geometry-only (2|0..0><0..0| - I on the ancillas): derivable
             # for any zero-flagged encoding, no encoding hook needed.
-            kernel = self.kernel(power=power, uncompute=True, **prep_kwargs)
+            kernel = self.kernel(power=power,
+                                 uncompute=True,
+                                 state_prep=state_prep)
             if "reflection" not in self._observable_cache:
                 self._observable_cache["reflection"] = reflection_observable(
                     self.encoding)
             observable = self._observable_cache["reflection"]
         else:
             # Encoding-specific: delegated to the BlockEncoding hook.
-            kernel = self.kernel(power=power, uncompute=False, **prep_kwargs)
+            kernel = self.kernel(power=power,
+                                 uncompute=False,
+                                 state_prep=state_prep)
             if "select" not in self._observable_cache:
                 self._observable_cache["select"] = (
                     self._encoding.select_observable())
@@ -416,11 +423,11 @@ class Walk:
                 *,
                 state_prep: Kernel | None = None) -> list[float]:
         """Measure moments <T_0>, ..., <T_{count-1}> (see ``moment``)."""
+        if (ket is None) == (state_prep is None):
+            raise ValueError("provide exactly one of ket or state_prep")
         if int(count) != count or count < 0:
             raise ValueError("count must be a non-negative integer")
         if state_prep is not None:
-            if ket is not None:
-                raise ValueError("provide exactly one of ket or state_prep")
             return [
                 self.moment(None, order, state_prep=state_prep)
                 for order in range(int(count))

--- a/tests/python/test_state_prep_injection.py
+++ b/tests/python/test_state_prep_injection.py
@@ -28,8 +28,14 @@ THETA0, THETA1 = 0.37, -0.52
 
 @cudaq.kernel
 def product_prep(qubits: cudaq.qview):
-    rx(0.37, qubits[0])
-    ry(-0.52, qubits[1])
+    rx(THETA0, qubits[0])
+    ry(THETA1, qubits[1])
+
+
+@cudaq.kernel
+def noop_prep(qubits: cudaq.qview):
+    # Degenerate injection: leaves the register in |0...0>.
+    pass
 
 
 def _prepared_ket():
@@ -66,9 +72,11 @@ def test_walk_factories_prep_injection():
         (walk.kernel, dict(power=2)),
         (walk.kernel, dict(power=1, uncompute=False)),
         (walk.adjoint_kernel, dict(power=2)),
+        (walk.adjoint_kernel, dict(power=1, uncompute=False)),
         (walk.roundtrip_kernel, dict(power=2)),
         (walk.controlled_kernel, dict(power=2, control_state=1)),
         (walk.controlled_kernel, dict(power=2, control_state=0)),
+        (walk.controlled_kernel, dict(power=1, uncompute=False)),
         (walk.controlled_roundtrip_kernel, dict(power=1)),
     ):
         via_prep = _state(factory(state_prep=product_prep, **kwargs))
@@ -120,11 +128,62 @@ def test_moment_requires_exactly_one_input_mode():
         walk.moment(None, 1)
     with pytest.raises(ValueError, match="exactly one"):
         walk.moments(ket, 3, state_prep=product_prep)
+    # Both-None must raise too (it previously fell through to
+    # state_from(None), which aborts the process in native code).
+    with pytest.raises(ValueError, match="exactly one"):
+        walk.moments(None, 3)
 
 
 def test_prep_mode_returns_zero_argument_kernels():
-    # The injected form must be directly sampleable: no arguments at all.
+    # Every injected form must be directly sampleable: no arguments at
+    # all, through the sample launcher (a different marshaling path than
+    # get_state).
     enc = PauliLCU(HAMILTONIAN)
-    kernel = Walk(enc).kernel(power=1, state_prep=product_prep)
-    counts = cudaq.sample(kernel, shots_count=100)
-    assert sum(counts.values()) == 100
+    walk = Walk(enc)
+    transformer = QSVT(enc)
+    sequence = PhaseSequence([0.4, -0.2, 0.7],
+                             walk_directions=["forward", "adjoint"])
+    for kernel in (
+            enc.encode_kernel(state_prep=product_prep),
+            enc.walk_kernel(power=1, state_prep=product_prep),
+            walk.kernel(power=1, state_prep=product_prep),
+            walk.kernel(power=1, uncompute=False, state_prep=product_prep),
+            walk.adjoint_kernel(power=1, state_prep=product_prep),
+            walk.roundtrip_kernel(power=1, state_prep=product_prep),
+            walk.controlled_kernel(power=1, state_prep=product_prep),
+            walk.controlled_kernel(power=1,
+                                   uncompute=False,
+                                   state_prep=product_prep),
+            walk.controlled_roundtrip_kernel(power=1, state_prep=product_prep),
+            transformer.kernel(sequence, state_prep=product_prep),
+            transformer.controlled_kernel(sequence, state_prep=product_prep),
+    ):
+        counts = cudaq.sample(kernel, shots_count=100)
+        assert sum(counts.values()) == 100
+
+
+def test_noop_prep_matches_zero_state_input():
+    # A do-nothing prep must equal the State-taking twin fed |0...0>.
+    enc = PauliLCU(HAMILTONIAN)
+    zero = np.zeros(1 << enc.num_system, dtype=np.complex128)
+    zero[0] = 1.0
+    via_prep = _state(enc.encode_kernel(state_prep=noop_prep))
+    via_state = _state(enc.encode_kernel(), sim.state_from(zero))
+    np.testing.assert_allclose(via_prep, via_state, atol=1e-12)
+
+
+def test_two_preps_from_one_factory_do_not_cross_contaminate():
+    # Two kernels minted by the same factory capture different preps
+    # under identical inner-kernel names; each must keep its own prep,
+    # including after the other has been built and launched.
+    walk = Walk(PauliLCU(HAMILTONIAN))
+    with_product = walk.kernel(power=1, state_prep=product_prep)
+    first = _state(with_product)
+    with_noop = walk.kernel(power=1, state_prep=noop_prep)
+    zero = np.zeros_like(_prepared_ket())
+    zero[0] = 1.0
+    np.testing.assert_allclose(_state(with_noop),
+                               _state(walk.kernel(power=1),
+                                      sim.state_from(zero)),
+                               atol=1e-12)
+    np.testing.assert_allclose(_state(with_product), first, atol=1e-12)

--- a/tests/python/test_state_prep_injection.py
+++ b/tests/python/test_state_prep_injection.py
@@ -1,0 +1,130 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                        #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""State-preparation injection into the primitive kernel factories.
+
+Every factory accepts an optional ``state_prep`` kernel with signature
+``(qubits: cudaq.qview)``; when provided, the factory returns a
+zero-argument, fully hardware-shaped circuit (no ``cudaq.State`` data
+anywhere). These tests pin each prep-mode circuit against its
+``State``-taking twin fed the identical prepared state as data.
+"""
+
+import numpy as np
+import pytest
+
+import cudaq
+
+from cudaq_algorithms import PauliLCU, PhaseSequence, QSVT, Walk
+from cudaq_algorithms import sim_utils as sim
+
+HAMILTONIAN = {"ZI": 0.70, "IZ": -0.43, "XX": 0.19, "YZ": 0.11}
+THETA0, THETA1 = 0.37, -0.52
+
+
+@cudaq.kernel
+def product_prep(qubits: cudaq.qview):
+    rx(0.37, qubits[0])
+    ry(-0.52, qubits[1])
+
+
+def _prepared_ket():
+    """The dense statevector product_prep produces (little-endian)."""
+    q0 = np.array([np.cos(0.5 * THETA0), -1.0j * np.sin(0.5 * THETA0)])
+    q1 = np.array([np.cos(0.5 * THETA1), np.sin(0.5 * THETA1)])
+    return np.kron(q1, q0).astype(np.complex128)
+
+
+def _state(kernel, *args):
+    return np.asarray(cudaq.get_state(kernel, *args), dtype=np.complex128)
+
+
+def test_encode_kernel_prep_injection():
+    enc = PauliLCU(HAMILTONIAN)
+    via_prep = _state(enc.encode_kernel(state_prep=product_prep))
+    via_state = _state(enc.encode_kernel(), sim.state_from(_prepared_ket()))
+    np.testing.assert_allclose(via_prep, via_state, atol=1e-12)
+
+
+def test_walk_kernel_prep_injection():
+    enc = PauliLCU(HAMILTONIAN)
+    via_prep = _state(enc.walk_kernel(power=2, state_prep=product_prep))
+    via_state = _state(enc.walk_kernel(power=2),
+                       sim.state_from(_prepared_ket()))
+    np.testing.assert_allclose(via_prep, via_state, atol=1e-12)
+
+
+def test_walk_factories_prep_injection():
+    walk = Walk(PauliLCU(HAMILTONIAN))
+    ket = sim.state_from(_prepared_ket())
+
+    for factory, kwargs in (
+        (walk.kernel, dict(power=2)),
+        (walk.kernel, dict(power=1, uncompute=False)),
+        (walk.adjoint_kernel, dict(power=2)),
+        (walk.roundtrip_kernel, dict(power=2)),
+        (walk.controlled_kernel, dict(power=2, control_state=1)),
+        (walk.controlled_kernel, dict(power=2, control_state=0)),
+        (walk.controlled_roundtrip_kernel, dict(power=1)),
+    ):
+        via_prep = _state(factory(state_prep=product_prep, **kwargs))
+        via_state = _state(factory(**kwargs), ket)
+        np.testing.assert_allclose(via_prep,
+                                   via_state,
+                                   atol=1e-12,
+                                   err_msg=f"{factory.__name__} {kwargs}")
+
+
+def test_qsvt_kernels_prep_injection():
+    transformer = QSVT(PauliLCU(HAMILTONIAN))
+    sequence = PhaseSequence([0.4, -0.2, 0.7],
+                             walk_directions=["forward", "adjoint"])
+    ket = sim.state_from(_prepared_ket())
+
+    via_prep = _state(transformer.kernel(sequence, state_prep=product_prep))
+    via_state = _state(transformer.kernel(sequence), ket)
+    np.testing.assert_allclose(via_prep, via_state, atol=1e-12)
+
+    via_prep = _state(
+        transformer.controlled_kernel(sequence,
+                                      control_state=1,
+                                      state_prep=product_prep))
+    via_state = _state(
+        transformer.controlled_kernel(sequence, control_state=1), ket)
+    np.testing.assert_allclose(via_prep, via_state, atol=1e-12)
+
+
+def test_moment_prep_injection_matches_ket_path():
+    walk = Walk(PauliLCU(HAMILTONIAN))
+    ket = _prepared_ket()
+    for order in range(4):
+        via_ket = walk.moment(ket, order)
+        via_prep = walk.moment(None, order, state_prep=product_prep)
+        assert via_prep == pytest.approx(via_ket, abs=1e-10)
+
+    np.testing.assert_allclose(walk.moments(None, 4, state_prep=product_prep),
+                               walk.moments(ket, 4),
+                               atol=1e-10)
+
+
+def test_moment_requires_exactly_one_input_mode():
+    walk = Walk(PauliLCU(HAMILTONIAN))
+    ket = _prepared_ket()
+    with pytest.raises(ValueError, match="exactly one"):
+        walk.moment(ket, 1, state_prep=product_prep)
+    with pytest.raises(ValueError, match="exactly one"):
+        walk.moment(None, 1)
+    with pytest.raises(ValueError, match="exactly one"):
+        walk.moments(ket, 3, state_prep=product_prep)
+
+
+def test_prep_mode_returns_zero_argument_kernels():
+    # The injected form must be directly sampleable: no arguments at all.
+    enc = PauliLCU(HAMILTONIAN)
+    kernel = Walk(enc).kernel(power=1, state_prep=product_prep)
+    counts = cudaq.sample(kernel, shots_count=100)
+    assert sum(counts.values()) == 100


### PR DESCRIPTION
## Summary

Every kernel factory in the LCU/qubitization/QSVT stack now accepts an
optional **`state_prep`** kernel — signature `(qubits: cudaq.qview)` —
composing input-state preparation directly into the returned circuit.
With it, factories return **zero-argument, fully hardware-shaped
circuits**: the system register is allocated in |0...0>, `state_prep`
runs on it, and the operation follows. No `cudaq.State` data anywhere —
directly sampleable and synthesizable.

Without `state_prep`, nothing changes: the factories keep returning the
`cudaq.State`-taking circuits (the simulation-friendly form used by
`sim_utils` and the dense-reference tests).

## Motivation

The `State`-taking factories are ideal for simulation but not executable
on hardware — a QPU takes circuits, not statevectors. Until now the
hardware path required hand-composing the module-level kernels inside a
user kernel. This PR makes the factory ergonomics cover the hardware
path too, and it is the seam the upcoming state-preparation primitives
(and a QPE example) plug into.

## Contract and mechanism

- `state_prep` acts only on the register it is handed, which arrives in
  |0...0> with width `num_system`. The width cannot be verified at
  factory time (documented contract); a mismatched prep fails at launch.
- The composition mechanism is the same closure-captured kernel
  injection the `BlockEncoding` protocol already relies on — no new
  kernel-language surface.

## Testing

7 tests (`test_state_prep_injection.py`); full package suite 56, and
76 + 1 skip with the compiled extension. Every prep-mode circuit is
pinned against its `State`-taking twin fed the identical prepared state
as data: encode, walks (forward/adjoint, with and without uncompute),
roundtrips, controlled variants at both control states, QSVT plain and
controlled, and the moment path (both entry modes agree to 1e-10 across
orders). The exactly-one-input-mode validation is covered, and a
composed zero-argument circuit is sampled directly.

## Related

- The Suzuki-Trotter PR adds the same parameter to `Trotter.kernel`.
- The state-preparation primitives (Givens-rotation Slater-determinant
  prep, Hartree-Fock + fixed-parameter UCC) will ship as factories
  producing exactly this `(qubits: cudaq.qview)` kernel shape.