### PR TITLE
Build wheels from main and cover the full support matrix

### DIFF
--- a/.github/workflows/build_cudaq_wheels.yaml
+++ b/.github/workflows/build_cudaq_wheels.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ['amd64']
+        platform: ['amd64', 'arm64']
         cuda_version: ['12.6', '13.0']
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaq-algorithms') && format('linux-{0}-cpu32', matrix.platform) || 'ubuntu-latest' }}
     permissions:

--- a/.github/workflows/build_cudaq_wheels.yaml
+++ b/.github/workflows/build_cudaq_wheels.yaml
@@ -42,10 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: ['amd64']
-        # cu13 packaging (pyproject.toml.cu13) is supported by the build
-        # scripts but not yet exercised in CI; deferred until a cu13 devdeps
-        # image is available. Add '13.x' here to enable.
-        cuda_version: ['12.6']
+        cuda_version: ['12.6', '13.0']
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaq-algorithms') && format('linux-{0}-cpu32', matrix.platform) || 'ubuntu-latest' }}
     permissions:
       actions: write

--- a/.github/workflows/wheel_algorithms.yaml
+++ b/.github/workflows/wheel_algorithms.yaml
@@ -113,8 +113,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.12']
-        platform: ['amd64']
+        python: ['3.11', '3.12', '3.13']
+        platform: ['amd64', 'arm64']
         cuda_version: ['12.6', '13.0']
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaq-algorithms') && format('linux-{0}-cpu8', matrix.platform) || 'ubuntu-latest' }}
     container:
@@ -225,8 +225,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.12']
-        platform: ['amd64']
+        python: ['3.11', '3.12', '3.13']
+        platform: ['amd64', 'arm64']
         cuda_version: ['12.6', '13.0']
     steps:
       - name: Checkout repository

--- a/.github/workflows/wheel_algorithms.yaml
+++ b/.github/workflows/wheel_algorithms.yaml
@@ -9,6 +9,28 @@
 name: Algorithms wheels
 
 on:
+  # Build wheels from main whenever a merge touches anything that ships in
+  # (or validates) the wheels, and nightly as a safety net, so installable
+  # artifacts always exist for the current main. Both events use the
+  # default Release / 0.14.99 configuration.
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/build_cudaq_wheels.yaml'
+      - '.github/workflows/scripts/**'
+      - '.github/workflows/wheel_algorithms.yaml'
+      - '.cudaq_version'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'include/**'
+      - 'lib/**'
+      - 'pyproject.toml.cu*'
+      - 'python/**'
+      - 'scripts/ci/**'
+      - 'tests/**'
+  schedule:
+    - cron: '0 8 * * *'
   workflow_dispatch:
     inputs:
       build_type:
@@ -93,7 +115,7 @@ jobs:
       matrix:
         python: ['3.12']
         platform: ['amd64']
-        cuda_version: ['12.6']
+        cuda_version: ['12.6', '13.0']
     runs-on: ${{ startsWith(github.repository, 'NVIDIA/cudaq-algorithms') && format('linux-{0}-cpu8', matrix.platform) || 'ubuntu-latest' }}
     container:
       image: ghcr.io/nvidia/cuda-quantum-devdeps:manylinux-${{ matrix.platform }}-cu${{ matrix.cuda_version }}-gcc12-main
@@ -139,7 +161,7 @@ jobs:
           bash scripts/ci/build_wheels.sh \
             --cuda-version ${{ steps.config.outputs.cuda_major }} \
             --cudaq-prefix /usr/local/cudaq \
-            --build-type ${{ inputs.build_type }} \
+            --build-type ${{ inputs.build_type || 'Release' }} \
             --python-version ${{ matrix.python }} \
             --version ${{ inputs.version || '0.14.99' }} \
             --devdeps
@@ -205,7 +227,7 @@ jobs:
       matrix:
         python: ['3.12']
         platform: ['amd64']
-        cuda_version: ['12.6']
+        cuda_version: ['12.6', '13.0']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/scripts/ci/test_wheels.sh
+++ b/scripts/ci/test_wheels.sh
@@ -37,6 +37,28 @@ fi
 # Help the metapackage detect CUDA major version in CPU-only validation jobs.
 $python -m pip install --extra-index-url https://pypi.nvidia.com/ "cuda_toolkit[cudart]==${cuda_version}.*" || true
 
