### PR TITLE
Add pure-Python double factorization of two-electron integrals

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Simulation-only helpers (statevector access) are isolated in
 [examples/pauli_lcu_qsvt/](examples/pauli_lcu_qsvt/), and
 [examples/hamiltonian_simulation/](examples/hamiltonian_simulation/).
 
+Classical chemistry preprocessing ships as a peer pure-Python module:
+double factorization of two-electron integrals (X-DF and C-DF/RC-DF) on
+NumPy/SciPy with optional CuPy GPU acceleration — see
+[docs/double_factorization.md](docs/double_factorization.md).
+
 ## Chemistry Inputs
 
 CUDA-Q Algorithms does not provide an official bridge to PySCF or any other

--- a/benchmarks/double_factorization/bench_cg_inner_solve.py
+++ b/benchmarks/double_factorization/bench_cg_inner_solve.py
@@ -1,0 +1,411 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Benchmarks for the C-DF matrix-free CG inner core solve.
+
+Modes:
+  (default)     new batched CG vs explicit lstsq (where the design matrix fits),
+                on NumPy and CuPy.
+  --ab          also time the original list-based CG to measure the Tier-0
+                vectorization win. SLOW at n>=19 -- the list-based CG is exactly
+                what this work replaced.
+  --tol-sweep   CG iterations and time vs inner tolerance / regularization.
+                Shows that cost is iteration-bound, not matvec-bound.
+  --scaling     synthetic sweep in n to locate the CPU/GPU crossover.
+
+Default problem is H2O/6-311G (n = 19), the case that motivated the matrix-free
+path: there the lstsq design matrix is ~4 GB while the ERI itself is ~1 MB.
+
+    PYTHONPATH=build/python:/usr/local/cudaq python3 \
+        benchmarks/double_factorization/bench_cg_inner_solve.py --tol-sweep
+"""
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+
+import cudaq_algorithms as algorithms
+
+df = algorithms.double_factorization
+from cudaq_algorithms.double_factorization import _factorization as F
+from cudaq_algorithms.double_factorization._backend import (
+    AUTO_GPU_MIN_ORBITALS_COMPRESSED, AUTO_GPU_MIN_ORBITALS_EXPLICIT,
+    resolve_backend, to_device, to_numpy)
+
+
+def _sync(xp):
+    """Block until queued device work finishes (no-op on NumPy)."""
+    if xp.__name__ == "cupy":
+        xp.cuda.runtime.deviceSynchronize()
+
+
+def molecular_eri(basis):
+    from pyscf import ao2mo, gto, scf
+    mol = gto.M(atom="O 0 0 0; H 0 0 0.957; H 0 0.926 -0.24",
+                basis=basis,
+                verbose=0)
+    mf = scf.RHF(mol).run()
+    n = mf.mo_coeff.shape[1]
+    return np.asarray(ao2mo.restore("s1", ao2mo.kernel(mol, mf.mo_coeff), n))
+
+
+def synthetic_eri(n, num_vectors, seed=0):
+    rng = np.random.default_rng(seed)
+    leaves = rng.standard_normal((num_vectors, n, n))
+    leaves = 0.5 * (leaves + leaves.transpose(0, 2, 1))
+    return np.einsum("xpq,xrs->pqrs", leaves, leaves)
+
+
+def warm_start_rotations(eri, num_leaves, xp):
+    """Realistic leaf rotations: the top ``num_leaves`` X-DF leaves on device."""
+    xdf = df.explicit_double_factorization(eri,
+                                           threshold=0.0,
+                                           max_num_leaves=num_leaves)
+    rotations = xdf.leaf_rotations[:num_leaves]
+    while len(rotations) < num_leaves:  # pad if rank-deficient
+        rotations.append(np.eye(eri.shape[0]))
+    return [to_device(np.asarray(r, dtype=float), xp) for r in rotations]
+
+
+def cg_iterations(eri_dev, rotations_dev, xp, regularization, tolerance):
+    """Iteration count for the batched CG (mirrors _solve_inner_cores_cg)."""
+    n = eri_dev.shape[0]
+    num_leaves = len(rotations_dev)
+    rotations = xp.stack(rotations_dev)
+    metric = xp.einsum("tpk,upl->tukl", rotations, rotations)
+    metric = metric * metric
+    rhs = xp.stack(
+        [F._project_eri_into_leaf(eri_dev, u, xp) for u in rotations_dev])
+
+    def apply_operator(z):
+        out = xp.einsum("tukl,ulm,tunm->tkn", metric, z, metric, optimize=True)
+        return out + (2.0 * regularization) * z if regularization > 0 else out
+
+    ip = lambda x, y: xp.sum(x * y)
+    z = xp.zeros((num_leaves, n, n))
+    residual = rhs.copy()
+    direction = residual.copy()
+    rs = ip(residual, residual)
+    threshold = (tolerance**2) * max(float(to_numpy(rs)), 1.0)
+    iterations = 0
+    for _ in range(max(50, num_leaves * n * n)):
+        if float(to_numpy(rs)) <= threshold:
+            break
+        iterations += 1
+        ad = apply_operator(direction)
+        curvature = ip(direction, ad)
+        if float(to_numpy(curvature)) <= 0:
+            break
+        step = rs / curvature
+        z = z + step * direction
+        residual = residual - step * ad
+        new = ip(residual, residual)
+        direction = residual + (new / rs) * direction
+        rs = new
+    return iterations
+
+
+# --------------------------------------------------------------------------- #
+# The ORIGINAL list-based CG, reconstructed here so we can A/B the Tier-0 win.
+# (Double for-loop matvec; per-iteration host sync on every inner product.)
+# --------------------------------------------------------------------------- #
+def cg_list_based(eri_dev, rotations_dev, xp, regularization, tolerance):
+    n = eri_dev.shape[0]
+    num_leaves = len(rotations_dev)
+    overlaps = [[
+        rotations_dev[t].T @ rotations_dev[u] for u in range(num_leaves)
+    ] for t in range(num_leaves)]
+    metric = [[overlaps[t][u] * overlaps[t][u] for u in range(num_leaves)]
+              for t in range(num_leaves)]
+    rhs = [F._project_eri_into_leaf(eri_dev, u, xp) for u in rotations_dev]
+
+    def apply_operator(z):
+        result = []
+        for t in range(num_leaves):
+            acc = xp.zeros((n, n))
+            for u in range(num_leaves):
+                acc = acc + metric[t][u] @ z[u] @ metric[t][u].T
+            if regularization > 0.0:
+                acc = acc + 2.0 * regularization * z[t]
+            result.append(acc)
+        return result
+
+    def inner_product(x, y):
+        return float(to_numpy(sum(xp.sum(xi * yi) for xi, yi in zip(x, y))))
+
+    z = [xp.zeros((n, n)) for _ in range(num_leaves)]
+    residual = [r.copy() for r in rhs]
+    direction = [r.copy() for r in residual]
+    residual_norm_sq = inner_product(residual, residual)
+    threshold = (tolerance**2) * max(residual_norm_sq, 1.0)
+    for _ in range(max(50, num_leaves * n * n)):
+        if residual_norm_sq <= threshold:
+            break
+        operator_direction = apply_operator(direction)
+        curvature = inner_product(direction, operator_direction)
+        if curvature <= 0.0:
+            break
+        step = residual_norm_sq / curvature
+        z = [zi + step * di for zi, di in zip(z, direction)]
+        residual = [
+            ri - step * oi for ri, oi in zip(residual, operator_direction)
+        ]
+        new_norm_sq = inner_product(residual, residual)
+        beta = new_norm_sq / residual_norm_sq
+        direction = [ri + beta * di for ri, di in zip(residual, direction)]
+        residual_norm_sq = new_norm_sq
+    return [0.5 * (zi + zi.T) for zi in z]
+
+
+def time_call(fn, repeats, xp):
+    fn()  # warm up (allocations, cuBLAS handles)
+    _sync(xp)
+    best = float("inf")
+    result = None
+    for _ in range(repeats):
+        start = time.perf_counter()
+        result = fn()
+        _sync(xp)
+        best = min(best, time.perf_counter() - start)
+    return best, result
+
+
+def lstsq_design_gb(n, num_leaves):
+    return (n**4) * (num_leaves * n * (n + 1) // 2) * 8 / 1e9
+
+
+def run_default(eri, num_leaves, rho, tol, repeats, ab):
+    n = eri.shape[0]
+    for backend in _backends():
+        xp, name = resolve_backend(backend)
+        eri_dev = to_device(np.asarray(eri, dtype=float), xp)
+        rotations = warm_start_rotations(eri, num_leaves, xp)
+        print(f"\n=== {name}  n={n}  leaves={num_leaves}  rho={rho:g}  "
+              f"tol={tol:g} ===")
+
+        iters = cg_iterations(eri_dev, rotations, xp, rho, tol)
+        new_time, new_cores = time_call(
+            lambda: F._solve_inner_cores_cg(eri_dev, rotations, xp, rho, tol,
+                                            None), repeats, xp)
+        print(
+            f"  CG (batched)       : {new_time*1e3:9.2f} ms   ({iters} iters)")
+
+        if ab:
+            old_time, old_cores = time_call(
+                lambda: cg_list_based(eri_dev, rotations, xp, rho, tol),
+                repeats, xp)
+            diff = max(
+                float(np.linalg.norm(to_numpy(a) - to_numpy(b)))
+                for a, b in zip(new_cores, old_cores))
+            print(f"  CG (old list-based): {old_time*1e3:9.2f} ms   "
+                  f"speedup x{old_time/new_time:.1f}   |dZ|={diff:.1e}")
+
+        gb = lstsq_design_gb(n, num_leaves)
+        if gb <= 8.0:
+            ls_time, ls_cores = time_call(
+                lambda: F._solve_inner_cores_lstsq(eri_dev, rotations, xp, rho
+                                                   ), repeats, xp)
+            rn = to_numpy(F._reconstruct_dev(rotations, new_cores, xp))
+            rl = to_numpy(F._reconstruct_dev(rotations, ls_cores, xp))
+            print(f"  lstsq (design {gb:.2f} GB): {ls_time*1e3:9.2f} ms   "
+                  f"|recon dCG-lstsq|={np.linalg.norm(rn-rl):.1e}")
+        else:
+            print(f"  lstsq: SKIPPED -- design matrix {gb:.1f} GB (> 8 GB); "
+                  f"this is the case CG exists for.")
+
+
+def run_tol_sweep(eri, num_leaves, repeats):
+    n = eri.shape[0]
+    for backend in _backends():
+        xp, name = resolve_backend(backend)
+        eri_dev = to_device(np.asarray(eri, dtype=float), xp)
+        rotations = warm_start_rotations(eri, num_leaves, xp)
+        print(f"\n=== tol/rho sweep  {name}  n={n}  leaves={num_leaves} ===")
+        print(f"  {'rho':>8} {'tol':>8} {'iters':>6} {'ms':>9}")
+        for rho in (1e-3, 1e-2):
+            for tol in (1e-10, 1e-6, 1e-4):
+                iters = cg_iterations(eri_dev, rotations, xp, rho, tol)
+                t, _ = time_call(
+                    lambda: F._solve_inner_cores_cg(
+                        eri_dev, rotations, xp, rho, tol, None), repeats, xp)
+                print(f"  {rho:>8g} {tol:>8g} {iters:>6d} {t*1e3:>9.1f}")
+
+
+def run_scaling(rho, tol, repeats):
+    for backend in _backends():
+        xp, name = resolve_backend(backend)
+        print(f"\n=== scaling sweep (synthetic)  {name}  rho={rho:g} ===")
+        print(f"  {'n':>4} {'leaves':>7} {'iters':>6} {'ms':>9}")
+        for n in (8, 16, 24, 32, 48):
+            eri = synthetic_eri(n, num_vectors=max(2, n // 2), seed=1)
+            eri_dev = to_device(eri, xp)
+            rotations = warm_start_rotations(eri, n, xp)
+            iters = cg_iterations(eri_dev, rotations, xp, rho, tol)
+            t, _ = time_call(
+                lambda: F._solve_inner_cores_cg(eri_dev, rotations, xp, rho,
+                                                tol, None), repeats, xp)
+            print(f"  {n:>4} {n:>7} {iters:>6d} {t*1e3:>9.1f}")
+
+
+def run_full(n, num_leaves, rho, max_iterations, repeats):
+    """End-to-end compressed_double_factorization: warm-start + inexact in-loop
+    CG ('accel', the new defaults) vs the cold/tight in-loop solve ('plain'),
+    on a synthetic ERI. Verifies the final reconstruction error matches."""
+    eri = synthetic_eri(n, num_vectors=max(2, num_leaves - 1), seed=5)
+    for backend in _backends():
+        print(f"\n=== full C-DF  {backend}  n={n}  leaves={num_leaves}  "
+              f"rho={rho:g}  maxiter={max_iterations} ===")
+
+        def solve(accel):
+            kw = dict(num_leaves=num_leaves,
+                      max_iterations=max_iterations,
+                      regularization=rho,
+                      inner_solver="cg",
+                      backend=backend)
+            if not accel:  # original behavior: cold start, tight in-loop solve
+                kw.update(cg_warm_start=False, cg_optimization_tolerance=1e-10)
+            return df.compressed_double_factorization(eri, **kw)
+
+        best_plain = best_accel = float("inf")
+        err_plain = err_accel = None
+        for _ in range(repeats):
+            t = time.perf_counter()
+            f = solve(False)
+            best_plain = min(best_plain, time.perf_counter() - t)
+            err_plain = df.factorization_error(eri, f)
+            t = time.perf_counter()
+            f = solve(True)
+            best_accel = min(best_accel, time.perf_counter() - t)
+            err_accel = df.factorization_error(eri, f)
+        print(
+            f"  plain (cold, tol=1e-10): {best_plain:7.2f} s  err={err_plain:.3e}"
+        )
+        print(
+            f"  accel (warm + inexact) : {best_accel:7.2f} s  err={err_accel:.3e}"
+            f"   speedup x{best_plain/best_accel:.1f}")
+
+
+def run_leaf_sweep(eri, leaf_counts, rho, max_iterations, repeats):
+    """Time and accuracy vs leaf count for X-DF (Cholesky first factorization)
+    and C-DF (matrix-free CG inner solve), on a molecular ERI. Rows print as they
+    are computed so partial results survive if the large leaf counts run long."""
+    n = eri.shape[0]
+    norm = float(np.linalg.norm(eri))
+    xdf_backend = resolve_backend(
+        "auto", problem_size=n, gpu_min_size=AUTO_GPU_MIN_ORBITALS_EXPLICIT)[1]
+    cdf_backend = resolve_backend(
+        "auto", problem_size=n,
+        gpu_min_size=AUTO_GPU_MIN_ORBITALS_COMPRESSED)[1]
+    print(
+        f"\n=== leaf sweep  n={n}  rho={rho:g}  C-DF maxiter={max_iterations} "
+        f"  (auto backends: X-DF={xdf_backend}, C-DF={cdf_backend}) ===")
+    print(f"  {'leaves':>6} | {'X-DF s':>8} {'X-DF rel':>10} | "
+          f"{'C-DF s':>8} {'C-DF rel':>10}  {'C-DF/X-DF err':>13}")
+
+    for num_leaves in leaf_counts:
+
+        def do_xdf():
+            return df.explicit_double_factorization(
+                eri,
+                threshold=0.0,
+                max_num_leaves=num_leaves,
+                first_factorization="cholesky",
+                backend="auto")
+
+        def do_cdf():
+            return df.compressed_double_factorization(
+                eri,
+                num_leaves=num_leaves,
+                max_iterations=max_iterations,
+                regularization=rho,
+                inner_solver="cg",
+                backend="auto")
+
+        t_x, xdf = _best_time(do_xdf, repeats, xdf_backend)
+        x_rel = df.factorization_error(eri, xdf) / norm
+        t_c, cdf = _best_time(do_cdf, repeats, cdf_backend)
+        c_rel = df.factorization_error(eri, cdf) / norm
+        ratio = c_rel / x_rel if x_rel > 0 else float("nan")
+        print(f"  {num_leaves:>6} | {t_x:>8.3f} {x_rel:>10.3e} | "
+              f"{t_c:>8.3f} {c_rel:>10.3e}  {ratio:>12.2f}x")
+
+
+def _best_time(fn, repeats, backend_name):
+    xp, _ = resolve_backend(backend_name)
+    best = float("inf")
+    result = None
+    for _ in range(repeats):
+        start = time.perf_counter()
+        result = fn()
+        _sync(xp)
+        best = min(best, time.perf_counter() - start)
+    return best, result
+
+
+def _backends():
+    backends = ["numpy"]
+    if df.cupy_gpu_available():
+        backends.append("cupy")
+    return backends
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--basis", default="6-311g")
+    parser.add_argument("--leaves", type=int, default=20)
+    parser.add_argument("--rho", type=float, default=1e-3)
+    parser.add_argument("--tol", type=float, default=1e-10)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--ab",
+                        action="store_true",
+                        help="also time the original list-based CG (slow)")
+    parser.add_argument("--tol-sweep", action="store_true")
+    parser.add_argument("--scaling", action="store_true")
+    parser.add_argument("--full",
+                        action="store_true",
+                        help="end-to-end C-DF: accel vs plain in-loop CG")
+    parser.add_argument("--n",
+                        type=int,
+                        default=16,
+                        help="orbital count for --full (synthetic ERI)")
+    parser.add_argument("--max-iterations", type=int, default=150)
+    parser.add_argument("--leaf-sweep",
+                        action="store_true",
+                        help="X-DF (Cholesky) and C-DF (CG) time/accuracy vs "
+                        "leaf count, on the molecular ERI")
+    parser.add_argument("--leaves-list",
+                        default="4,16,32,64,96",
+                        help="comma-separated leaf counts for --leaf-sweep")
+    args = parser.parse_args()
+
+    if not df.cupy_gpu_available():
+        print("(CuPy GPU not available -- NumPy only)")
+
+    if args.full:  # synthetic ERI; no PySCF needed
+        run_full(args.n, args.leaves, args.rho, args.max_iterations,
+                 args.repeats)
+    elif args.scaling:  # synthetic sweep; no PySCF needed
+        run_scaling(args.rho, args.tol, args.repeats)
+    else:
+        eri = molecular_eri(args.basis)
+        print(f"H2O/{args.basis}: n={eri.shape[0]}  "
+              f"||eri||_F={np.linalg.norm(eri):.4f}")
+        if args.leaf_sweep:
+            leaf_counts = [int(x) for x in args.leaves_list.split(",")]
+            run_leaf_sweep(eri, leaf_counts, args.rho, args.max_iterations,
+                           args.repeats)
+        elif args.tol_sweep:
+            run_tol_sweep(eri, args.leaves, args.repeats)
+        else:
+            run_default(eri, args.leaves, args.rho, args.tol, args.repeats,
+                        args.ab)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/double_factorization.md
+++ b/docs/double_factorization.md
@@ -1,0 +1,127 @@
+# Double Factorization (X-DF and C-DF)
+
+`cudaq_algorithms.double_factorization` factorizes the two-electron integrals of
+an electronic-structure Hamiltonian into a sum of low-rank, diagonalizable pieces
+— the representation used by double-factorized block encodings, qubitization, and
+measurement schemes. It implements the explicit (X-DF) and compressed (C-DF)
+variants of Cohn, Motta, and Parrish, *Quantum Filter Diagonalization with
+Compressed Double-Factorized Hamiltonians*, PRX Quantum **2**, 040352 (2021)
+([arXiv:2104.08957](https://arxiv.org/abs/2104.08957)).
+
+## Convention
+
+The two-electron integrals are supplied in **chemist notation** `(pq|rs)` over
+real spatial orbitals (8-fold symmetric), as an `(n, n, n, n)` array `eri` with
+`eri[p, q, r, s] == (pq|rs)` (e.g. from `pyscf.ao2mo.restore("s1", ...)`).
+
+Double factorization writes
+
+```
+(pq|rs)  ~=  sum_t sum_{k,l} U^t_pk U^t_qk  Z^t_kl  U^t_rl U^t_sl
+```
+
+with orthogonal **leaf rotations** `U^t` (which compile into a Givens-rotation
+fabric) and symmetric **core** matrices `Z^t`.
+
+## Backends (NVIDIA math libraries)
+
+Heavy linear algebra (eigendecompositions, tensor contractions, least squares)
+runs on the NVIDIA math libraries — cuSOLVER and cuBLAS via **CuPy** — when a GPU
+is available, and falls back to **NumPy/SciPy** otherwise. Every entry point
+accepts `backend="auto"` (default), `"cupy"`, or `"numpy"`.
+
+`"auto"` is **size-aware**: below an empirical orbital-count crossover the GPU's
+per-kernel launch and host-sync latency makes it slower than NumPy, so `auto`
+stays on the CPU for small problems and switches to the GPU only once the work is
+large enough to amortize that overhead (and the GPU lead then grows with `n`). The
+crossovers differ by method — C-DF (contraction-heavy) crosses around `n ≈ 18`,
+while X-DF (a cheap Cholesky loop + tiny per-leaf eigh) stays CPU-favorable until
+`n ≈ 56`. Pass `backend="cupy"` or `"numpy"` to force a backend regardless of size.
+
+## API
+
+| function | description |
+|----------|-------------|
+| `explicit_double_factorization(eri, threshold=1e-8, max_num_leaves=None, second_factor_threshold=0.0, first_factorization="cholesky", backend="auto")` | X-DF (rank-one cores). First factorization defaults to **pivoted Cholesky**; pass `first_factorization="eigendecomposition"` for the eigendecomposition variant. |
+| `compressed_double_factorization(eri, num_leaves, max_iterations=2000, tolerance=1e-10, regularization=0.0, inner_solver="lstsq", cg_tolerance=1e-10, cg_max_iterations=None, cg_warm_start=True, cg_optimization_tolerance=None, backend="auto")` | C-DF by least-squares optimization (warm-started from X-DF). `regularization=rho>0` enables **RC-DF** (see below). `inner_solver="cg"` selects the matrix-free inner core solve, with `cg_warm_start` / `cg_optimization_tolerance` accelerators (see below). |
+| `reconstruct_eri(factorization)` | Rebuild the `(pq\|rs)` tensor from a factorization. |
+| `factorization_error(eri, factorization)` | Frobenius norm of the reconstruction residual. |
+| `modified_one_body_integrals(one_body, eri)` | The DF one-body correction `kappa_pq = h_pq - 1/2 sum_r (pr\|qr)`. |
+| `double_factorization_one_norm(factorization, one_body_eigenvalues, convention="lcu")` | One-norm `lambda` of the DF Hamiltonian; `convention="lcu"` (Pauli-rotation) or `"burg"` (qubitization). |
+
+All functions return/operate on a `DoubleFactorization` dataclass with
+`num_orbitals`, `leaf_rotations` (`U^t`), `leaf_cores` (`Z^t`), `num_leaves`, and
+`reconstruct_eri()`.
+
+## X-DF vs C-DF
+
+- **X-DF** is exact and cheap. The first factorization of the ERI supermatrix
+  into symmetric leaves `(pq|rs) = sum_t L^t_pq L^t_rs` defaults to **pivoted
+  Cholesky**: the ERI matrix is positive semidefinite (a Gram matrix of orbital
+  densities), so Cholesky is rank-revealing — it keeps leaves while the residual
+  pivot exceeds `threshold` and stops at the true rank (at most the symmetric-pair
+  dimension `n(n+1)/2`), which is cheaper than a full eigendecomposition. (Pass
+  `first_factorization="eigendecomposition"` for the symmetric-eigendecomposition
+  variant, `(pq|rs) = sum_t lambda_t V^t_pq V^t_rs`, required for indefinite
+  inputs.) Each symmetric leaf is then eigendecomposed to give `U^t` and the
+  rank-one core `Z^t`. At full rank the reconstruction is exact to machine
+  precision, independent of the first-factor method.
+- **C-DF** lifts the rank-one restriction on `Z^t` and minimizes
+  `O = 1/2 || eri - reconstruction ||_F^2` over a fixed number of leaves. The leaf
+  rotations are parameterized as `U^t = exp(X^t)` (antisymmetric `X^t`) and
+  optimized with L-BFGS, while the symmetric cores are solved in closed form at
+  each step (the two-step scheme of the paper, warm-started from X-DF). C-DF
+  reaches a target accuracy with substantially fewer leaves than X-DF.
+
+## RC-DF regularization
+
+Setting `regularization=rho > 0` enables **regularized C-DF** (RC-DF, Oumarou
+et al., *Quantum* **8**, 1371 (2024), [arXiv:2212.07957](https://arxiv.org/abs/2212.07957)),
+adding the L2 penalty `rho * sum_{t,k,l} (Z^t_kl)^2` to the objective (Eq. 17).
+The penalty is folded into the inner core solve as a ridge term, so it actually
+shrinks the cores `Z^t` (it also conditions the otherwise rank-deficient inner
+system). Smaller cores lower the Hamiltonian one-norm `lambda` — and hence the
+qubitization runtime and measurement variance — at a modest cost in
+reconstruction accuracy. `rho` is an absolute coefficient whose useful scale
+depends on the integral magnitude (the paper uses `~1e-6` to `1e-3`); pick it by
+trading off `factorization_error` against `double_factorization_one_norm`. By the
+envelope theorem the analytic optimization gradient is unchanged in form, so
+RC-DF runs at the same per-iteration cost as plain C-DF.
+
+## Inner core solve: explicit vs matrix-free
+
+At each L-BFGS step the symmetric cores `Z^t` are recovered exactly by a linear
+solve for fixed rotations. Two solvers are available via `inner_solver`:
+
+- `"lstsq"` (default) forms an explicit `n^4 x num_params` design matrix and
+  solves it with least squares. Simple and robust for small/medium systems, but
+  the design matrix does not scale.
+- `"cg"` is the **matrix-free conjugate-gradient** solve (RC-DF,
+  [arXiv:2212.07957](https://arxiv.org/abs/2212.07957), Eqs. 25-30). It applies
+  the normal-equations operator `A(Z)^t = sum_{t'} M_{tt'} Z^{t'} M_{tt'}^T` with
+  `M_{tt'} = (U^t^T U^{t'})` elementwise-squared — only `n x n` matrix products,
+  never materializing the design matrix — so it scales to large orbital counts.
+  `cg_tolerance` and `cg_max_iterations` control the CG iteration.
+
+Both solvers produce the same reconstruction; when the inner system is full rank
+(e.g. `regularization > 0`) they produce the same cores to machine precision.
+
+The CG inner solve is **iteration-bound**: its cost is roughly linear in the
+number of CG iterations, which is set by the requested tolerance and the
+conditioning, not by the matvec. Two accelerators (active only for
+`inner_solver="cg"`) cut the per-step cost without changing the final accuracy:
+
+- **`cg_warm_start=True`** seeds each L-BFGS step's CG from the previous step's
+  cores. The cores move slowly between steps, so the warm start collapses the
+  iteration count.
+- **`cg_optimization_tolerance`** (default `max(cg_tolerance, 1e-6)`) solves the
+  *in-loop* systems only loosely — an inexact inner solve, which is sound here
+  because the envelope theorem only needs an approximate gradient — while the
+  single **final** solve is tightened to `cg_tolerance`. So the returned cores
+  are accurate even though the optimization steps used a cheap inner solve.
+
+## Example
+
+See [`examples/double_factorization/double_factorization.py`](../examples/double_factorization/double_factorization.py),
+which factorizes H2O/STO-3G integrals from PySCF and compares X-DF and C-DF
+reconstruction errors at equal leaf counts.

--- a/examples/double_factorization/double_factorization.py
+++ b/examples/double_factorization/double_factorization.py
@@ -11,8 +11,8 @@ integrals, following Cohn, Motta, and Parrish, PRX Quantum 2, 040352 (2021).
 Generates restricted Hartree-Fock molecular-orbital integrals for H2O/STO-3G with
 PySCF, then double-factorizes the ERI tensor two ways:
 
-  * X-DF: exact nested eigendecompositions (rank-one cores), truncated by leaf
-    eigenvalue magnitude.
+  * X-DF: the exact factorization (rank-one cores) via pivoted Cholesky of
+    the ERI supermatrix (the default), truncated by residual pivot.
   * C-DF: a least-squares-optimized factorization that reaches comparable
     accuracy with far fewer leaves.
 

--- a/examples/double_factorization/double_factorization.py
+++ b/examples/double_factorization/double_factorization.py
@@ -1,0 +1,83 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Explicit (X-DF) and compressed (C-DF) double factorization of the two-electron
+integrals, following Cohn, Motta, and Parrish, PRX Quantum 2, 040352 (2021).
+
+Generates restricted Hartree-Fock molecular-orbital integrals for H2O/STO-3G with
+PySCF, then double-factorizes the ERI tensor two ways:
+
+  * X-DF: exact nested eigendecompositions (rank-one cores), truncated by leaf
+    eigenvalue magnitude.
+  * C-DF: a least-squares-optimized factorization that reaches comparable
+    accuracy with far fewer leaves.
+
+Heavy linear algebra uses the NVIDIA math libraries (cuSOLVER/cuBLAS via CuPy)
+when a GPU is available; otherwise it falls back to NumPy/SciPy.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+import cudaq_algorithms as algorithms
+
+df = algorithms.double_factorization
+
+
+def water_mo_eri():
+    from pyscf import ao2mo, gto, scf
+    mol = gto.M(atom="O 0 0 0; H 0 0 0.957; H 0 0.926 -0.24",
+                basis="sto-3g",
+                verbose=0)
+    mf = scf.RHF(mol).run()
+    n = mf.mo_coeff.shape[1]
+    return np.asarray(ao2mo.restore("s1", ao2mo.kernel(mol, mf.mo_coeff), n))
+
+
+def main():
+    backend = "auto"
+    _, backend_name = df.resolve_backend(backend)
+    eri = water_mo_eri()
+    norm = np.linalg.norm(eri)
+    print("Double factorization of H2O/STO-3G two-electron integrals")
+    print(f"  backend: {backend_name}")
+    print(f"  orbitals: {eri.shape[0]}   ||eri||_F: {norm:.6f}")
+
+    full = df.explicit_double_factorization(eri,
+                                            threshold=0.0,
+                                            backend=backend)
+    print("\nX-DF (explicit):")
+    print(f"  full-rank leaves: {full.num_leaves}   "
+          f"reconstruction error: {df.factorization_error(eri, full):.3e}")
+    for threshold in (1.0e-2, 1.0e-3, 1.0e-4):
+        truncated = df.explicit_double_factorization(eri,
+                                                     threshold=threshold,
+                                                     backend=backend)
+        rel = df.factorization_error(eri, truncated) / norm
+        print(
+            f"  threshold {threshold:.0e}: leaves={truncated.num_leaves:2d}  "
+            f"rel error={rel:.3e}")
+
+    print("\nC-DF (compressed) vs X-DF at equal leaf count:")
+    for num_leaves in (2, 4):
+        explicit = df.explicit_double_factorization(eri,
+                                                    threshold=0.0,
+                                                    max_num_leaves=num_leaves,
+                                                    backend=backend)
+        compressed = df.compressed_double_factorization(eri,
+                                                        num_leaves=num_leaves,
+                                                        max_iterations=600,
+                                                        backend=backend)
+        x_rel = df.factorization_error(eri, explicit) / norm
+        c_rel = df.factorization_error(eri, compressed) / norm
+        print(f"  leaves={num_leaves:2d}:  X-DF rel error={x_rel:.3e}   "
+              f"C-DF rel error={c_rel:.3e}")
+        assert c_rel <= x_rel + 1.0e-6
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml.cu12
+++ b/pyproject.toml.cu12
@@ -14,6 +14,7 @@ license = "Apache-2.0"
 dependencies = [
   "cuda-quantum-cu12 == 0.14.*",
   "numpy",
+  "scipy",
 ]
 
 [tool.scikit-build]

--- a/pyproject.toml.cu13
+++ b/pyproject.toml.cu13
@@ -14,6 +14,7 @@ license = "Apache-2.0"
 dependencies = [
   "cuda-quantum-cu13 == 0.14.*",
   "numpy",
+  "scipy",
 ]
 
 [tool.scikit-build]

--- a/python/cudaq_algorithms/__init__.py
+++ b/python/cudaq_algorithms/__init__.py
@@ -15,6 +15,9 @@ The package has two kinds of components:
 - Pure-Python modules (:mod:`.pauli_lcu`, :mod:`.qubitization`, :mod:`.qsvt`,
   :mod:`.trotter`, :mod:`.sim_utils`): quantum primitives implemented as
   CUDA-Q Python kernels. These only require the ``cudaq`` Python package.
+- Pure-Python classical preprocessing (:mod:`.double_factorization`):
+  chemistry-oriented numerics on NumPy/SciPy with optional CuPy GPU
+  acceleration; no ``cudaq`` or compiled-extension dependency.
 
 The native extension is optional: if it is not present (for example in a
 source checkout without a build), the pure-Python APIs below still import
@@ -35,6 +38,9 @@ except ModuleNotFoundError as exc:
         raise
     _NATIVE_IMPORT_ERROR = exc
     __version__ = "CUDA-Q Algorithms (compiled extension not built)"
+
+# Pure-Python classical preprocessing (no compiled-extension dependency).
+from . import double_factorization
 
 # Pure-Python quantum primitives (no compiled-extension dependency).
 from . import (block_encoding, common_kernels, pauli_lcu, qsvt, qubitization,

--- a/python/cudaq_algorithms/__init__.py
+++ b/python/cudaq_algorithms/__init__.py
@@ -17,7 +17,9 @@ The package has two kinds of components:
   CUDA-Q Python kernels. These only require the ``cudaq`` Python package.
 - Pure-Python classical preprocessing (:mod:`.double_factorization`):
   chemistry-oriented numerics on NumPy/SciPy with optional CuPy GPU
-  acceleration; no ``cudaq`` or compiled-extension dependency.
+  acceleration. The subpackage itself imports neither ``cudaq`` nor the
+  compiled extension, but it is reached through this package, whose
+  import does load ``cudaq`` alongside it.
 
 The native extension is optional: if it is not present (for example in a
 source checkout without a build), the pure-Python APIs below still import

--- a/python/cudaq_algorithms/double_factorization/__init__.py
+++ b/python/cudaq_algorithms/double_factorization/__init__.py
@@ -1,0 +1,33 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Double factorization of two-electron integrals (X-DF and C-DF).
+
+Explicit (X-DF) and compressed (C-DF) double factorization following Cohn,
+Motta, and Parrish, PRX Quantum 2, 040352 (2021) (arXiv:2104.08957). Heavy
+linear algebra runs on the NVIDIA math libraries (cuSOLVER / cuBLAS via CuPy)
+when a GPU is available, with a NumPy/SciPy fallback selected automatically.
+"""
+from ._backend import cupy_gpu_available, resolve_backend
+from ._factorization import (DoubleFactorization,
+                             compressed_double_factorization,
+                             double_factorization_one_norm,
+                             explicit_double_factorization,
+                             factorization_error, modified_one_body_integrals,
+                             reconstruct_eri)
+
+__all__ = [
+    "DoubleFactorization",
+    "explicit_double_factorization",
+    "compressed_double_factorization",
+    "reconstruct_eri",
+    "factorization_error",
+    "modified_one_body_integrals",
+    "double_factorization_one_norm",
+    "cupy_gpu_available",
+    "resolve_backend",
+]

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -38,7 +38,7 @@ except Exception:  # pragma: no cover - environment without CuPy
 # than NumPy; above them the batched cuSOLVER/cuBLAS linear algebra wins and the
 # lead grows with ``n``. X-DF (a cheap Cholesky loop + tiny per-leaf eigh) stays
 # CPU-favorable far longer than the contraction-heavy C-DF optimization. See
-# benchmarks/double_factorization/ and DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md.
+# benchmarks/double_factorization/.
 AUTO_GPU_MIN_ORBITALS_COMPRESSED = 18
 AUTO_GPU_MIN_ORBITALS_EXPLICIT = 56
 

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -97,7 +97,9 @@ def to_numpy(array) -> np.ndarray:
 def expm_skew_symmetric(generator: ArrayLike, xp: ArrayModule) -> DeviceArray:
     """Matrix exponential of a real antisymmetric matrix, returning an orthogonal
     matrix. Uses a Hermitian eigendecomposition (cuSOLVER on the CuPy backend),
-    avoiding any dependence on a general matrix-exponential routine."""
+    avoiding any dependence on a general matrix-exponential routine. Also the
+    per-leaf fallback of :func:`expm_skew_symmetric_batched` where CuPy's
+    batched eigensolver does not apply (matrix dimension > 32)."""
     generator = xp.asarray(generator)
     # i * X is Hermitian for real antisymmetric X, so eigh applies.
     hermitian = 1j * generator
@@ -112,8 +114,19 @@ def expm_skew_symmetric_batched(generators: ArrayLike,
     """Batched :func:`expm_skew_symmetric` over a stack of real antisymmetric
     matrices ``generators`` (shape ``(num_leaves, n, n)``). One batched Hermitian
     eigendecomposition instead of ``num_leaves`` separate ones -- on the CuPy