+# Pip-installed CUDA libraries live inside site-packages (e.g.
+# nvidia/cuda_runtime/lib for cu12, nvidia/cu13/lib for cu13) and are not on
+# the loader path, so the metapackage's ctypes-based CUDA detection cannot
+# load libcudart and silently falls back to the cu12 variant. Expose the
+# library directory so detection selects the variant under test.
+cudart_libdir=$($python - <<'EOF'
+import glob
+import os
+import site
+
+for directory in site.getsitepackages():
+    matches = glob.glob(os.path.join(directory, "nvidia", "**",
+                                     "libcudart.so*"), recursive=True)
+    if matches:
+        print(os.path.dirname(sorted(matches)[0]))
+        break
+EOF
+)
+if [[ -n "$cudart_libdir" ]]; then
+    export LD_LIBRARY_PATH="$cudart_libdir${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+
 $python -m pip install "${find_links[@]}" "cudaq-algorithms==${algorithms_version}"
 $python -c "import cudaq_algorithms"
 


### PR DESCRIPTION

## Summary

Three wheel-pipeline gaps, one PR (the edits live in the same two
workflow files plus the wheel test script):

1. **No wheels are ever built from main.** `wheel_algorithms.yaml` has
   only `workflow_dispatch` and `workflow_call` triggers, and the PR
   workflow's `build-wheels` path filter only fires on packaging
   changes — so merging library code never produces an installable
   artifact. (The only main-built wheels to date are from a manual
   dispatch.)
2. **The cu13 path is dangling.** The metapackage ships a
   `pyproject.toml.cu13` stanza referencing a `cudaq-algorithms-cu13`
   wheel that no pipeline builds: the three wheel matrices are
   hardcoded to `['12.6']`.
3. **Single-cell matrix.** Wheels were built only for Python 3.12 on
   amd64, while the library CI already builds and tests on amd64 and
   arm64.

## Changes

- **`push` trigger on main** (path-filtered to files that ship in or
  validate the wheels) plus a **nightly `schedule`** as a safety net,
  so current-main artifacts always exist.
- **`build_type` fallback**: `inputs.build_type` had no default outside
  `workflow_dispatch`/`workflow_call`, so push/schedule runs would have
  passed an empty `--build-type` to the build script; it now falls back
  to `Release` (matching the existing `version` fallback pattern).
- **Full support matrix**: Python 3.11/3.12/3.13 and amd64/arm64 for
  the algorithms wheels and the install test, arm64 for the CUDA-Q
  dependency wheels (which already build all three Python versions per
  platform). No script changes were needed: the runner labels were
  already platform-parameterized, the arm64 manylinux devdeps images
  exist at both CUDA versions, and artifact names already encode
  python/platform/cuda.
- **CUDA 13.0 added to the three wheel matrices**: CUDA-Q dependency
  wheels (`build_cudaq_wheels.yaml`), algorithms wheels, and the CPU
  install test. The comment deferring cu13 ("until a cu13 devdeps
  image is available") is stale — `ghcr.io/nvidia/cuda-quantum-devdeps:
  manylinux-amd64-cu13.0-gcc12-main` exists now, `build_wheels.sh`
  already selects `pyproject.toml.cu${cuda_major}` generically,
  `build_metapackages.sh` already packages both stanzas, and
  `cuda_toolkit==13.0.*` (used by the wheel test) is available on
  pypi.nvidia.com. The library side already compiles at 13.0 in
  `lib_algorithms.yaml`; packaging was the only hole.

- **Wheel-test fix uncovered by the cu13 leg**: the metapackage picks
  its variant by ctypes-loading `libcudart`, but pip-installed CUDA
  runtimes keep their libraries inside site-packages
  (`nvidia/cuda_runtime/lib` for cu12, `nvidia/cu13/lib` for cu13)
  where the loader cannot find them — so detection always failed and
  silently fell back to cu12. The cu12 test leg was passing by
  coincidence; the cu13 leg failed resolution. `test_wheels.sh` now
  puts the pip-installed `libcudart` directory on `LD_LIBRARY_PATH`
  before installing the metapackage, so both legs exercise real
  variant detection (and the script's installed-variant assertion is
  now meaningful on cu12 too).

## Follow-up (separate PR)

A `test-wheels-gpu` job (GPU runner + `CUDAQ_DEFAULT_SIMULATOR=nvidia`,
mirroring cuda-quantum's `gpu_validation` job in `python_wheels.yml` on
`linux-amd64-gpu-a100-latest-1`) — pending confirmation that this
repo's runner groups include the GPU pool. Currently no job in this
repo's CI executes on a GPU.