-    backend this is a single cuSOLVER call rather than a Python-driven loop."""
+    backend this is a single cuSOLVER call rather than a Python-driven loop.
+
+    CuPy dispatches stacked ``eigh`` to cuSOLVER's batched Jacobi solver
+    (``syevj``/``heevjBatched``), which is documented for matrix dimensions
+    up to 32; above that this falls back to per-leaf (non-batched)
+    eigendecompositions, which remain on the GPU through the standard
+    cuSOLVER path."""
     generators = xp.asarray(generators)
+    if xp.__name__ == "cupy" and generators.shape[-1] > 32:
+        return xp.stack([
+            expm_skew_symmetric(generators[index], xp)
+            for index in range(generators.shape[0])
+        ])
     hermitian = 1j * generators
     eigenvalues, eigenvectors = xp.linalg.eigh(
         hermitian)  # batched over axis 0

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -14,7 +14,19 @@ APIs accept a ``backend`` argument of ``"auto"`` (default), ``"cupy"``, or
 """
 from __future__ import annotations
 
+from typing import Any, TypeAlias
+
 import numpy as np
+from numpy.typing import ArrayLike
+
+# The array namespace used for a computation: the ``numpy`` module or, when
+# a GPU is available, ``cupy``. CuPy is optional, so there is no importable
+# static type covering both namespaces.
+ArrayModule: TypeAlias = Any
+
+# An array living on the active backend: ``numpy.ndarray`` on the NumPy
+# backend, ``cupy.ndarray`` on the CuPy backend.
+DeviceArray: TypeAlias = Any
 
 try:  # CuPy is optional; absence simply forces the NumPy path.
     import cupy as _cupy  # type: ignore
@@ -41,7 +53,9 @@ def cupy_gpu_available() -> bool:
         return False
 
 
-def resolve_backend(backend: str = "auto", problem_size=None, gpu_min_size=0):
+def resolve_backend(backend: str = "auto",
+                    problem_size: int | None = None,
+                    gpu_min_size: int = 0) -> tuple[ArrayModule, str]:
     """Return ``(array_module, name)`` for the requested backend.
 
     ``"auto"`` selects CuPy when a GPU is available *and* the problem is large
@@ -68,7 +82,7 @@ def resolve_backend(backend: str = "auto", problem_size=None, gpu_min_size=0):
         "'auto', 'cupy', or 'numpy'.")
 
 
-def to_device(array, xp):
+def to_device(array: ArrayLike, xp: ArrayModule) -> DeviceArray:
     """Move a host/device array onto the backend ``xp``."""
     if xp is np:
         return np.asarray(array)
@@ -82,7 +96,8 @@ def to_numpy(array) -> np.ndarray:
     return np.asarray(array)
 
 
-def expm_skew_symmetric(generator, xp):
+def expm_skew_symmetric(generator: ArrayLike,
+                        xp: ArrayModule) -> DeviceArray:
     """Matrix exponential of a real antisymmetric matrix, returning an orthogonal
     matrix. Uses a Hermitian eigendecomposition (cuSOLVER on the CuPy backend),
     avoiding any dependence on a general matrix-exponential routine."""
@@ -95,7 +110,8 @@ def expm_skew_symmetric(generator, xp):
     return xp.real(rotated)
 
 
-def expm_skew_symmetric_batched(generators, xp):
+def expm_skew_symmetric_batched(generators: ArrayLike,
+                                xp: ArrayModule) -> DeviceArray:
     """Batched :func:`expm_skew_symmetric` over a stack of real antisymmetric
     matrices ``generators`` (shape ``(num_leaves, n, n)``). One batched Hermitian
     eigendecomposition instead of ``num_leaves`` separate ones -- on the CuPy

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -68,18 +68,16 @@ def resolve_backend(backend: str = "auto",
         return np, "numpy"
     if backend == "cupy":
         if not cupy_gpu_available():
-            raise RuntimeError(
-                "double_factorization error - the 'cupy' backend was requested "
-                "but no CuPy/GPU is available.")
+            raise RuntimeError("the 'cupy' backend was requested but no "
+                               "CuPy/GPU is available.")
         return _cupy, "cupy"
     if backend == "auto":
         if cupy_gpu_available() and (problem_size is None
                                      or problem_size >= gpu_min_size):
             return _cupy, "cupy"
         return np, "numpy"
-    raise ValueError(
-        f"double_factorization error - unknown backend '{backend}'; expected "
-        "'auto', 'cupy', or 'numpy'.")
+    raise ValueError(f"unknown backend '{backend}'; expected 'auto', 'cupy', "
+                     "or 'numpy'.")
 
 
 def to_device(array: ArrayLike, xp: ArrayModule) -> DeviceArray:

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -1,0 +1,111 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Array-backend selection for double factorization.
+
+Prefers the NVIDIA math libraries (cuSOLVER / cuBLAS via CuPy) when a GPU is
+available, and falls back to NumPy otherwise. All public double-factorization
+APIs accept a ``backend`` argument of ``"auto"`` (default), ``"cupy"``, or
+``"numpy"``.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+try:  # CuPy is optional; absence simply forces the NumPy path.
+    import cupy as _cupy  # type: ignore
+except Exception:  # pragma: no cover - environment without CuPy
+    _cupy = None
+
+# Empirical CPU/GPU crossovers (orbital count ``n``) for ``backend="auto"``.
+# Below these the GPU's per-kernel launch + host-sync latency makes CuPy slower
+# than NumPy; above them the batched cuSOLVER/cuBLAS linear algebra wins and the
+# lead grows with ``n``. X-DF (a cheap Cholesky loop + tiny per-leaf eigh) stays
+# CPU-favorable far longer than the contraction-heavy C-DF optimization. See
+# benchmarks/double_factorization/ and DOUBLE_FACTORIZATION_CPP_PORT_NOTES.md.
+AUTO_GPU_MIN_ORBITALS_COMPRESSED = 18
+AUTO_GPU_MIN_ORBITALS_EXPLICIT = 56
+
+
+def cupy_gpu_available() -> bool:
+    """Return True when CuPy is importable and at least one GPU is visible."""
+    if _cupy is None:
+        return False
+    try:
+        return _cupy.cuda.runtime.getDeviceCount() > 0
+    except Exception:  # pragma: no cover - driver/runtime issues
+        return False
+
+
+def resolve_backend(backend: str = "auto", problem_size=None, gpu_min_size=0):
+    """Return ``(array_module, name)`` for the requested backend.
+
+    ``"auto"`` selects CuPy when a GPU is available *and* the problem is large
+    enough to amortize GPU launch/sync overhead -- i.e. ``problem_size`` (the
+    orbital count ``n``) is at least ``gpu_min_size`` -- otherwise NumPy. With no
+    ``problem_size`` hint it keeps the legacy behavior: CuPy whenever a GPU is
+    present. ``"cupy"`` / ``"numpy"`` force the backend regardless of size.
+    """
+    if backend == "numpy":
+        return np, "numpy"
+    if backend == "cupy":
+        if not cupy_gpu_available():
+            raise RuntimeError(
+                "double_factorization error - the 'cupy' backend was requested "
+                "but no CuPy/GPU is available.")
+        return _cupy, "cupy"
+    if backend == "auto":
+        if cupy_gpu_available() and (problem_size is None
+                                     or problem_size >= gpu_min_size):
+            return _cupy, "cupy"
+        return np, "numpy"
+    raise ValueError(
+        f"double_factorization error - unknown backend '{backend}'; expected "
+        "'auto', 'cupy', or 'numpy'.")
+
+
+def to_device(array, xp):
+    """Move a host/device array onto the backend ``xp``."""
+    if xp is np:
+        return np.asarray(array)
+    return xp.asarray(array)
+
+
+def to_numpy(array) -> np.ndarray:
+    """Return a host NumPy copy of a NumPy or CuPy array."""
+    if _cupy is not None and isinstance(array, _cupy.ndarray):
+        return _cupy.asnumpy(array)
+    return np.asarray(array)
+
+
+def expm_skew_symmetric(generator, xp):
+    """Matrix exponential of a real antisymmetric matrix, returning an orthogonal
+    matrix. Uses a Hermitian eigendecomposition (cuSOLVER on the CuPy backend),
+    avoiding any dependence on a general matrix-exponential routine."""
+    generator = xp.asarray(generator)
+    # i * X is Hermitian for real antisymmetric X, so eigh applies.
+    hermitian = 1j * generator
+    eigenvalues, eigenvectors = xp.linalg.eigh(hermitian)
+    phases = xp.exp(-1j * eigenvalues)
+    rotated = (eigenvectors * phases) @ eigenvectors.conj().T
+    return xp.real(rotated)
+
+
+def expm_skew_symmetric_batched(generators, xp):
+    """Batched :func:`expm_skew_symmetric` over a stack of real antisymmetric
+    matrices ``generators`` (shape ``(num_leaves, n, n)``). One batched Hermitian
+    eigendecomposition instead of ``num_leaves`` separate ones -- on the CuPy
+    backend this is a single cuSOLVER call rather than a Python-driven loop."""
+    generators = xp.asarray(generators)
+    hermitian = 1j * generators
+    eigenvalues, eigenvectors = xp.linalg.eigh(
+        hermitian)  # batched over axis 0
+    phases = xp.exp(-1j * eigenvalues)  # (num_leaves, n)
+    # Scale each leaf's eigenvector columns by its phases, then V diag(phase) V^H.
+    scaled = eigenvectors * phases[:, None, :]
+    rotated = scaled @ xp.conj(eigenvectors).transpose(0, 2, 1)
+    return xp.real(rotated)

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -94,39 +94,21 @@ def to_numpy(array) -> np.ndarray:
     return np.asarray(array)
 
 
-def expm_skew_symmetric(generator: ArrayLike, xp: ArrayModule) -> DeviceArray:
-    """Matrix exponential of a real antisymmetric matrix, returning an orthogonal
-    matrix. Uses a Hermitian eigendecomposition (cuSOLVER on the CuPy backend),
-    avoiding any dependence on a general matrix-exponential routine. Also the
-    per-leaf fallback of :func:`expm_skew_symmetric_batched` where CuPy's
-    batched eigensolver does not apply (matrix dimension > 32)."""
-    generator = xp.asarray(generator)
-    # i * X is Hermitian for real antisymmetric X, so eigh applies.
-    hermitian = 1j * generator
-    eigenvalues, eigenvectors = xp.linalg.eigh(hermitian)
-    phases = xp.exp(-1j * eigenvalues)
-    rotated = (eigenvectors * phases) @ eigenvectors.conj().T
-    return xp.real(rotated)
-
-
 def expm_skew_symmetric_batched(generators: ArrayLike,
                                 xp: ArrayModule) -> DeviceArray:
-    """Batched :func:`expm_skew_symmetric` over a stack of real antisymmetric
-    matrices ``generators`` (shape ``(num_leaves, n, n)``). One batched Hermitian
-    eigendecomposition instead of ``num_leaves`` separate ones -- on the CuPy
-    backend this is a single cuSOLVER call rather than a Python-driven loop.
+    """Batched matrix exponential over a stack of real antisymmetric
+    matrices ``generators`` (shape ``(num_leaves, n, n)``), returning
+    orthogonal matrices. ``i * X`` is Hermitian for real antisymmetric
+    ``X``, so one batched Hermitian eigendecomposition covers the whole
+    stack -- on the CuPy backend a single cuSOLVER call rather than a
+    Python-driven loop, with no dependence on a general
+    matrix-exponential routine.
 
-    CuPy dispatches stacked ``eigh`` to cuSOLVER's batched Jacobi solver
-    (``syevj``/``heevjBatched``), which is documented for matrix dimensions
-    up to 32; above that this falls back to per-leaf (non-batched)
-    eigendecompositions, which remain on the GPU through the standard
-    cuSOLVER path."""
+    Stacked ``eigh`` on current CuPy handles matrix dimensions well
+    beyond cuSOLVER's batched-Jacobi 32 limit (verified in review on
+    CuPy 13.6 / CUDA 12.9 up to n = 64, matching ``scipy.linalg.expm``
+    to ~1e-12), so no per-leaf fallback is needed here."""
     generators = xp.asarray(generators)
-    if xp.__name__ == "cupy" and generators.shape[-1] > 32:
-        return xp.stack([
-            expm_skew_symmetric(generators[index], xp)
-            for index in range(generators.shape[0])
-        ])
     hermitian = 1j * generators
     eigenvalues, eigenvectors = xp.linalg.eigh(
         hermitian)  # batched over axis 0

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -96,8 +96,7 @@ def to_numpy(array) -> np.ndarray:
     return np.asarray(array)
 
 
-def expm_skew_symmetric(generator: ArrayLike,
-                        xp: ArrayModule) -> DeviceArray:
+def expm_skew_symmetric(generator: ArrayLike, xp: ArrayModule) -> DeviceArray:
     """Matrix exponential of a real antisymmetric matrix, returning an orthogonal
     matrix. Uses a Hermitian eigendecomposition (cuSOLVER on the CuPy backend),
     avoiding any dependence on a general matrix-exponential routine."""

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -1,0 +1,661 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Explicit (X-DF) and compressed (C-DF) double factorization.
+
+Follows Cohn, Motta, and Parrish, "Quantum Filter Diagonalization with
+Compressed Double-Factorized Hamiltonians," PRX Quantum 2, 040352 (2021)
+(arXiv:2104.08957).
+
+The two-electron integrals are taken in chemist notation ``(pq|rs)`` over real
+spatial orbitals (8-fold symmetry), i.e. an ``(n, n, n, n)`` array ``eri`` with
+``eri[p, q, r, s] == (pq|rs)``. Double factorization writes
+
+    (pq|rs) ~= sum_t sum_kl U^t_pk U^t_qk Z^t_kl U^t_rl U^t_sl
+
+with orthogonal "leaf" rotations ``U^t`` (the Givens-rotation fabric) and
+symmetric "core" matrices ``Z^t``. X-DF obtains these from nested
+eigendecompositions (each ``Z^t`` is rank one). C-DF instead minimizes the
+least-squares reconstruction error, allowing general symmetric ``Z^t`` and far
+fewer leaves at equal accuracy.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import numpy as np
+import scipy.linalg
+import scipy.optimize
+
+from ._backend import (AUTO_GPU_MIN_ORBITALS_COMPRESSED,
+                       AUTO_GPU_MIN_ORBITALS_EXPLICIT,
+                       expm_skew_symmetric_batched, resolve_backend, to_device,
+                       to_numpy)
+
+
+@dataclass
+class DoubleFactorization:
+    """Result of a double factorization of the two-electron integrals.
+
+    ``leaf_rotations[t]`` is the orthogonal matrix ``U^t`` (shape
+    ``(num_orbitals, num_orbitals)``) and ``leaf_cores[t]`` is the symmetric
+    core ``Z^t`` for leaf ``t``. ``method`` is ``"X-DF"`` or ``"C-DF"``.
+    """
+
+    num_orbitals: int
+    leaf_rotations: List[np.ndarray]
+    leaf_cores: List[np.ndarray]
+    method: str
+    first_factorization: Optional[
+        str] = None  # "cholesky" or "eigendecomposition"
+    leaf_weights: Optional[
+        np.ndarray] = None  # first-factor pivots/eigenvalues
+
+    @property
+    def num_leaves(self) -> int:
+        return len(self.leaf_rotations)
+
+    def reconstruct_eri(self) -> np.ndarray:
+        """Reconstruct the ``(n, n, n, n)`` chemist-notation ERI tensor."""
+        n = self.num_orbitals
+        eri = np.zeros((n, n, n, n), dtype=float)
+        for rotation, core in zip(self.leaf_rotations, self.leaf_cores):
+            eri += np.einsum("pk,qk,kl,rl,sl->pqrs",
+                             rotation,
+                             rotation,
+                             core,
+                             rotation,
+                             rotation,
+                             optimize=True)
+        return eri
+
+
+def _sorted_symmetric_eigendecomposition(matrix, xp):
+    """Eigenpairs of a symmetric matrix, ordered by descending |eigenvalue|."""
+    eigenvalues, eigenvectors = xp.linalg.eigh(matrix)
+    order = xp.argsort(xp.abs(eigenvalues))[::-1]
+    return eigenvalues[order], eigenvectors[:, order]
+
+
+def _pivoted_cholesky(matrix, threshold, max_rank, xp):
+    """Pivoted Cholesky factorization of a symmetric positive-semidefinite
+    matrix: returns ``(vectors, pivots)`` with ``matrix ~= sum_t v_t v_t^T``.
+
+    The largest residual-diagonal entry is pivoted on at each step, so the
+    factorization is rank-revealing and stops once that pivot drops to or below
+    ``threshold`` (or after ``max_rank`` vectors). This is the standard
+    Cholesky/density-fitting decomposition of the (PSD) electron-repulsion
+    integrals; non-positive residual pivots (numerical null space) terminate it.
+    """
+    m = matrix.shape[0]
+    residual = xp.real(xp.diag(matrix)).astype(float).copy()
+    initial_max = float(xp.max(residual)) if m else 0.0
+    # Rank-revealing floor: stop once the residual pivot reaches the numerical
+    # null space. Without this, threshold == 0 would keep extracting vectors with
+    # vanishing (eventually denormal) pivots, and dividing by sqrt(pivot) yields
+    # garbage rotations.
+    floor = max(float(threshold), initial_max * 1.0e-14)
+    vectors: List = []
+    pivots: List[float] = []
+    limit = m if max_rank is None else min(int(max_rank), m)
+    for _ in range(limit):
+        pivot_index = int(xp.argmax(residual))
+        pivot = float(residual[pivot_index])
+        if pivot <= floor:
+            break
+        column = matrix[:, pivot_index].astype(float).copy()
+        for previous in vectors:
+            column = column - previous * float(previous[pivot_index])
+        vector = column / xp.sqrt(xp.asarray(pivot))
+        vectors.append(vector)
+        pivots.append(pivot)
+        residual = residual - vector * vector
+        residual = xp.where(residual > 0.0, residual, 0.0)
+    return vectors, pivots
+
+
+def _second_factorization(leaf, scale, second_factor_threshold, xp):
+    """Eigendecompose a symmetric leaf ``L = U diag(gamma) U^T`` and return
+    ``(U, Z)`` with the symmetric core ``Z = scale * outer(gamma, gamma)``."""
+    leaf = 0.5 * (leaf + leaf.T)
+    gamma, rotation = xp.linalg.eigh(leaf)
+    if second_factor_threshold > 0.0:
+        importance = xp.sum(xp.abs(gamma))
+        gamma = xp.where(importance * xp.abs(gamma) > second_factor_threshold,
+                         gamma, 0.0)
+    core = scale * xp.outer(gamma, gamma)
+    return to_numpy(rotation), to_numpy(core)
+
+
+def _validate_eri(eri) -> int:
+    eri = np.asarray(eri)
+    if eri.ndim != 4 or len(set(eri.shape)) != 1:
+        raise ValueError(
+            "double_factorization error - eri must be a square rank-4 tensor "
+            "(n, n, n, n) in chemist notation (pq|rs).")
+    return eri.shape[0]
+
+
+def explicit_double_factorization(
+        eri,
+        threshold: float = 1.0e-8,
+        max_num_leaves: Optional[int] = None,
+        second_factor_threshold: float = 0.0,
+        first_factorization: str = "cholesky",
+        backend: str = "auto") -> DoubleFactorization:
+    """Explicit double factorization (X-DF).
+
+    First factorization of the ERI supermatrix ``(pq|rs) = sum_t L^t_pq L^t_rs``
+    into symmetric leaves ``L^t``:
+
+    * ``first_factorization="cholesky"`` (default) -- pivoted Cholesky of the
+      positive-semidefinite ERI matrix. Rank-revealing: it keeps leaves while the
+      residual-diagonal pivot exceeds ``threshold`` (the numerical null space
+      terminates it), so it stops at the true factorization rank.
+    * ``first_factorization="eigendecomposition"`` -- symmetric eigendecomposition
+      ``(pq|rs) = sum_t lambda_t V^t_pq V^t_rs`` keeping ``|lambda_t| > threshold``.
+      Required for indefinite inputs; the ERI is PSD so Cholesky is preferred.
+
+    ``max_num_leaves`` caps the leaf count. Second factorization: each symmetric
+    leaf is eigendecomposed, ``L^t = U^t diag(gamma^t) (U^t)^T``, giving the
+    rank-one core ``Z^t = outer(gamma^t, gamma^t)`` (scaled by ``lambda_t`` in the
+    eigendecomposition case). ``second_factor_threshold`` optionally zeros small
+    ``gamma^t_k`` (importance-weighted, matching OpenFermion's convention).
+
+    Returns a :class:`DoubleFactorization` with NumPy arrays.
+    """
+    n = _validate_eri(eri)
+    xp, _ = resolve_backend(backend,
+                            problem_size=n,
+                            gpu_min_size=AUTO_GPU_MIN_ORBITALS_EXPLICIT)
+    eri_dev = to_device(np.asarray(eri, dtype=float), xp)
+    supermatrix = eri_dev.reshape(n * n, n * n)
+    supermatrix = 0.5 * (supermatrix + supermatrix.T)
+
+    rotations: List[np.ndarray] = []
+    cores: List[np.ndarray] = []
+    weights: List[float] = []
+
+    if first_factorization == "cholesky":
+        vectors, pivots = _pivoted_cholesky(supermatrix, threshold,
+                                            max_num_leaves, xp)
+        for vector, pivot in zip(vectors, pivots):
+            rotation, core = _second_factorization(vector.reshape(n, n), 1.0,
+                                                   second_factor_threshold, xp)
+            rotations.append(rotation)
+            cores.append(core)
+            weights.append(pivot)
+    elif first_factorization == "eigendecomposition":
+        eigenvalues, eigenvectors = _sorted_symmetric_eigendecomposition(
+            supermatrix, xp)
+        abs_eigenvalues = to_numpy(xp.abs(eigenvalues))
+        for index in range(n * n):
+            if abs_eigenvalues[index] <= threshold:
+                break
+            if max_num_leaves is not None and len(rotations) >= max_num_leaves:
+                break
+            lam = eigenvalues[index]
+            rotation, core = _second_factorization(
+                eigenvectors[:, index].reshape(n, n), lam,
+                second_factor_threshold, xp)
+            rotations.append(rotation)
+            cores.append(core)
+            weights.append(float(to_numpy(lam)))
+    else:
+        raise ValueError(
+            "double_factorization error - first_factorization must be "
+            "'cholesky' or 'eigendecomposition'.")
+
+    return DoubleFactorization(num_orbitals=n,
+                               leaf_rotations=rotations,
+                               leaf_cores=cores,
+                               method="X-DF",
+                               first_factorization=first_factorization,
+                               leaf_weights=np.asarray(weights))
+
+
+def _leaf_outer_columns(rotation, xp):
+    """Return ``A`` with ``A[:, k] = vec(u_k u_k^T)`` for rotation columns u_k."""
+    n = rotation.shape[0]
+    outer = xp.einsum("pk,qk->pqk", rotation, rotation)
+    return outer.reshape(n * n, n)
+
+
+def _project_eri_into_leaf(eri_dev, rotation, xp):
+    """R^t_kl = sum_pqrs U^t_pk U^t_qk (pq|rs) U^t_rl U^t_sl (the RHS of the inner
+    normal equations / projection of the ERIs into a leaf's rotated basis)."""
+    a = xp.einsum("pk,qk->pqk", rotation, rotation)
+    return xp.einsum("pqk,pqrs,rsl->kl", a, eri_dev, a, optimize=True)
+
+
+def _solve_inner_cores_cg(eri_dev,
+                          rotations_dev,
+                          xp,
+                          regularization=0.0,
+                          tolerance=1.0e-10,
+                          max_iterations=None,
+                          initial_guess=None):
+    """Matrix-free conjugate-gradient solve for the symmetric cores ``{Z^t}``.
+
+    Solves the same normal equations as the least-squares solver,
+    ``(A + 2 rho I) Z = R``, but never forms the ``n^4 x num_params`` design
+    matrix (RC-DF Eqs. 25-30). The operator factorizes as
+
+        A(Z)^t = sum_{t'} M_{tt'} Z^{t'} M_{tt'}^T ,
+        M_{tt'} = (U^t^T U^{t'}) elementwise-squared      (Eq. 27)
+
+    so each matvec is just ``n x n`` matrix products; the ERIs are contracted
+    only once to build the RHS ``R^t``. The cores are stacked into a single
+    ``(num_leaves, n, n)`` array so the whole operator is one batched ``einsum``
+    (a strided-batched GEMM under cuBLAS) rather than ``num_leaves^2`` Python-
+    driven launches, and the CG scalars stay on device -- only the convergence and
+    curvature guards sync to host. This scales to large orbital counts where the
+    explicit design matrix is infeasible.
+
+    ``initial_guess`` (a stacked ``(num_leaves, n, n)`` array) warm-starts CG. In
+    the C-DF optimizer the rotations -- and hence the cores -- change slowly
+    between L-BFGS steps, so seeding from the previous step's solution collapses
+    the iteration count.
+    """
+    n = eri_dev.shape[0]
+    num_leaves = len(rotations_dev)
+
+    # M_{tt'} = (U^t^T U^{t'}) elementwise-squared, stacked as (t, t', k, l).
+    rotations = xp.stack(rotations_dev)
+    metric = xp.einsum("tpk,upl->tukl", rotations, rotations)
+    metric = metric * metric
+    rhs = xp.stack(
+        [_project_eri_into_leaf(eri_dev, u, xp) for u in rotations_dev])
+
+    def apply_operator(z):
+        # A(Z)^t = sum_{t'} M_{tt'} Z^{t'} M_{tt'}^T, all leaves at once.
+        out = xp.einsum("tukl,ulm,tunm->tkn", metric, z, metric, optimize=True)
+        if regularization > 0.0:
+            out = out + (2.0 * regularization) * z
+        return out
+
+    def inner_product(x, y):
+        # A device scalar (0-d array); converted to host only where needed.
+        return xp.sum(x * y)
+
+    if initial_guess is None:
+        z = xp.zeros((num_leaves, n, n))
+        residual = rhs.copy()  # r = rhs - A(0) = rhs since z = 0
+    else:
+        z = xp.asarray(initial_guess).copy()
+        residual = rhs - apply_operator(z)
+    direction = residual.copy()
+    residual_norm_sq = inner_product(residual, residual)
+    threshold = (tolerance**2) * max(float(to_numpy(residual_norm_sq)), 1.0)
+    limit = max_iterations if max_iterations is not None else max(
+        50, num_leaves * n * n)
+
+    for _ in range(limit):
+        if float(to_numpy(residual_norm_sq)) <= threshold:
+            break
+        operator_direction = apply_operator(direction)
+        curvature = inner_product(direction, operator_direction)
+        if float(to_numpy(curvature)) <= 0.0:
+            break
+        step = residual_norm_sq / curvature  # device scalar
+        z = z + step * direction
+        residual = residual - step * operator_direction
+        new_norm_sq = inner_product(residual, residual)
+        beta = new_norm_sq / residual_norm_sq  # device scalar
+        direction = residual + beta * direction
+        residual_norm_sq = new_norm_sq
+
+    z = 0.5 * (z + z.transpose(0, 2, 1))
+    return [z[t] for t in range(num_leaves)]
+
+
+def _solve_inner_cores_lstsq(eri_dev, rotations_dev, xp, regularization=0.0):
+    """Least-squares optimal symmetric cores ``{Z^t}`` for fixed rotations.
+
+    Solves, for fixed ``U^t``,
+
+        min_Z  1/2 || eri - sum_t U^t Z^t (U^t)^T (congruence) ||_F^2
+                  + rho * sum_{t,k,l} (Z^t_kl)^2
+
+    exactly (linear in the symmetric ``Z^t``) via an explicit design matrix. The
+    ``rho`` (``regularization``) term is the RC-DF L2 penalty
+    (arXiv:2212.07957, Eq. 17); it shrinks the cores and conditions the otherwise
+    rank-deficient inner system. See ``_solve_inner_cores_cg`` for the matrix-free
+    alternative that scales to large orbital counts.
+    """
+    n = eri_dev.shape[0]
+    target = eri_dev.reshape(-1)
+
+    columns = []
+    metadata = []  # (leaf, k, l) with k <= l
+    for leaf_index, rotation in enumerate(rotations_dev):
+        a = _leaf_outer_columns(rotation, xp)  # (n*n, n)
+        for k in range(n):
+            for l in range(k, n):
+                column = xp.outer(a[:, k], a[:, l])
+                if l != k:
+                    column = column + xp.outer(a[:, l], a[:, k])
+                columns.append(column.reshape(-1))
+                metadata.append((leaf_index, k, l))
+
+    design = xp.stack(columns, axis=1)
+
+    if regularization > 0.0:
+        # Augmented rows enforce the L2 penalty rho * ||Z||_F^2 (full k, l). For
+        # the k <= l parameterization, off-diagonal entries appear twice in
+        # ||Z||_F^2, so they carry weight 2 (diagonal weight 1). The factor 2
+        # below comes from the 1/2 on the least-squares term in Eq. 17.
+        weights = xp.asarray(
+            [1.0 if k == l else 2.0 for (_, k, l) in metadata])
+        penalty = xp.sqrt(2.0 * regularization * weights)
+        design = xp.concatenate([design, xp.diag(penalty)], axis=0)
+        target = xp.concatenate([target, xp.zeros(penalty.shape[0])], axis=0)
+
+    solution = xp.linalg.lstsq(design, target, rcond=None)[0]
+
+    cores = [xp.zeros((n, n)) for _ in rotations_dev]
+    for index, (leaf_index, k, l) in enumerate(metadata):
+        value = solution[index]
+        cores[leaf_index][k, l] = value
+        cores[leaf_index][l, k] = value
+    return cores
+
+
+def _solve_inner_cores(eri_dev,
+                       rotations_dev,
+                       xp,
+                       regularization=0.0,
+                       solver="lstsq",
+                       cg_tolerance=1.0e-10,
+                       cg_max_iterations=None,
+                       initial_guess=None):
+    """Dispatch the inner core solve to the explicit ``"lstsq"`` solver or the
+    matrix-free ``"cg"`` solver. ``initial_guess`` warm-starts CG and is ignored
+    by the direct lstsq solver."""
+    if solver == "lstsq":
+        return _solve_inner_cores_lstsq(eri_dev, rotations_dev, xp,
+                                        regularization)
+    if solver == "cg":
+        return _solve_inner_cores_cg(eri_dev, rotations_dev, xp,
+                                     regularization, cg_tolerance,
+                                     cg_max_iterations, initial_guess)
+    raise ValueError(
+        "double_factorization error - inner_solver must be 'lstsq' or 'cg'.")
+
+
+def _reconstruct_dev(rotations_dev, cores_dev, xp):
+    # Stack the leaves and reconstruct in a single batched contraction (the sum
+    # over leaves t is folded into the einsum), instead of a Python loop with a
+    # separate n^4 einsum and accumulation per leaf.
+    rotations = rotations_dev if _is_stacked(rotations_dev) else xp.stack(
+        list(rotations_dev))
+    cores = cores_dev if _is_stacked(cores_dev) else xp.stack(list(cores_dev))
+    return xp.einsum("tpk,tqk,tkl,trl,tsl->pqrs",
+                     rotations,
+                     rotations,
+                     cores,
+                     rotations,
+                     rotations,
+                     optimize=True)
+
+
+def _is_stacked(arrays):
+    """True for a single stacked ``(num_leaves, n, n)`` array, False for a list
+    of ``(n, n)`` leaf arrays."""
+    return hasattr(arrays, "ndim") and arrays.ndim == 3
+
+
+def _skew_to_vector(generator, n):
+    rows, cols = np.tril_indices(n, k=-1)
+    return generator[rows, cols]
+
+
+def _vector_to_skew(vector, n, xp):
+    generator = xp.zeros((n, n))
+    rows, cols = np.tril_indices(n, k=-1)
+    rows = xp.asarray(rows)
+    cols = xp.asarray(cols)
+    generator[rows, cols] = vector
+    generator[cols, rows] = -vector
+    return generator
+
+
+def _initial_generators(eri, num_leaves, n, backend):
+    """Warm-start antisymmetric generators from a truncated X-DF (identity pads
+    any missing leaves)."""
+    xdf = explicit_double_factorization(eri,
+                                        threshold=0.0,
+                                        max_num_leaves=num_leaves,
+                                        backend=backend)
+    generators = []
+    for rotation in xdf.leaf_rotations:
+        rotation = np.asarray(rotation, dtype=float).copy()
+        # exp(antisymmetric) is always special orthogonal (det +1), but eigh
+        # leaf rotations can be reflections (det -1), which have no real
+        # antisymmetric logarithm. Flipping one column flips the determinant
+        # without changing u_k u_k^T (hence without changing the factorization),
+        # so force det +1 before taking the logarithm.
+        if np.linalg.det(rotation) < 0.0:
+            rotation[:, 0] *= -1.0
+        skew = scipy.linalg.logm(rotation).real
+        skew = 0.5 * (skew - skew.T)  # clean numerical asymmetry
+        generators.append(skew)
+    while len(generators) < num_leaves:
+        generators.append(np.zeros((n, n)))
+    return generators[:num_leaves]
+
+
+def compressed_double_factorization(
+        eri,
+        num_leaves: int,
+        max_iterations: int = 2000,
+        tolerance: float = 1.0e-10,
+        regularization: float = 0.0,
+        inner_solver: str = "lstsq",
+        cg_tolerance: float = 1.0e-10,
+        cg_max_iterations: Optional[int] = None,
+        cg_warm_start: bool = True,
+        cg_optimization_tolerance: Optional[float] = None,
+        initial_generators: Optional[List[np.ndarray]] = None,
+        backend: str = "auto") -> DoubleFactorization:
+    """Compressed double factorization (C-DF) by least-squares optimization.
+
+    Minimizes ``O = 1/2 || eri - sum_t U^t Z^t (U^t)^T (congruence) ||_F^2`` over
+    a fixed number of leaves. Uses the two-step scheme of arXiv:2104.08957: the
+    leaf rotations are parameterized as ``U^t = exp(X^t)`` with antisymmetric
+    ``X^t`` and optimized with L-BFGS (warm-started from X-DF), while the
+    symmetric cores ``Z^t`` are solved exactly in closed form at each step.
+
+    ``regularization`` (``rho``) enables RC-DF (arXiv:2212.07957, Eq. 17): the
+    L2 penalty ``rho * sum_{t,k,l} (Z^t_kl)^2`` is added to the objective and,
+    crucially, folded into the inner core solve as a ridge term. It shrinks the
+    cores -- lowering the Hamiltonian one-norm ``lambda`` and the measurement
+    variance -- and conditions the inner system. ``rho`` is an absolute
+    coefficient (its useful scale depends on the integral magnitude; the paper
+    uses ~1e-6 to 1e-3). ``rho = 0`` reproduces plain C-DF.
+
+    ``inner_solver`` selects how the cores are solved each step: ``"lstsq"``
+    (default) forms an explicit design matrix, while ``"cg"`` is the matrix-free
+    conjugate-gradient solve (RC-DF Eqs. 25-30) that avoids the ``n^4``-row design
+    matrix and scales to large orbital counts. ``cg_tolerance`` and
+    ``cg_max_iterations`` control the CG solve.
+
+    For ``inner_solver="cg"`` two accelerators cut the per-step CG cost without
+    changing the final accuracy: ``cg_warm_start`` (default ``True``) seeds each
+    step's CG from the previous step's cores -- which move slowly between L-BFGS
+    steps -- and ``cg_optimization_tolerance`` (default ``max(cg_tolerance,
+    1e-6)``) solves the *in-loop* systems only loosely (an inexact inner solve;
+    the gradient need only be approximate by the envelope theorem) while the
+    single final solve is tightened to ``cg_tolerance``.
+
+    Returns a :class:`DoubleFactorization` with NumPy arrays.
+    """
+    n = _validate_eri(eri)
+    if num_leaves < 1:
+        raise ValueError(
+            "double_factorization error - num_leaves must be >= 1.")
+    if inner_solver not in ("lstsq", "cg"):
+        raise ValueError(
+            "double_factorization error - inner_solver must be 'lstsq' or 'cg'."
+        )
+    xp, _ = resolve_backend(backend,
+                            problem_size=n,
+                            gpu_min_size=AUTO_GPU_MIN_ORBITALS_COMPRESSED)
+    eri_dev = to_device(np.asarray(eri, dtype=float), xp)
+
+    if initial_generators is None:
+        initial_generators = _initial_generators(eri, num_leaves, n, backend)
+
+    x0 = np.concatenate(
+        [_skew_to_vector(np.asarray(g), n) for g in initial_generators])
+
+    per_leaf = n * (n - 1) // 2
+    lower = np.tril_indices(n, k=-1)
+
+    # Inexact in-loop CG (forcing sequence) + warm start across L-BFGS steps.
+    use_warm = inner_solver == "cg" and cg_warm_start
+    loop_tolerance = (cg_optimization_tolerance if cg_optimization_tolerance
+                      is not None else max(cg_tolerance, 1.0e-6))
+    warm_state = {"z": None}
+
+    def unpack(parameter_vector):
+        # Build all leaf generators, then exponentiate them in one batched
+        # Hermitian eigendecomposition (single cuSOLVER call on GPU). Returns
+        # stacked (num_leaves, n, n) arrays.
+        skews = xp.stack([
+            _vector_to_skew(
+                to_device(parameter_vector[i * per_leaf:(i + 1) * per_leaf],
+                          xp), n, xp) for i in range(num_leaves)
+        ])
+        rotations = expm_skew_symmetric_batched(skews, xp)
+        return skews, rotations
+
+    def objective_and_gradient(parameter_vector):
+        # Two-step objective O(X) with the cores Z at their (regularized)
+        # least-squares optimum. Because dO/dZ = 0 there, the envelope theorem
+        # gives dO/dX = (dO/dU at fixed Z) chained through dU/dX; the L2 penalty
+        # has no explicit X-dependence, so the gradient keeps the same form for
+        # any regularization. dO/dU^t_ak = -4 sum_qrsl Delta_aqrs U_qk Z_kl U_rl
+        # U_sl (Eq. 17 of arXiv:2104.08957).
+        skews, rotations = unpack(parameter_vector)
+        cores = _solve_inner_cores(eri_dev, rotations, xp, regularization,
+                                   inner_solver, loop_tolerance,
+                                   cg_max_iterations,
+                                   warm_state["z"] if use_warm else None)
+        if use_warm:
+            warm_state["z"] = xp.stack(cores)
+        residual = eri_dev - _reconstruct_dev(rotations, cores, xp)
+        loss = 0.5 * xp.sum(residual * residual)
+        if regularization > 0.0:
+            loss = loss + regularization * sum(
+                xp.sum(core * core) for core in cores)
+        loss = float(to_numpy(loss))
+
+        # dO/dU for all leaves in one batched contraction, then a single
+        # device->host transfer (the leaf index t is the batch axis).
+        cores_dev = cores if _is_stacked(cores) else xp.stack(list(cores))
+        grad_u_all = to_numpy(-4.0 * xp.einsum("aqrs,tqk,tkl,trl,tsl->tak",
+                                               residual,
+                                               rotations,
+                                               cores_dev,
+                                               rotations,
+                                               rotations,
+                                               optimize=True))
+        skews_host = to_numpy(skews)
+        gradient_chunks = []
+        for leaf_index in range(num_leaves):
+            # Adjoint of d(exp)/dX: grad_X = L_exp(X^T, grad_U) (Frechet
+            # derivative), then project onto the antisymmetric parameters. The
+            # Frechet step stays on the host (it is ~2% of the step cost).
+            grad_x = scipy.linalg.expm_frechet(skews_host[leaf_index].T,
+                                               grad_u_all[leaf_index],
+                                               compute_expm=False)
+            grad_x = grad_x - grad_x.T
+            gradient_chunks.append(grad_x[lower])
+        return loss, np.concatenate(gradient_chunks)
+
+    result = scipy.optimize.minimize(objective_and_gradient,
+                                     x0,
+                                     method="L-BFGS-B",
+                                     jac=True,
+                                     options={
+                                         "maxiter": max_iterations,
+                                         "ftol": tolerance,
+                                         "gtol": tolerance,
+                                     })
+
+    # Final cores at the tight cg_tolerance (warm-started from the last step).
+    _, rotations = unpack(result.x)
+    cores = _solve_inner_cores(eri_dev, rotations, xp, regularization,
+                               inner_solver, cg_tolerance, cg_max_iterations,
+                               warm_state["z"] if use_warm else None)
+    return DoubleFactorization(num_orbitals=n,
+                               leaf_rotations=[to_numpy(r) for r in rotations],
+                               leaf_cores=[to_numpy(c) for c in cores],
+                               method="C-DF")
+
+
+def reconstruct_eri(factorization: DoubleFactorization) -> np.ndarray:
+    """Reconstruct the chemist-notation ERI tensor from a factorization."""
+    return factorization.reconstruct_eri()
+
+
+def factorization_error(eri, factorization: DoubleFactorization) -> float:
+    """Frobenius norm of the ERI reconstruction residual."""
+    return float(
+        np.linalg.norm(
+            np.asarray(eri, dtype=float) - factorization.reconstruct_eri()))
+
+
+def modified_one_body_integrals(one_body, eri) -> np.ndarray:
+    """Return the DF-corrected one-body matrix ``kappa_pq = h_pq - 1/2 sum_r
+    (pr|qr)`` (Eq. 3 of arXiv:2104.08957), used when assembling the full
+    double-factorized Hamiltonian from the two-body factorization."""
+    one_body = np.asarray(one_body, dtype=float)
+    eri = np.asarray(eri, dtype=float)
+    return one_body - 0.5 * np.einsum("prqr->pq", eri, optimize=True)
+
+
+def double_factorization_one_norm(factorization: DoubleFactorization,
+                                  one_body_eigenvalues,
+                                  convention: str = "lcu") -> float:
+    """One-norm ``lambda`` of the double-factorized Hamiltonian (RC-DF,
+    arXiv:2212.07957), used to assess factorization quality.
+
+    ``convention="lcu"`` (Eq. 13) -- the LCU / Pauli-rotation norm
+    ``sum_k |F_k| + sum_t (sum_{k<l} |Z^t_kl| + 1/4 sum_k |Z^t_kk|)``.
+
+    ``convention="burg"`` (Eq. 15) -- the qubitization norm
+    ``sum_k |F_k| + 1/4 sum_t sum_i (sum_k |W^t_ki|)^2`` with ``W^t = sqrt(Z^t)``
+    (the matrix square root, which may be complex for indefinite cores).
+
+    ``one_body_eigenvalues`` are the diagonal one-body (Fock-like) eigenvalues.
+    """
+    one_body_eigenvalues = np.asarray(one_body_eigenvalues, dtype=float)
+    lam = float(np.sum(np.abs(one_body_eigenvalues)))
+
+    if convention == "lcu":
+        for core in factorization.leaf_cores:
+            core = np.asarray(core)
+            # sum_{k<l} |Z_kl| (strict upper triangle) + 1/4 sum_k |Z_kk|
+            lam += float(np.sum(np.abs(np.triu(core, k=1))))
+            lam += 0.25 * float(np.sum(np.abs(np.diag(core))))
+        return lam
+
+    if convention == "burg":
+        for core in factorization.leaf_cores:
+            eigenvalues, vectors = np.linalg.eigh(np.asarray(core,
+                                                             dtype=float))
+            root = (vectors * np.sqrt(eigenvalues.astype(complex))) @ \
+                vectors.conj().T  # W = sqrt(Z), possibly complex
+            column_abs_sum = np.sum(np.abs(root), axis=0)  # sum_k |W_ki| per i
+            lam += 0.25 * float(np.sum(column_abs_sum**2))
+        return lam
+
+    raise ValueError(
+        "double_factorization error - convention must be 'lcu' or 'burg'.")

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -125,9 +125,9 @@ def _pivoted_cholesky(
     return vectors, pivots
 
 
-def _second_factorization(
-        leaf: DeviceArray, scale: ArrayLike, second_factor_threshold: float,
-        xp: ArrayModule) -> tuple[np.ndarray, np.ndarray]:
+def _second_factorization(leaf: DeviceArray, scale: ArrayLike,
+                          second_factor_threshold: float,
+                          xp: ArrayModule) -> tuple[np.ndarray, np.ndarray]:
     """Eigendecompose a symmetric leaf ``L = U diag(gamma) U^T`` and return
     ``(U, Z)`` with the symmetric core ``Z = scale * outer(gamma, gamma)``."""
     leaf = 0.5 * (leaf + leaf.T)
@@ -227,8 +227,7 @@ def explicit_double_factorization(
                                leaf_weights=np.asarray(weights))
 
 
-def _leaf_outer_columns(rotation: DeviceArray,
-                        xp: ArrayModule) -> DeviceArray:
+def _leaf_outer_columns(rotation: DeviceArray, xp: ArrayModule) -> DeviceArray:
     """Return ``A`` with ``A[:, k] = vec(u_k u_k^T)`` for rotation columns u_k."""
     n = rotation.shape[0]
     outer = xp.einsum("pk,qk->pqk", rotation, rotation)
@@ -325,11 +324,10 @@ def _solve_inner_cores_cg(
     return [z[t] for t in range(num_leaves)]
 
 
-def _solve_inner_cores_lstsq(
-        eri_dev: DeviceArray,
-        rotations_dev: DeviceArray,
-        xp: ArrayModule,
-        regularization: float = 0.0) -> List[DeviceArray]:
+def _solve_inner_cores_lstsq(eri_dev: DeviceArray,
+                             rotations_dev: DeviceArray,
+                             xp: ArrayModule,
+                             regularization: float = 0.0) -> List[DeviceArray]:
     """Least-squares optimal symmetric cores ``{Z^t}`` for fixed rotations.
 
     Solves, for fixed ``U^t``,

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -109,7 +109,10 @@ def _pivoted_cholesky(
     floor = max(float(threshold), initial_max * 1.0e-14)
     vectors: List = []
     pivots: List[float] = []
-    most_negative = 0.0
+    # Track the initial diagonal too: a (near-)negative-semidefinite input
+    # yields few or zero pivots, and that is exactly the case that most
+    # needs the warning below.
+    most_negative = min(0.0, float(xp.min(residual))) if m else 0.0
     limit = m if max_rank is None else min(int(max_rank), m)
     for _ in range(limit):
         pivot_index = int(xp.argmax(residual))
@@ -125,7 +128,8 @@ def _pivoted_cholesky(
         residual = residual - vector * vector
         most_negative = min(most_negative, float(xp.min(residual)))
         residual = xp.where(residual > 0.0, residual, 0.0)
-    if initial_max > 0.0 and most_negative < -1.0e-8 * initial_max:
+    negative_scale = max(initial_max, -most_negative)
+    if negative_scale > 0.0 and most_negative < -1.0e-8 * negative_scale:
         warnings.warn(
             "double_factorization: the ERI supermatrix is not positive "
             f"semidefinite (residual diagonal reached {most_negative:.3e}); "
@@ -158,11 +162,16 @@ def _validate_eri(eri: ArrayLike) -> int:
                          "chemist notation (pq|rs).")
     # The leaf symmetrization silently assumes the real-orbital index
     # symmetries within each pair; a violation would otherwise surface only
-    # as an unexplained reconstruction error.
+    # as an unexplained reconstruction error. Pair swap is included: the
+    # C-DF gradient folds four residual terms into a single -4 prefactor,
+    # which assumes the full 8-fold symmetry on the unsymmetrized tensor
+    # (X-DF symmetrizes the supermatrix and would hide a violation; C-DF
+    # would silently optimize the wrong objective).
     if not (np.allclose(eri, eri.transpose(1, 0, 2, 3))
-            and np.allclose(eri, eri.transpose(0, 1, 3, 2))):
+            and np.allclose(eri, eri.transpose(0, 1, 3, 2))
+            and np.allclose(eri, eri.transpose(2, 3, 0, 1))):
         raise ValueError("eri must have the real-orbital chemist symmetries "
-                         "(pq|rs) == (qp|rs) == (pq|sr).")
+                         "(pq|rs) == (qp|rs) == (pq|sr) == (rs|pq).")
     return eri.shape[0]
 
 
@@ -219,8 +228,12 @@ def explicit_double_factorization(
         eigenvalues, eigenvectors = _sorted_symmetric_eigendecomposition(
             supermatrix, xp)
         abs_eigenvalues = to_numpy(xp.abs(eigenvalues))
+        # Same relative rank floor as the Cholesky path: threshold == 0
+        # stops at the numerical rank instead of emitting n^2 null leaves.
+        top = float(abs_eigenvalues[0]) if abs_eigenvalues.size else 0.0
+        floor = max(float(threshold), top * 1.0e-14)
         for index in range(n * n):
-            if abs_eigenvalues[index] <= threshold:
+            if abs_eigenvalues[index] <= floor:
                 break
             if max_num_leaves is not None and len(rotations) >= max_num_leaves:
                 break
@@ -476,6 +489,13 @@ def _initial_generators(eri: ArrayLike, num_leaves: int, n: int,
             rotation[:, 0] *= -1.0
         skew = scipy.linalg.logm(rotation).real
         skew = 0.5 * (skew - skew.T)  # clean numerical asymmetry
+        # logm sits on a branch cut for rotations with a (-1, -1)
+        # eigenvalue pair (det +1), where taking .real silently yields
+        # exp(skew) != rotation. The generators are only a warm start, so
+        # fall back to a neutral zero generator instead of seeding the
+        # optimizer with a wrong one.
+        if not np.allclose(scipy.linalg.expm(skew), rotation, atol=1.0e-8):
+            skew = np.zeros_like(skew)
         generators.append(skew)
     while len(generators) < num_leaves:
         generators.append(np.zeros((n, n)))
@@ -661,9 +681,15 @@ def double_factorization_one_norm(factorization: DoubleFactorization,
     ``convention="lcu"`` (Eq. 13) -- the LCU / Pauli-rotation norm
     ``sum_k |F_k| + sum_t (sum_{k<l} |Z^t_kl| + 1/4 sum_k |Z^t_kk|)``.
 
-    ``convention="burg"`` (Eq. 15) -- the qubitization norm
-    ``sum_k |F_k| + 1/4 sum_t sum_i (sum_k |W^t_ki|)^2`` with ``W^t = sqrt(Z^t)``
-    (the matrix square root, which may be complex for indefinite cores).
+    ``convention="burg"`` -- the qubitization norm in the standard
+    von Burg/Lee form: with each core eigendecomposed as
+    ``Z^t = sum_i lambda^t_i v^t_i (v^t_i)^T``,
+    ``sum_k |F_k| + 1/4 sum_t sum_i |lambda^t_i| (sum_k |v^t_ki|)^2``.
+    (A factorization ``Z = W W^T`` leaves ``W`` free up to a right
+    orthogonal gauge, and the column-norm formula is not gauge
+    invariant; the eigenfactor is the standard, gauge-fixed choice and
+    reduces to RC-DF Eq. 15 / von Burg's ``(1/4)(sum_k |gamma_k|)^2``
+    for rank-one cores.)
 
     ``one_body_eigenvalues`` are the diagonal one-body (Fock-like) eigenvalues.
     """
@@ -682,10 +708,9 @@ def double_factorization_one_norm(factorization: DoubleFactorization,
         for core in factorization.leaf_cores:
             eigenvalues, vectors = np.linalg.eigh(np.asarray(core,
                                                              dtype=float))
-            root = (vectors * np.sqrt(eigenvalues.astype(complex))) @ \
-                vectors.conj().T  # W = sqrt(Z), possibly complex
-            column_abs_sum = np.sum(np.abs(root), axis=0)  # sum_k |W_ki| per i
-            lam += 0.25 * float(np.sum(column_abs_sum**2))
+            column_abs_sum = np.sum(np.abs(vectors), axis=0)
+            lam += 0.25 * float(np.sum(
+                np.abs(eigenvalues) * column_abs_sum**2))
         return lam
 
     raise ValueError("convention must be 'lcu' or 'burg'.")

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -32,10 +32,12 @@ import numpy as np
 import scipy.linalg
 import scipy.optimize
 
+from numpy.typing import ArrayLike
+
 from ._backend import (AUTO_GPU_MIN_ORBITALS_COMPRESSED,
-                       AUTO_GPU_MIN_ORBITALS_EXPLICIT,
-                       expm_skew_symmetric_batched, resolve_backend, to_device,
-                       to_numpy)
+                       AUTO_GPU_MIN_ORBITALS_EXPLICIT, ArrayModule,
+                       DeviceArray, expm_skew_symmetric_batched,
+                       resolve_backend, to_device, to_numpy)
 
 
 @dataclass
@@ -75,14 +77,18 @@ class DoubleFactorization:
         return eri
 
 
-def _sorted_symmetric_eigendecomposition(matrix, xp):
+def _sorted_symmetric_eigendecomposition(
+        matrix: DeviceArray,
+        xp: ArrayModule) -> tuple[DeviceArray, DeviceArray]:
     """Eigenpairs of a symmetric matrix, ordered by descending |eigenvalue|."""
     eigenvalues, eigenvectors = xp.linalg.eigh(matrix)
     order = xp.argsort(xp.abs(eigenvalues))[::-1]
     return eigenvalues[order], eigenvectors[:, order]
 
 
-def _pivoted_cholesky(matrix, threshold, max_rank, xp):
+def _pivoted_cholesky(
+        matrix: DeviceArray, threshold: float, max_rank: Optional[int],
+        xp: ArrayModule) -> tuple[List[DeviceArray], List[float]]:
     """Pivoted Cholesky factorization of a symmetric positive-semidefinite
     matrix: returns ``(vectors, pivots)`` with ``matrix ~= sum_t v_t v_t^T``.
 
@@ -119,7 +125,9 @@ def _pivoted_cholesky(matrix, threshold, max_rank, xp):
     return vectors, pivots
 
 
-def _second_factorization(leaf, scale, second_factor_threshold, xp):
+def _second_factorization(
+        leaf: DeviceArray, scale: ArrayLike, second_factor_threshold: float,
+        xp: ArrayModule) -> tuple[np.ndarray, np.ndarray]:
     """Eigendecompose a symmetric leaf ``L = U diag(gamma) U^T`` and return
     ``(U, Z)`` with the symmetric core ``Z = scale * outer(gamma, gamma)``."""
     leaf = 0.5 * (leaf + leaf.T)
@@ -132,7 +140,7 @@ def _second_factorization(leaf, scale, second_factor_threshold, xp):
     return to_numpy(rotation), to_numpy(core)
 
 
-def _validate_eri(eri) -> int:
+def _validate_eri(eri: ArrayLike) -> int:
     eri = np.asarray(eri)
     if eri.ndim != 4 or len(set(eri.shape)) != 1:
         raise ValueError(
@@ -142,7 +150,7 @@ def _validate_eri(eri) -> int:
 
 
 def explicit_double_factorization(
-        eri,
+        eri: ArrayLike,
         threshold: float = 1.0e-8,
         max_num_leaves: Optional[int] = None,
         second_factor_threshold: float = 0.0,
@@ -219,27 +227,30 @@ def explicit_double_factorization(
                                leaf_weights=np.asarray(weights))
 
 
-def _leaf_outer_columns(rotation, xp):
+def _leaf_outer_columns(rotation: DeviceArray,
+                        xp: ArrayModule) -> DeviceArray:
     """Return ``A`` with ``A[:, k] = vec(u_k u_k^T)`` for rotation columns u_k."""
     n = rotation.shape[0]
     outer = xp.einsum("pk,qk->pqk", rotation, rotation)
     return outer.reshape(n * n, n)
 
 
-def _project_eri_into_leaf(eri_dev, rotation, xp):
+def _project_eri_into_leaf(eri_dev: DeviceArray, rotation: DeviceArray,
+                           xp: ArrayModule) -> DeviceArray:
     """R^t_kl = sum_pqrs U^t_pk U^t_qk (pq|rs) U^t_rl U^t_sl (the RHS of the inner
     normal equations / projection of the ERIs into a leaf's rotated basis)."""
     a = xp.einsum("pk,qk->pqk", rotation, rotation)
     return xp.einsum("pqk,pqrs,rsl->kl", a, eri_dev, a, optimize=True)
 
 
-def _solve_inner_cores_cg(eri_dev,
-                          rotations_dev,
-                          xp,
-                          regularization=0.0,
-                          tolerance=1.0e-10,
-                          max_iterations=None,
-                          initial_guess=None):
+def _solve_inner_cores_cg(
+        eri_dev: DeviceArray,
+        rotations_dev: DeviceArray,
+        xp: ArrayModule,
+        regularization: float = 0.0,
+        tolerance: float = 1.0e-10,
+        max_iterations: Optional[int] = None,
+        initial_guess: Optional[DeviceArray] = None) -> List[DeviceArray]:
     """Matrix-free conjugate-gradient solve for the symmetric cores ``{Z^t}``.
 
     Solves the same normal equations as the least-squares solver,
@@ -314,7 +325,11 @@ def _solve_inner_cores_cg(eri_dev,
     return [z[t] for t in range(num_leaves)]
 
 
-def _solve_inner_cores_lstsq(eri_dev, rotations_dev, xp, regularization=0.0):
+def _solve_inner_cores_lstsq(
+        eri_dev: DeviceArray,
+        rotations_dev: DeviceArray,
+        xp: ArrayModule,
+        regularization: float = 0.0) -> List[DeviceArray]:
     """Least-squares optimal symmetric cores ``{Z^t}`` for fixed rotations.
 
     Solves, for fixed ``U^t``,
@@ -366,14 +381,15 @@ def _solve_inner_cores_lstsq(eri_dev, rotations_dev, xp, regularization=0.0):
     return cores
 
 
-def _solve_inner_cores(eri_dev,
-                       rotations_dev,
-                       xp,
-                       regularization=0.0,
-                       solver="lstsq",
-                       cg_tolerance=1.0e-10,
-                       cg_max_iterations=None,
-                       initial_guess=None):
+def _solve_inner_cores(
+        eri_dev: DeviceArray,
+        rotations_dev: DeviceArray,
+        xp: ArrayModule,
+        regularization: float = 0.0,
+        solver: str = "lstsq",
+        cg_tolerance: float = 1.0e-10,
+        cg_max_iterations: Optional[int] = None,
+        initial_guess: Optional[DeviceArray] = None) -> List[DeviceArray]:
     """Dispatch the inner core solve to the explicit ``"lstsq"`` solver or the
     matrix-free ``"cg"`` solver. ``initial_guess`` warm-starts CG and is ignored
     by the direct lstsq solver."""
@@ -388,7 +404,8 @@ def _solve_inner_cores(eri_dev,
         "double_factorization error - inner_solver must be 'lstsq' or 'cg'.")
 
 
-def _reconstruct_dev(rotations_dev, cores_dev, xp):
+def _reconstruct_dev(rotations_dev: DeviceArray, cores_dev: DeviceArray,
+                     xp: ArrayModule) -> DeviceArray:
     # Stack the leaves and reconstruct in a single batched contraction (the sum
     # over leaves t is folded into the einsum), instead of a Python loop with a
     # separate n^4 einsum and accumulation per leaf.
@@ -404,18 +421,19 @@ def _reconstruct_dev(rotations_dev, cores_dev, xp):
                      optimize=True)
 
 
-def _is_stacked(arrays):
+def _is_stacked(arrays: object) -> bool:
     """True for a single stacked ``(num_leaves, n, n)`` array, False for a list
     of ``(n, n)`` leaf arrays."""
     return hasattr(arrays, "ndim") and arrays.ndim == 3
 
 
-def _skew_to_vector(generator, n):
+def _skew_to_vector(generator: np.ndarray, n: int) -> np.ndarray:
     rows, cols = np.tril_indices(n, k=-1)
     return generator[rows, cols]
 
 
-def _vector_to_skew(vector, n, xp):
+def _vector_to_skew(vector: DeviceArray, n: int,
+                    xp: ArrayModule) -> DeviceArray:
     generator = xp.zeros((n, n))
     rows, cols = np.tril_indices(n, k=-1)
     rows = xp.asarray(rows)
@@ -425,7 +443,8 @@ def _vector_to_skew(vector, n, xp):
     return generator
 
 
-def _initial_generators(eri, num_leaves, n, backend):
+def _initial_generators(eri: ArrayLike, num_leaves: int, n: int,
+                        backend: str) -> List[np.ndarray]:
     """Warm-start antisymmetric generators from a truncated X-DF (identity pads
     any missing leaves)."""
     xdf = explicit_double_factorization(eri,
@@ -451,7 +470,7 @@ def _initial_generators(eri, num_leaves, n, backend):
 
 
 def compressed_double_factorization(
-        eri,
+        eri: ArrayLike,
         num_leaves: int,
         max_iterations: int = 2000,
         tolerance: float = 1.0e-10,
@@ -605,14 +624,16 @@ def reconstruct_eri(factorization: DoubleFactorization) -> np.ndarray:
     return factorization.reconstruct_eri()
 
 
-def factorization_error(eri, factorization: DoubleFactorization) -> float:
+def factorization_error(eri: ArrayLike,
+                        factorization: DoubleFactorization) -> float:
     """Frobenius norm of the ERI reconstruction residual."""
     return float(
         np.linalg.norm(
             np.asarray(eri, dtype=float) - factorization.reconstruct_eri()))
 
 
-def modified_one_body_integrals(one_body, eri) -> np.ndarray:
+def modified_one_body_integrals(one_body: ArrayLike,
+                                eri: ArrayLike) -> np.ndarray:
     """Return the DF-corrected one-body matrix ``kappa_pq = h_pq - 1/2 sum_r
     (pr|qr)`` (Eq. 3 of arXiv:2104.08957), used when assembling the full
     double-factorized Hamiltonian from the two-body factorization."""
@@ -622,7 +643,7 @@ def modified_one_body_integrals(one_body, eri) -> np.ndarray:
 
 
 def double_factorization_one_norm(factorization: DoubleFactorization,
-                                  one_body_eigenvalues,
+                                  one_body_eigenvalues: ArrayLike,
                                   convention: str = "lcu") -> float:
     """One-norm ``lambda`` of the double-factorized Hamiltonian (RC-DF,
     arXiv:2212.07957), used to assess factorization quality.

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -154,17 +154,15 @@ def _second_factorization(leaf: DeviceArray, scale: ArrayLike,
 def _validate_eri(eri: ArrayLike) -> int:
     eri = np.asarray(eri)
     if eri.ndim != 4 or len(set(eri.shape)) != 1:
-        raise ValueError(
-            "double_factorization error - eri must be a square rank-4 tensor "
-            "(n, n, n, n) in chemist notation (pq|rs).")
+        raise ValueError("eri must be a square rank-4 tensor (n, n, n, n) in "
+                         "chemist notation (pq|rs).")
     # The leaf symmetrization silently assumes the real-orbital index
     # symmetries within each pair; a violation would otherwise surface only
     # as an unexplained reconstruction error.
     if not (np.allclose(eri, eri.transpose(1, 0, 2, 3))
             and np.allclose(eri, eri.transpose(0, 1, 3, 2))):
-        raise ValueError(
-            "double_factorization error - eri must have the real-orbital "
-            "chemist symmetries (pq|rs) == (qp|rs) == (pq|sr).")
+        raise ValueError("eri must have the real-orbital chemist symmetries "
+                         "(pq|rs) == (qp|rs) == (pq|sr).")
     return eri.shape[0]
 
 
@@ -234,9 +232,8 @@ def explicit_double_factorization(
             cores.append(core)
             weights.append(float(to_numpy(lam)))
     else:
-        raise ValueError(
-            "double_factorization error - first_factorization must be "
-            "'cholesky' or 'eigendecomposition'.")
+        raise ValueError("first_factorization must be 'cholesky' or "
+                         "'eigendecomposition'.")
 
     return DoubleFactorization(num_orbitals=n,
                                leaf_rotations=rotations,
@@ -417,8 +414,7 @@ def _solve_inner_cores(
         return _solve_inner_cores_cg(eri_dev, rotations_dev, xp,
                                      regularization, cg_tolerance,
                                      cg_max_iterations, initial_guess)
-    raise ValueError(
-        "double_factorization error - inner_solver must be 'lstsq' or 'cg'.")
+    raise ValueError("inner_solver must be 'lstsq' or 'cg'.")
 
 
 def _reconstruct_dev(rotations_dev: DeviceArray, cores_dev: DeviceArray,
@@ -533,12 +529,9 @@ def compressed_double_factorization(
     """
     n = _validate_eri(eri)
     if num_leaves < 1:
-        raise ValueError(
-            "double_factorization error - num_leaves must be >= 1.")
+        raise ValueError("num_leaves must be >= 1.")
     if inner_solver not in ("lstsq", "cg"):
-        raise ValueError(
-            "double_factorization error - inner_solver must be 'lstsq' or 'cg'."
-        )
+        raise ValueError("inner_solver must be 'lstsq' or 'cg'.")
     xp, _ = resolve_backend(backend,
                             problem_size=n,
                             gpu_min_size=AUTO_GPU_MIN_ORBITALS_COMPRESSED)
@@ -695,5 +688,4 @@ def double_factorization_one_norm(factorization: DoubleFactorization,
             lam += 0.25 * float(np.sum(column_abs_sum**2))
         return lam
 
-    raise ValueError(
-        "double_factorization error - convention must be 'lcu' or 'burg'.")
+    raise ValueError("convention must be 'lcu' or 'burg'.")

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -25,6 +25,7 @@ fewer leaves at equal accuracy.
 """
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -108,6 +109,7 @@ def _pivoted_cholesky(
     floor = max(float(threshold), initial_max * 1.0e-14)
     vectors: List = []
     pivots: List[float] = []
+    most_negative = 0.0
     limit = m if max_rank is None else min(int(max_rank), m)
     for _ in range(limit):
         pivot_index = int(xp.argmax(residual))
@@ -121,7 +123,16 @@ def _pivoted_cholesky(
         vectors.append(vector)
         pivots.append(pivot)
         residual = residual - vector * vector
+        most_negative = min(most_negative, float(xp.min(residual)))
         residual = xp.where(residual > 0.0, residual, 0.0)
+    if initial_max > 0.0 and most_negative < -1.0e-8 * initial_max:
+        warnings.warn(
+            "double_factorization: the ERI supermatrix is not positive "
+            f"semidefinite (residual diagonal reached {most_negative:.3e}); "
+            "the pivoted-Cholesky first factorization drops the negative "
+            "part, so the reconstruction error can far exceed `threshold`. "
+            "Use first_factorization='eigendecomposition' for indefinite "
+            "inputs.", RuntimeWarning)
     return vectors, pivots
 
 
@@ -146,6 +157,14 @@ def _validate_eri(eri: ArrayLike) -> int:
         raise ValueError(
             "double_factorization error - eri must be a square rank-4 tensor "
             "(n, n, n, n) in chemist notation (pq|rs).")
+    # The leaf symmetrization silently assumes the real-orbital index
+    # symmetries within each pair; a violation would otherwise surface only
+    # as an unexplained reconstruction error.
+    if not (np.allclose(eri, eri.transpose(1, 0, 2, 3))
+            and np.allclose(eri, eri.transpose(0, 1, 3, 2))):
+        raise ValueError(
+            "double_factorization error - eri must have the real-orbital "
+            "chemist symmetries (pq|rs) == (qp|rs) == (pq|sr).")
     return eri.shape[0]
 
 

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -370,3 +370,24 @@ def test_explicit_double_factorization_matches_openfermion_reference():
     np.testing.assert_allclose(mine.reconstruct_eri(),
                                reference_eri,
                                atol=1.0e-9)
+
+
+def test_asymmetric_eri_is_rejected():
+    eri = _synthetic_eri(4, 3, seed=11)
+    eri[0, 1, 2, 3] += 0.05  # break (pq|rs) == (qp|rs)
+    with pytest.raises(ValueError, match="chemist symmetries"):
+        df.explicit_double_factorization(eri)
+
+
+def test_indefinite_eri_warns_on_cholesky_path():
+    # A negative-weight leaf makes the supermatrix indefinite while keeping
+    # the within-pair index symmetries intact.
+    eri = _synthetic_eri(4, 3, seed=12) - 2.0 * _synthetic_eri(4, 1, seed=13)
+    with pytest.warns(RuntimeWarning, match="not positive semidefinite"):
+        factorization = df.explicit_double_factorization(eri)
+    # The dropped negative part shows up as reconstruction error far above
+    # the threshold; the eigendecomposition path handles the same input.
+    assert df.factorization_error(eri, factorization) > 1.0e-3
+    exact = df.explicit_double_factorization(
+        eri, first_factorization="eigendecomposition")
+    assert df.factorization_error(eri, exact) < 1.0e-10

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -1,0 +1,372 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""Tests for explicit (X-DF) and compressed (C-DF) double factorization."""
+import os
+
+import numpy as np
+import pytest
+
+import cudaq_algorithms as algorithms
+
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+
+df = algorithms.double_factorization
+
+# Run every test on the NumPy backend, plus the CuPy (GPU) backend when present.
+_BACKENDS = ["numpy"]
+if df.cupy_gpu_available():
+    _BACKENDS.append("cupy")
+
+
+def _synthetic_eri(n, num_vectors, seed):
+    """An 8-fold-symmetric chemist-notation ERI of known low rank."""
+    rng = np.random.default_rng(seed)
+    leaves = rng.standard_normal((num_vectors, n, n))
+    leaves = 0.5 * (leaves + leaves.transpose(0, 2, 1))
+    return np.einsum("xpq,xrs->pqrs", leaves, leaves)
+
+
+def _h2o_eri():
+    pytest.importorskip("pyscf")
+    from pyscf import ao2mo, gto, scf
+    mol = gto.M(atom="O 0 0 0; H 0 0 0.957; H 0 0.926 -0.24",
+                basis="sto-3g",
+                verbose=0)
+    mf = scf.RHF(mol).run()
+    n = mf.mo_coeff.shape[1]
+    return np.asarray(ao2mo.restore("s1", ao2mo.kernel(mol, mf.mo_coeff), n))
+
+
+def _max_orthogonality_error(factorization):
+    return max((float(np.linalg.norm(u.T @ u - np.eye(u.shape[0])))
+                for u in factorization.leaf_rotations),
+               default=0.0)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_explicit_double_factorization_is_exact_at_full_rank(backend):
+    eri = _h2o_eri()
+    factorization = df.explicit_double_factorization(eri,
+                                                     threshold=0.0,
+                                                     backend=backend)
+    assert factorization.method == "X-DF"
+    assert df.factorization_error(eri, factorization) < 1.0e-9
+    assert _max_orthogonality_error(factorization) < 1.0e-10
+    # Cores are symmetric.
+    for core in factorization.leaf_cores:
+        assert np.allclose(core, core.T, atol=1.0e-12)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_explicit_double_factorization_truncation_monotone(backend):
+    eri = _h2o_eri()
+    full = df.explicit_double_factorization(eri,
+                                            threshold=0.0,
+                                            backend=backend)
+    coarse = df.explicit_double_factorization(eri,
+                                              threshold=1.0e-2,
+                                              backend=backend)
+    fine = df.explicit_double_factorization(eri,
+                                            threshold=1.0e-4,
+                                            backend=backend)
+    # More aggressive truncation -> fewer leaves and larger (or equal) error.
+    assert coarse.num_leaves <= fine.num_leaves <= full.num_leaves
+    assert (df.factorization_error(eri, coarse)
+            >= df.factorization_error(eri, fine) - 1.0e-12)
+    # max_num_leaves caps the leaf count.
+    capped = df.explicit_double_factorization(eri,
+                                              threshold=0.0,
+                                              max_num_leaves=3,
+                                              backend=backend)
+    assert capped.num_leaves == 3
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_pivoted_cholesky_is_default_and_rank_revealing(backend):
+    eri = _h2o_eri()
+    n = eri.shape[0]
+    factorization = df.explicit_double_factorization(eri,
+                                                     threshold=1.0e-12,
+                                                     backend=backend)
+    # Pivoted Cholesky is the default first factorization.
+    assert factorization.first_factorization == "cholesky"
+    # The ERI supermatrix is PSD, so Cholesky stops at the true rank
+    # (<= the symmetric-pair dimension n(n+1)/2), not n^2.
+    assert factorization.num_leaves <= n * (n + 1) // 2
+    assert df.factorization_error(eri, factorization) < 1.0e-8
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_cholesky_and_eigendecomposition_agree(backend):
+    eri = _h2o_eri()
+    cholesky = df.explicit_double_factorization(eri,
+                                                threshold=0.0,
+                                                first_factorization="cholesky",
+                                                backend=backend)
+    eigen = df.explicit_double_factorization(
+        eri,
+        threshold=0.0,
+        first_factorization="eigendecomposition",
+        backend=backend)
+    assert eigen.first_factorization == "eigendecomposition"
+    # Both reconstruct the same ERI exactly, regardless of first-factor method.
+    assert df.factorization_error(eri, cholesky) < 1.0e-9
+    assert df.factorization_error(eri, eigen) < 1.0e-9
+    np.testing.assert_allclose(cholesky.reconstruct_eri(),
+                               eigen.reconstruct_eri(),
+                               atol=1.0e-9)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_compressed_double_factorization_beats_explicit(backend):
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=7)
+    for num_leaves in (1, 2):
+        explicit = df.explicit_double_factorization(eri,
+                                                    threshold=0.0,
+                                                    max_num_leaves=num_leaves,
+                                                    backend=backend)
+        compressed = df.compressed_double_factorization(eri,
+                                                        num_leaves=num_leaves,
+                                                        max_iterations=500,
+                                                        backend=backend)
+        assert compressed.method == "C-DF"
+        assert compressed.num_leaves == num_leaves
+        # Compression is never worse than the explicit factorization.
+        assert (df.factorization_error(eri, compressed)
+                <= df.factorization_error(eri, explicit) + 1.0e-6)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_compressed_double_factorization_exact_at_true_rank(backend):
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=11)
+    compressed = df.compressed_double_factorization(eri,
+                                                    num_leaves=3,
+                                                    max_iterations=1500,
+                                                    backend=backend)
+    assert df.factorization_error(eri, compressed) < 1.0e-4
+    assert _max_orthogonality_error(compressed) < 1.0e-9
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_rcdf_regularization_shrinks_cores_and_one_norm(backend):
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=7)
+    one_body = np.array([0.4, -0.3, 0.2, -0.1])
+
+    plain = df.compressed_double_factorization(eri,
+                                               num_leaves=2,
+                                               max_iterations=800,
+                                               regularization=0.0,
+                                               backend=backend)
+    regularized = df.compressed_double_factorization(eri,
+                                                     num_leaves=2,
+                                                     max_iterations=800,
+                                                     regularization=1.0e-2,
+                                                     backend=backend)
+
+    def core_norm(factorization):
+        return sum(float(np.linalg.norm(z)) for z in factorization.leaf_cores)
+
+    # RC-DF shrinks the cores ...
+    assert core_norm(regularized) < core_norm(plain)
+    # ... lowering the Hamiltonian one-norm in both conventions ...
+    for convention in ("lcu", "burg"):
+        assert (df.double_factorization_one_norm(regularized,
+                                                 one_body,
+                                                 convention=convention)
+                < df.double_factorization_one_norm(plain,
+                                                   one_body,
+                                                   convention=convention))
+    # ... at the cost of reconstruction accuracy.
+    assert (df.factorization_error(eri, regularized)
+            >= df.factorization_error(eri, plain) - 1.0e-9)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_compressed_matrix_free_cg_matches_lstsq(backend):
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=11)
+    # The matrix-free conjugate-gradient inner solve (RC-DF Eqs. 25-30) is an
+    # alternative to the explicit design-matrix least squares; both must reach
+    # the same reconstruction accuracy, with and without regularization.
+    for regularization in (0.0, 1.0e-2):
+        lstsq = df.compressed_double_factorization(
+            eri,
+            num_leaves=2,
+            max_iterations=800,
+            regularization=regularization,
+            inner_solver="lstsq",
+            backend=backend)
+        cg = df.compressed_double_factorization(eri,
+                                                num_leaves=2,
+                                                max_iterations=800,
+                                                regularization=regularization,
+                                                inner_solver="cg",
+                                                backend=backend)
+        assert cg.method == "C-DF"
+        assert abs(
+            df.factorization_error(eri, cg) -
+            df.factorization_error(eri, lstsq)) < 1.0e-6
+    # CG is exact at the true rank, like the least-squares solver.
+    exact = df.compressed_double_factorization(eri,
+                                               num_leaves=3,
+                                               max_iterations=1500,
+                                               inner_solver="cg",
+                                               backend=backend)
+    assert df.factorization_error(eri, exact) < 1.0e-4
+    with pytest.raises(ValueError):
+        df.compressed_double_factorization(eri,
+                                           num_leaves=2,
+                                           inner_solver="bogus",
+                                           backend=backend)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_cg_accelerators_preserve_accuracy(backend):
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=11)
+    # The warm-start + inexact-in-loop accelerators (defaults) must reach the
+    # same final reconstruction as the cold-start, tight-in-loop CG: the single
+    # final solve is always tightened to cg_tolerance.
+    for regularization in (0.0, 1.0e-2):
+        accel = df.compressed_double_factorization(
+            eri,
+            num_leaves=2,
+            max_iterations=800,
+            regularization=regularization,
+            inner_solver="cg",
+            backend=backend)
+        plain = df.compressed_double_factorization(
+            eri,
+            num_leaves=2,
+            max_iterations=800,
+            regularization=regularization,
+            inner_solver="cg",
+            cg_warm_start=False,
+            cg_optimization_tolerance=1.0e-10,
+            backend=backend)
+        assert abs(
+            df.factorization_error(eri, accel) -
+            df.factorization_error(eri, plain)) < 1.0e-4
+
+
+def test_auto_backend_is_size_aware():
+    from cudaq_algorithms.double_factorization._backend import resolve_backend
+    # Explicit choices are honored regardless of size.
+    assert resolve_backend("numpy")[1] == "numpy"
+    # A tiny problem under the GPU threshold always resolves to NumPy (whether or
+    # not a GPU is present): below the crossover the GPU loses.
+    assert resolve_backend("auto", problem_size=4, gpu_min_size=1000)[1] \
+        == "numpy"
+    # A large problem resolves to CuPy when a GPU is present, else NumPy.
+    expected = "cupy" if df.cupy_gpu_available() else "numpy"
+    assert resolve_backend("auto", problem_size=10000, gpu_min_size=1)[1] \
+        == expected
+
+
+def test_one_norm_conventions():
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=9)
+    factorization = df.explicit_double_factorization(eri, threshold=0.0)
+    one_body = np.array([0.5, -1.0, 0.25, 0.75])
+    base = float(np.sum(np.abs(one_body)))
+
+    lcu = df.double_factorization_one_norm(factorization,
+                                           one_body,
+                                           convention="lcu")
+    burg = df.double_factorization_one_norm(factorization,
+                                            one_body,
+                                            convention="burg")
+    assert lcu >= base
+    assert burg >= base
+    with pytest.raises(ValueError):
+        df.double_factorization_one_norm(factorization,
+                                         one_body,
+                                         convention="bogus")
+
+
+def test_reconstruct_eri_matches_helper():
+    eri = _synthetic_eri(n=4, num_vectors=2, seed=3)
+    factorization = df.explicit_double_factorization(eri, threshold=0.0)
+    np.testing.assert_allclose(df.reconstruct_eri(factorization),
+                               factorization.reconstruct_eri())
+
+
+def test_modified_one_body_integrals():
+    eri = _synthetic_eri(n=4, num_vectors=2, seed=5)
+    one_body = np.diag([0.1, -0.2, 0.3, -0.4])
+    kappa = df.modified_one_body_integrals(one_body, eri)
+    expected = one_body - 0.5 * np.einsum("prqr->pq", eri)
+    np.testing.assert_allclose(kappa, expected)
+    assert np.allclose(kappa, kappa.T)
+
+
+def test_double_factorization_one_norm_nonnegative_and_additive():
+    eri = _synthetic_eri(n=4, num_vectors=3, seed=9)
+    factorization = df.explicit_double_factorization(eri, threshold=0.0)
+    one_body_eigenvalues = np.array([0.5, -1.0, 0.25, 0.75])
+    lam = df.double_factorization_one_norm(factorization, one_body_eigenvalues)
+    assert lam >= float(np.sum(np.abs(one_body_eigenvalues)))
+
+
+def test_invalid_inputs_raise():
+    with pytest.raises(ValueError):
+        df.explicit_double_factorization(np.zeros((3, 3)))  # not rank-4
+    with pytest.raises(ValueError):
+        df.compressed_double_factorization(_synthetic_eri(4, 2, 1),
+                                           num_leaves=0)
+
+
+def _openfermion_factorize():
+    """OpenFermion's explicit-DF ``factorize``, or skip if unavailable.
+
+    The public ``openfermion.resource_estimates.df`` API is gated behind an
+    optional ``jax`` dependency, but the factorization itself only needs NumPy,
+    so fall back to loading the module file directly when the gate blocks the
+    normal import.
+    """
+    pytest.importorskip("openfermion")
+    try:
+        from openfermion.resource_estimates import df as of_df
+        if hasattr(of_df, "factorize"):
+            return of_df.factorize
+    except Exception:
+        pass
+    import importlib.util
+    import openfermion
+    path = os.path.join(os.path.dirname(openfermion.__file__),
+                        "resource_estimates", "df", "factorize_df.py")
+    if not os.path.exists(path):
+        pytest.skip("OpenFermion explicit-DF reference is not available")
+    spec = importlib.util.spec_from_file_location("_of_factorize_df", path)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        pytest.skip("OpenFermion explicit-DF reference could not be loaded")
+    return module.factorize
+
+
+def test_explicit_double_factorization_matches_openfermion_reference():
+    """Cross-check X-DF against OpenFermion's independent explicit-DF reference.
+
+    Compared on the reconstructed ERI tensor (convention-independent), since the
+    two implementations store leaves differently and apply different second-factor
+    truncation conventions.
+    """
+    factorize = _openfermion_factorize()
+    eri = _h2o_eri()
+    n = eri.shape[0]
+    reference_eri, _factors, rank, _num_eigenvectors = factorize(
+        eri, thresh=1.0e-13)
+
+    # The reference reconstructs the ERI, and its first-factor rank cannot exceed
+    # the symmetric-pair dimension n(n+1)/2.
+    assert np.linalg.norm(reference_eri - eri) < 1.0e-9
+    assert rank <= n * (n + 1) // 2
+
+    mine = df.explicit_double_factorization(eri, threshold=0.0)
+    np.testing.assert_allclose(mine.reconstruct_eri(),
+                               reference_eri,
+                               atol=1.0e-9)

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -391,3 +391,112 @@ def test_indefinite_eri_warns_on_cholesky_path():
     exact = df.explicit_double_factorization(
         eri, first_factorization="eigendecomposition")
     assert df.factorization_error(eri, exact) < 1.0e-10
+
+
+def test_one_norms_match_hand_computation():
+    # One leaf with a core built from hand-chosen eigenpairs:
+    # V = rotation by pi/6, lambda = (2.0, -0.5), Z = V diag(lambda) V^T.
+    c, s = np.cos(np.pi / 6.0), np.sin(np.pi / 6.0)
+    rotation = np.array([[c, -s], [s, c]])
+    core = rotation @ np.diag([2.0, -0.5]) @ rotation.T
+    factorization = df.DoubleFactorization(num_orbitals=2,
+                                           leaf_rotations=[np.eye(2)],
+                                           leaf_cores=[core],
+                                           method="X-DF")
+    one_body_eigenvalues = [0.3, -0.7]  # sum |F| = 1.0
+
+    # lcu: sum|F| + sum_{k<l}|Z_kl| + 1/4 sum_k |Z_kk|, entries by hand:
+    # Z00 = 2c^2 - 0.5s^2, Z11 = 2s^2 - 0.5c^2, Z01 = 2.5cs.
+    z00 = 2.0 * c**2 - 0.5 * s**2
+    z11 = 2.0 * s**2 - 0.5 * c**2
+    z01 = 2.5 * c * s
+    expected_lcu = 1.0 + abs(z01) + 0.25 * (abs(z00) + abs(z11))
+    assert df.double_factorization_one_norm(factorization,
+                                            one_body_eigenvalues,
+                                            convention="lcu") == pytest.approx(
+                                                expected_lcu, abs=1e-12)
+
+    # burg (gauge-fixed eigen form): 1/4 sum_i |lambda_i| (sum_k |v_ki|)^2;
+    # both eigenvector columns have |c| + |s| absolute column sum.
+    expected_burg = 1.0 + 0.25 * (2.0 + 0.5) * (c + s)**2
+    assert df.double_factorization_one_norm(
+        factorization, one_body_eigenvalues,
+        convention="burg") == pytest.approx(expected_burg, abs=1e-12)
+
+
+def test_modified_one_body_matches_independent_loop():
+    rng = np.random.default_rng(21)
+    n = 3
+    one_body = rng.standard_normal((n, n))
+    eri = _synthetic_eri(n, 2, seed=22)
+
+    expected = np.empty((n, n))
+    for p in range(n):
+        for q in range(n):
+            correction = 0.0
+            for r in range(n):
+                correction += eri[p, r, q, r]
+            expected[p, q] = one_body[p, q] - 0.5 * correction
+
+    np.testing.assert_allclose(df.modified_one_body_integrals(one_body, eri),
+                               expected,
+                               atol=1e-14)
+
+
+def test_second_factor_threshold_truncates_cores():
+    eri = _synthetic_eri(4, 3, seed=23)
+    exact = df.explicit_double_factorization(eri)
+    # Pick a threshold from the data: the median importance-weighted gamma
+    # across the exact cores, so roughly half the entries get zeroed.
+    weighted = []
+    for core in exact.leaf_cores:
+        # Cholesky-path cores are outer(gamma, gamma), so |gamma_k| is
+        # sqrt of the core diagonal; the code weights |gamma_k| by
+        # importance = sum_k |gamma_k|.
+        gammas = np.sqrt(np.maximum(np.diag(core), 0.0))
+        weighted.extend(np.sum(gammas) * gammas)
+    threshold = float(np.median([w for w in weighted if w > 1.0e-12]))
+    truncated = df.explicit_double_factorization(
+        eri, second_factor_threshold=threshold)
+    heavy = df.explicit_double_factorization(eri,
+                                             second_factor_threshold=1.0e6)
+
+    err_exact = df.factorization_error(eri, exact)
+    err_truncated = df.factorization_error(eri, truncated)
+    assert err_exact < 1.0e-10
+    assert err_truncated > err_exact
+
+    # Truncation zeroes small gamma entries: the (rank-one) cores keep
+    # their rank but gain zero diagonal entries where gammas were dropped.
+    def zero_diagonal_count(cores):
+        return sum(
+            int(np.sum(np.isclose(np.diag(core), 0.0, atol=1.0e-12)))
+            for core in cores)
+
+    assert zero_diagonal_count(truncated.leaf_cores) > zero_diagonal_count(
+        exact.leaf_cores)
+    # An absurd threshold zeroes every core entirely.
+    assert all(np.allclose(core, 0.0) for core in heavy.leaf_cores)
+
+
+def test_negative_definite_supermatrix_warns_with_no_leaves():
+    eri = -_synthetic_eri(4, 3, seed=24)  # negative semidefinite supermatrix
+    with pytest.warns(RuntimeWarning, match="not positive semidefinite"):
+        factorization = df.explicit_double_factorization(eri)
+    assert factorization.num_leaves == 0
+    assert df.factorization_error(eri, factorization) > 1.0
+
+
+def test_eigendecomposition_threshold_zero_stops_at_numerical_rank():
+    eri = _synthetic_eri(5, 3, seed=25)
+    factorization = df.explicit_double_factorization(
+        eri, threshold=0.0, first_factorization="eigendecomposition")
+    assert factorization.num_leaves == 3
+    assert df.factorization_error(eri, factorization) < 1.0e-10
+
+
+def test_pair_swap_asymmetry_rejected():
+    eri = _synthetic_eri(4, 3, seed=26)
+    eri[0, 0, 1, 1] += 0.05  # breaks (pq|rs) == (rs|pq) only
+    with pytest.raises(ValueError, match="chemist symmetries"):
+        df.explicit_double_factorization(eri)


### PR DESCRIPTION

**Branch:** `wsttiger:features/add_python_double_factorization` → base:
`main`. Rebased onto current main (post #13/#14); five commits. The two
follow-up branches (chemistry bridge, `DoubleFactorizedEncoding`) stack
on this one.

---

## Title

Add pure-Python double factorization of two-electron integrals

## Body

This adds `cudaq_algorithms.double_factorization`: classical chemistry
preprocessing that factorizes two-electron repulsion integrals into the
low-rank leaf-rotation/core representation consumed by double-factorized
block encodings, qubitization, and measurement schemes. It implements
the explicit (X-DF) and compressed (C-DF) variants of Cohn, Motta, and
Parrish, PRX Quantum 2, 040352 (2021), plus the RC-DF regularization of
Oumarou et al. (Quantum 8, 1371 (2024)).

### What's included

* **X-DF** — exact double factorization; the first factorization
  defaults to pivoted Cholesky (rank-revealing on the PSD ERI
  supermatrix, stops at the true rank), with a symmetric-
  eigendecomposition variant for indefinite inputs. Exact to machine
  precision at full rank.
* **C-DF / RC-DF** — fixed-leaf-count compression by least squares:
  leaf rotations parameterized as `exp(X)` over antisymmetric `X` and
  optimized with L-BFGS, symmetric cores solved in closed form each
  step (the paper's two-step scheme), warm-started from X-DF;
  `regularization=rho` adds the RC-DF L2 core penalty. An optional
  matrix-free CG inner core solve (`inner_solver="cg"`, with warm
  starting) replaces the dense least-squares solve for larger systems.
* **Helpers** — ERI reconstruction, Frobenius reconstruction error,
  the DF one-body correction `kappa`, and DF Hamiltonian one-norms in
  both the Pauli-rotation (`"lcu"`) and qubitization (`"burg"`)
  conventions.
* **GPU path** — heavy linear algebra runs on cuSOLVER/cuBLAS via CuPy
  when a GPU is present, NumPy/SciPy otherwise. `backend="auto"` is
  size-aware (CPU below the empirical crossover where kernel-launch
  latency dominates; documented per method) and every entry point
  accepts an explicit `"cupy"`/`"numpy"` override. The subpackage has
  no `cudaq` dependency at all.
* Docs (`docs/double_factorization.md`), an H2O/STO-3G example (PySCF
  kept at the example boundary per the chemistry-inputs policy), a CG
  benchmark, and a test suite covering both first factorizations,
  C-DF/RC-DF, one-norm conventions, backend selection, and input
  validation — parameterized over NumPy plus CuPy when a GPU is
  present, with PySCF/OpenFermion reference tests that self-skip.

### Conventions

Integrals are chemist-notation `(pq|rs)` over real spatial orbitals
(8-fold symmetric), as from `pyscf.ao2mo.restore("s1", ...)`; the
factorization is `(pq|rs) ≈ Σ_t U^t Z^t U^tᵀ` with orthogonal leaf
rotations (compilable into Givens fabrics) and symmetric cores.

### Review

The branch went through an independent adversarial review, which
verified the mathematics quantitatively from scratch implementations
(reconstruction exactness, truncation error exactly matching the
documented eigenvalue bound, the C-DF analytic gradient against
central differences, the CG normal equations against the dense solve,
and both one-norm formulas re-derived from Pauli algebra) and found
one real defect, fixed in the final commit: **scipy is now a declared
dependency** (the package imports this subpackage unconditionally, and
it imports scipy at module load — a clean wheel install previously
failed at import). The same commit adds two guardrails the review
recommended: input tensors that violate the real-orbital chemist
symmetries are rejected (previously silently wrong answers), and the
pivoted-Cholesky path warns when it clamps a significant negative
residual on an indefinite supermatrix (previously silent accuracy
loss; the eigendecomposition path handles such inputs).

### Test plan

* `pytest tests/python` on the branch: the double-factorization suite
  passes in full — 17 passed, 1 skipped
  (OpenFermion cross-check; not installed) — and the only remaining
  failures on this base are the
  known extension-only state-prep/fermion tests, fixed by #15's line.
* Example runs end-to-end against PySCF-generated H2O integrals.