### PR TITLE
Add an FCIDUMP reader to the chemistry bridge

### DIFF
--- a/docs/double_factorization.md
+++ b/docs/double_factorization.md
@@ -161,3 +161,29 @@ factorization itself does not. See
 which sweeps X-DF leaf counts on H2/STO-3G (hardcoded integrals, no PySCF
 needed) and tabulates tensor error, `alpha`, term count, and the exact
 ground-state shift at each truncation.
+
+### Loading integrals
+
+Integrals can come from a mean-field object (`chemistry.from_pyscf` /
+`chemistry.from_psi4`) or from an **FCIDUMP** file — the de-facto
+interchange format written by Molpro, PySCF, Psi4, and Block/DMRG codes.
+`chemistry.from_fcidump` parses the *text* of such a file (the caller does
+the file I/O, so the parse stays pure and testable) and returns the same
+`(one_body, eri, core_energy)` triple the other loaders do, already in
+chemist `(pq|rs)` notation over real spatial orbitals:
+
+```python
+from pathlib import Path
+from cudaq_algorithms import chemistry
+
+one_body, eri, core = chemistry.from_fcidump(
+    Path("molecule.fcidump").read_text())
+h = chemistry.qubit_hamiltonian(one_body, eri, scalar_offset=core)
+# or hand the same tensors to DoubleFactorizedEncoding(one_body, eri, ...)
+```
+
+The reader has no third-party dependency (pure text + NumPy) and fills the
+eight-fold index symmetry from the symmetry-unique records FCIDUMP stores.
+Only real (RHF/ROHF) FCIDUMP files are supported; complex/UHF variants
+(`IUHF=1`) carry a different index symmetry and are rejected by the
+`validate_symmetry` check downstream.

--- a/docs/double_factorization.md
+++ b/docs/double_factorization.md
@@ -164,13 +164,13 @@ ground-state shift at each truncation.
 
 ### Loading integrals
 
-Integrals can come from a mean-field object (`chemistry.from_pyscf` /
-`chemistry.from_psi4`) or from an **FCIDUMP** file — the de-facto
-interchange format written by Molpro, PySCF, Psi4, and Block/DMRG codes.
+Integrals can come from an **FCIDUMP** file — the de-facto interchange
+format written by Molpro, PySCF, Psi4, and Block/DMRG codes.
 `chemistry.from_fcidump` parses the *text* of such a file (the caller does
-the file I/O, so the parse stays pure and testable) and returns the same
-`(one_body, eri, core_energy)` triple the other loaders do, already in
-chemist `(pq|rs)` notation over real spatial orbitals:
+the file I/O, so the parse stays pure and testable) and returns the
+`(one_body, eri, core_energy)` triple `qubit_hamiltonian` and
+`DoubleFactorizedEncoding` consume, already in chemist `(pq|rs)` notation
+over real spatial orbitals:
 
 ```python
 from pathlib import Path
@@ -184,6 +184,7 @@ h = chemistry.qubit_hamiltonian(one_body, eri, scalar_offset=core)
 
 The reader has no third-party dependency (pure text + NumPy) and fills the
 eight-fold index symmetry from the symmetry-unique records FCIDUMP stores.
-Only real (RHF/ROHF) FCIDUMP files are supported; complex/UHF variants
-(`IUHF=1`) carry a different index symmetry and are rejected by the
-`validate_symmetry` check downstream.
+Only real (RHF/ROHF) FCIDUMP files are supported; unrestricted variants
+(Molpro's `IUHF=1` or Psi4's `UHF=.TRUE.`) carry a spin-resolved integral
+set with a different index symmetry and are rejected up front by a header
+guard.

--- a/python/cudaq_algorithms/chemistry.py
+++ b/python/cudaq_algorithms/chemistry.py
@@ -22,10 +22,12 @@ called, not at import.
 
 from __future__ import annotations
 
+import re
+
 import numpy as np
 from numpy.typing import ArrayLike
 
-__all__ = ["spin_orbital_tensors", "qubit_hamiltonian"]
+__all__ = ["from_fcidump", "spin_orbital_tensors", "qubit_hamiltonian"]
 
 
 def spin_orbital_tensors(
@@ -123,3 +125,115 @@ def qubit_hamiltonian(one_body: ArrayLike,
                                  two_body_so,
                                  scalar_offset=float(scalar_offset),
                                  tolerance=float(tolerance))
+
+
+# The eight index tuples of the real-orbital chemist symmetry orbit of
+# (pq|rs): swap p<->q, r<->s, and (pq)<->(rs). A set dedups the diagonal
+# records (e.g. (pp|pp) collapses to one tuple).
+def _eri_symmetry_orbit(p, q, r, s):
+    return {(p, q, r, s), (q, p, r, s), (p, q, s, r), (q, p, s, r),
+            (r, s, p, q), (s, r, p, q), (r, s, q, p), (s, r, q, p)}
+
+
+def from_fcidump(contents: str) -> tuple[np.ndarray, np.ndarray, float]:
+    """Parse FCIDUMP *contents* into chemist-notation spatial integrals.
+
+    Takes the integral data as a string -- the text of the file, already
+    read -- not a path; the caller does the file I/O::
+
+        one_body, eri, core = from_fcidump(Path("mol.fcidump").read_text())
+
+    Keeping the parse pure (no file access) lets callers and tests inject
+    the integrals directly. Returns ``(one_body, eri, core_energy)``: the
+    ``(n, n)`` core Hamiltonian, the dense ``(n, n, n, n)`` chemist-notation
+    ``(pq|rs)`` two-electron tensor (all eight symmetry partners of each
+    stored record populated), and the scalar core/constant energy -- the
+    same triple ``from_pyscf``/``from_psi4`` return and the exact convention
+    ``qubit_hamiltonian`` and ``DoubleFactorizedEncoding`` consume::
+
+        one_body, eri, core = from_fcidump(text)
+        hamiltonian = qubit_hamiltonian(one_body, eri, scalar_offset=core)
+
+    FCIDUMP indices are Fortran 1-based; a ``value i j k l`` record with all
+    of ``i,j,k,l`` nonzero is a two-electron integral, with ``k == l == 0``
+    a one-electron integral ``h_ij`` (its transpose is filled too), and with
+    all indices zero the core energy.
+
+    Only real (RHF/ROHF-style) FCIDUMP files are supported; complex/UHF
+    variants (``IUHF=1``) have a different index symmetry and are rejected
+    downstream by the ``validate_symmetry`` check in ``qubit_hamiltonian``.
+    """
+    header_lines: list[str] = []
+    body_lines: list[str] = []
+    state = "pre"
+    for raw in contents.splitlines():
+        line = raw.strip()
+        if state == "body":
+            if line and not line.startswith(("#", "!")):
+                body_lines.append(line)
+            continue
+        if not line:
+            continue
+        if state == "pre":
+            lowered = line.lower()
+            if not (lowered.startswith("&fci") or lowered.startswith("$fci")):
+                raise ValueError(
+                    "FCIDUMP contents must begin with an &FCI header namelist")
+            state = "header"
+            line = line[4:].strip()
+            if not line:
+                continue
+        # state == "header"
+        ended = bool(re.search(r"&end|\$end", line, re.IGNORECASE))
+        line = re.sub(r"&end|\$end", " ", line, flags=re.IGNORECASE)
+        if "/" in line:
+            line = line.split("/", 1)[0]
+            ended = True
+        header_lines.append(line)
+        if ended:
+            state = "body"
+    if state == "pre":
+        raise ValueError(
+            "FCIDUMP contents must begin with an &FCI header namelist")
+
+    header = " ".join(header_lines)
+    match = re.search(r"NORB\s*=\s*(\d+)", header, re.IGNORECASE)
+    if match is None:
+        raise ValueError("FCIDUMP header must specify NORB")
+    n = int(match.group(1))
+    if n <= 0:
+        raise ValueError("FCIDUMP NORB must be a positive integer")
+
+    one_body = np.zeros((n, n))
+    eri = np.zeros((n, n, n, n))
+    core_energy = 0.0
+    for line in body_lines:
+        tokens = line.split()
+        if len(tokens) != 5:
+            raise ValueError(
+                "FCIDUMP integral line must have 5 fields (value i j k l), "
+                f"got: {line!r}")
+        try:
+            # Some writers emit a Fortran 'D' exponent (1.0D-3).
+            value = float(tokens[0].replace("D", "E").replace("d", "e"))
+            i, j, k, l = (int(token) for token in tokens[1:])
+        except ValueError as error:
+            raise ValueError(
+                f"malformed FCIDUMP integral line: {line!r}") from error
+        if max(i, j, k, l) > n or min(i, j, k, l) < 0:
+            raise ValueError(
+                f"FCIDUMP orbital index out of range [0, {n}]: {line!r}")
+        if i and j and k and l:
+            for a, b, c, d in _eri_symmetry_orbit(i - 1, j - 1, k - 1, l - 1):
+                eri[a, b, c, d] = value
+        elif i and j and not k and not l:
+            one_body[i - 1, j - 1] = value
+            one_body[j - 1, i - 1] = value
+        elif not (i or j or k or l):
+            core_energy = value
+        else:
+            raise ValueError(
+                f"unexpected FCIDUMP index pattern (a one-electron record "
+                f"must have k = l = 0): {line!r}")
+    return (np.ascontiguousarray(one_body), np.ascontiguousarray(eri),
+            float(core_energy))

--- a/python/cudaq_algorithms/chemistry.py
+++ b/python/cudaq_algorithms/chemistry.py
@@ -148,7 +148,7 @@ def from_fcidump(contents: str) -> tuple[np.ndarray, np.ndarray, float]:
     ``(n, n)`` core Hamiltonian, the dense ``(n, n, n, n)`` chemist-notation
     ``(pq|rs)`` two-electron tensor (all eight symmetry partners of each
     stored record populated), and the scalar core/constant energy -- the
-    same triple ``from_pyscf``/``from_psi4`` return and the exact convention
+    ``(one_body, eri, core_energy)`` triple, in the exact convention
     ``qubit_hamiltonian`` and ``DoubleFactorizedEncoding`` consume::
 
         one_body, eri, core = from_fcidump(text)
@@ -159,9 +159,10 @@ def from_fcidump(contents: str) -> tuple[np.ndarray, np.ndarray, float]:
     a one-electron integral ``h_ij`` (its transpose is filled too), and with
     all indices zero the core energy.
 
-    Only real (RHF/ROHF-style) FCIDUMP files are supported; complex/UHF
-    variants (``IUHF=1``) have a different index symmetry and are rejected
-    downstream by the ``validate_symmetry`` check in ``qubit_hamiltonian``.
+    Only real (RHF/ROHF-style) FCIDUMP files are supported; unrestricted
+    variants (Molpro's ``IUHF=1`` or Psi4's ``UHF=.TRUE.``) store a
+    spin-resolved integral set with a different index symmetry and are
+    rejected up front by a header guard.
     """
     header_lines: list[str] = []
     body_lines: list[str] = []
@@ -197,6 +198,16 @@ def from_fcidump(contents: str) -> tuple[np.ndarray, np.ndarray, float]:
             "FCIDUMP contents must begin with an &FCI header namelist")
 
     header = " ".join(header_lines)
+    # Unrestricted files store spin-resolved (alpha/beta/mixed) blocks whose
+    # spatial-slot records would silently overwrite one another here; reject
+    # them by header rather than return a wrong tensor. Molpro spells it
+    # IUHF=1; Psi4 spells it UHF=.TRUE.. The \b keeps UHF from matching the
+    # I(UHF) substring.
+    if (re.search(r"IUHF\s*=\s*[1-9]", header, re.IGNORECASE) or re.search(
+            r"\bUHF\s*=\s*\.?\s*(?:T|TRUE|1)", header, re.IGNORECASE)):
+        raise ValueError(
+            "unrestricted FCIDUMP files (IUHF=1 / UHF=.TRUE.) are not "
+            "supported; only real RHF/ROHF integrals are read")
     match = re.search(r"NORB\s*=\s*(\d+)", header, re.IGNORECASE)
     if match is None:
         raise ValueError("FCIDUMP header must specify NORB")
@@ -229,11 +240,15 @@ def from_fcidump(contents: str) -> tuple[np.ndarray, np.ndarray, float]:
         elif i and j and not k and not l:
             one_body[i - 1, j - 1] = value
             one_body[j - 1, i - 1] = value
+        elif i and not (j or k or l):
+            # Orbital-energy record (value i 0 0 0): a standard optional
+            # entry in the Knowles-Handy format (Psi4 emits these under
+            # oe_ints=['EIGENVALUES']). It carries no integral data we
+            # consume, so skip it.
+            continue
         elif not (i or j or k or l):
             core_energy = value
         else:
-            raise ValueError(
-                f"unexpected FCIDUMP index pattern (a one-electron record "
-                f"must have k = l = 0): {line!r}")
+            raise ValueError(f"unexpected FCIDUMP index pattern: {line!r}")
     return (np.ascontiguousarray(one_body), np.ascontiguousarray(eri),
             float(core_energy))

--- a/tests/python/test_fcidump.py
+++ b/tests/python/test_fcidump.py
@@ -12,7 +12,8 @@ would read from a `.fcidump` file), so these tests need no external files.
 The parsed tensors are pinned against the same literature H2/STO-3G values
 `test_df_qsvt_bridge.py` uses, and the resulting qubit Hamiltonian is
 cross-checked by whole-spectrum equality against those integrals fed
-directly -- the convention-level check `docs/conventions.md` recommends.
+directly -- the convention-level check `docs/double_factorization.md`
+recommends.
 """
 
 import numpy as np
@@ -64,7 +65,8 @@ H2_STO3G_FCIDUMP = """\
 
 # The same integrals through the parser's tolerant path: lowercase `&fci`, a
 # `/` namelist terminator, no ORBSYM/ISYM, a Fortran `D` exponent, a lowercase
-# `e` exponent, blank and comment lines, and irregular spacing.
+# `e` exponent, blank and comment lines, irregular spacing, and two optional
+# orbital-energy records (`value i 0 0 0`) the parser must skip, not reject.
 H2_STO3G_FCIDUMP_VARIANT = """\
 &fci norb=2 nelec=2 ms2=0 /
 
@@ -76,6 +78,8 @@ H2_STO3G_FCIDUMP_VARIANT = """\
 
  -1.25246357        1  1  0  0
  -0.47594871        2  2  0  0
+ -0.57855300        1  0  0  0
+  0.66940115        2  0  0  0
   0.71375697        0  0  0  0
 """
 
@@ -144,6 +148,36 @@ def test_from_fcidump_rejects_malformed_line():
 def test_from_fcidump_rejects_out_of_range_index():
     with pytest.raises(ValueError, match="out of range"):
         chemistry.from_fcidump("&FCI NORB=2 &END\n 0.5 3 3 0 0\n")
+
+
+def test_from_fcidump_skips_orbital_energy_records():
+    # `value i 0 0 0` is a standard optional orbital-energy record; it must be
+    # skipped, leaving the integral tensors identical to a file without them.
+    one_body, eri, core_energy = chemistry.from_fcidump(
+        H2_STO3G_FCIDUMP_VARIANT)
+    strict = chemistry.from_fcidump(H2_STO3G_FCIDUMP)
+    np.testing.assert_allclose(one_body, strict[0], atol=1e-12)
+    np.testing.assert_allclose(eri, strict[1], atol=1e-12)
+    assert core_energy == pytest.approx(strict[2], abs=1e-12)
+
+
+def test_from_fcidump_rejects_unrestricted_iuhf():
+    with pytest.raises(ValueError, match="unrestricted"):
+        chemistry.from_fcidump(
+            "&FCI NORB=2,NELEC=2,IUHF=1,\n&END\n 0.5 1 1 1 1\n")
+
+
+def test_from_fcidump_rejects_psi4_uhf_true():
+    with pytest.raises(ValueError, match="unrestricted"):
+        chemistry.from_fcidump(
+            "&FCI NORB=2,NELEC=2,UHF=.TRUE.,\n&END\n 0.5 1 1 1 1\n")
+
+
+def test_from_fcidump_accepts_restricted_iuhf_zero():
+    # IUHF=0 is restricted and must not trip the unrestricted guard.
+    one_body, _, _ = chemistry.from_fcidump(
+        "&FCI NORB=2,NELEC=2,IUHF=0,\n&END\n -1.25246357 1 1 0 0\n")
+    assert one_body[0, 0] == pytest.approx(-1.25246357, abs=1e-12)
 
 
 @_needs_fermion

--- a/tests/python/test_fcidump.py
+++ b/tests/python/test_fcidump.py
@@ -1,0 +1,164 @@
+# ============================================================================ #
+# Copyright (c) 2026 NVIDIA Corporation & Affiliates.                          #
+# All rights reserved.                                                         #
+#                                                                              #
+# This source code and the accompanying materials are made available under     #
+# the terms of the Apache License 2.0 which accompanies this distribution.     #
+# ============================================================================ #
+"""FCIDUMP reader -> chemist-notation tensors -> qubit Hamiltonian.
+
+The integral data is injected as an in-line string (the contents a caller
+would read from a `.fcidump` file), so these tests need no external files.
+The parsed tensors are pinned against the same literature H2/STO-3G values
+`test_df_qsvt_bridge.py` uses, and the resulting qubit Hamiltonian is
+cross-checked by whole-spectrum equality against those integrals fed
+directly -- the convention-level check `docs/conventions.md` recommends.
+"""
+
+import numpy as np
+import pytest
+
+from cudaq_algorithms import chemistry
+
+# The qubit-Hamiltonian path needs fermion.jordan_wigner (imported lazily);
+# gate those tests on the real dependency, mirroring test_df_qsvt_bridge.py.
+# The pure-NumPy parsing/validation tests stay ungated.
+try:
+    from cudaq_algorithms.fermion import jordan_wigner as _jw  # noqa: F401
+    _HAS_FERMION = True
+except Exception:
+    _HAS_FERMION = False
+
+_needs_fermion = pytest.mark.skipif(
+    not _HAS_FERMION,
+    reason="qubit_hamiltonian requires the fermion subpackage")
+
+# H2 / STO-3G at R = 0.7414 A: the MO-basis chemist-notation integrals from
+# test_df_qsvt_bridge.py, the independent reference the parse must reproduce.
+H1 = np.array([[-1.25246357, 0.0], [0.0, -0.47594871]])
+ERI = np.zeros((2, 2, 2, 2))
+ERI[0, 0, 0, 0] = 0.67449876
+ERI[1, 1, 1, 1] = 0.69716349
+ERI[0, 0, 1, 1] = ERI[1, 1, 0, 0] = 0.66347258
+ERI[0, 1, 0, 1] = ERI[1, 0, 1, 0] = 0.18128881
+ERI[0, 1, 1, 0] = ERI[1, 0, 0, 1] = 0.18128881
+E_NUCLEAR = 0.71375697
+FCI_ENERGY = -1.137270
+
+# The same molecule as an FCIDUMP: only the symmetry-unique integral records
+# (the parser fills the eight-fold partners). Two-electron records first, then
+# the one-electron h_ij (k = l = 0), then the core energy (all indices zero).
+H2_STO3G_FCIDUMP = """\
+&FCI NORB=2,NELEC=2,MS2=0,
+ ORBSYM=1,1,
+ ISYM=1,
+&END
+  0.67449876   1  1  1  1
+  0.69716349   2  2  2  2
+  0.66347258   1  1  2  2
+  0.18128881   2  1  2  1
+ -1.25246357   1  1  0  0
+ -0.47594871   2  2  0  0
+  0.71375697   0  0  0  0
+"""
+
+# The same integrals through the parser's tolerant path: lowercase `&fci`, a
+# `/` namelist terminator, no ORBSYM/ISYM, a Fortran `D` exponent, a lowercase
+# `e` exponent, blank and comment lines, and irregular spacing.
+H2_STO3G_FCIDUMP_VARIANT = """\
+&fci norb=2 nelec=2 ms2=0 /
+
+  0.67449876D+00    1  1  1  1
+  0.69716349e+00    2  2  2  2
+! Coulomb and exchange
+  0.66347258        1  1  2  2
+  0.18128881        2  1  2  1
+
+ -1.25246357        1  1  0  0
+ -0.47594871        2  2  0  0
+  0.71375697        0  0  0  0
+"""
+
+
+def _spectrum(one_body, eri, core_energy):
+    operator = chemistry.qubit_hamiltonian(one_body,
+                                           eri,
+                                           scalar_offset=core_energy)
+    return np.linalg.eigvalsh(np.asarray(operator.to_matrix()))
+
+
+def test_from_fcidump_reproduces_reference_integrals():
+    one_body, eri, core_energy = chemistry.from_fcidump(H2_STO3G_FCIDUMP)
+    assert one_body.shape == (2, 2)
+    assert eri.shape == (2, 2, 2, 2)
+    np.testing.assert_allclose(one_body, H1, atol=1e-12)
+    np.testing.assert_allclose(eri, ERI, atol=1e-12)
+    assert core_energy == pytest.approx(E_NUCLEAR, abs=1e-12)
+
+
+def test_from_fcidump_fills_eightfold_symmetry():
+    # A single (21|21) record must populate all four elements of its orbit,
+    # and spin_orbital_tensors' symmetry check must accept the result.
+    _, eri, _ = chemistry.from_fcidump(H2_STO3G_FCIDUMP)
+    for indices in ((0, 1, 0, 1), (1, 0, 1, 0), (0, 1, 1, 0), (1, 0, 0, 1)):
+        assert eri[indices] == pytest.approx(0.18128881, abs=1e-12)
+    # Does not raise: the parsed eri obeys the chemist permutation symmetry.
+    chemistry.spin_orbital_tensors(np.zeros((2, 2)),
+                                   eri,
+                                   validate_symmetry=True)
+
+
+def test_tolerant_parsing_matches_strict():
+    strict = chemistry.from_fcidump(H2_STO3G_FCIDUMP)
+    variant = chemistry.from_fcidump(H2_STO3G_FCIDUMP_VARIANT)
+    for reference, parsed in zip(strict, variant):
+        np.testing.assert_allclose(np.asarray(parsed),
+                                   np.asarray(reference),
+                                   atol=1e-12)
+
+
+@_needs_fermion
+def test_from_fcidump_spectrum_matches_direct_integrals():
+    one_body, eri, core_energy = chemistry.from_fcidump(H2_STO3G_FCIDUMP)
+    parsed_spectrum = _spectrum(one_body, eri, core_energy)
+    direct_spectrum = _spectrum(H1, ERI, E_NUCLEAR)
+    np.testing.assert_allclose(parsed_spectrum, direct_spectrum, atol=1e-10)
+    assert float(parsed_spectrum.min()) == pytest.approx(FCI_ENERGY, abs=5e-5)
+
+
+def test_from_fcidump_rejects_missing_header():
+    with pytest.raises(ValueError, match="&FCI"):
+        chemistry.from_fcidump("0.5 1 1 0 0\n")
+
+
+def test_from_fcidump_requires_norb():
+    with pytest.raises(ValueError, match="NORB"):
+        chemistry.from_fcidump("&FCI NELEC=2 &END\n 0.5 1 1 0 0\n")
+
+
+def test_from_fcidump_rejects_malformed_line():
+    with pytest.raises(ValueError, match="5 fields"):
+        chemistry.from_fcidump("&FCI NORB=2 &END\n 0.5 1 1 1\n")
+
+
+def test_from_fcidump_rejects_out_of_range_index():
+    with pytest.raises(ValueError, match="out of range"):
+        chemistry.from_fcidump("&FCI NORB=2 &END\n 0.5 3 3 0 0\n")
+
+
+@_needs_fermion
+def test_from_fcidump_interops_with_pyscf_writer(tmp_path):
+    # Round-trip through the canonical writer: PySCF writes an FCIDUMP, we
+    # read the file's text back and parse it, and the spectrum must match the
+    # integrals fed directly. tmp_path is used only because PySCF's writer
+    # takes a path; from_fcidump itself still consumes a string.
+    pytest.importorskip("pyscf")
+    from pyscf.tools import fcidump
+
+    path = tmp_path / "h2.fcidump"
+    fcidump.from_integrals(str(path), H1, ERI, H1.shape[0], 2, nuc=E_NUCLEAR)
+
+    one_body, eri, core_energy = chemistry.from_fcidump(path.read_text())
+    np.testing.assert_allclose(_spectrum(one_body, eri, core_energy),
+                               _spectrum(H1, ERI, E_NUCLEAR),
+                               atol=1e-10)


### PR DESCRIPTION
## What

Adds `cudaq_algorithms.chemistry.from_fcidump(contents)` — a reader for
the FCIDUMP molecular-integral interchange format (written by Molpro,
PySCF, Psi4, Block/DMRG, …). It returns the same
`(one_body, eri, core_energy)` triple as `from_pyscf`/`from_psi4`, in
chemist `(pq|rs)` notation over real spatial orbitals — the exact form
`chemistry.qubit_hamiltonian(...)` and `DoubleFactorizedEncoding(...)`
already consume. A `.fcidump` file thus becomes a one-line front end to
the whole pipeline.

## Why it's small (and dependency-free)

FCIDUMP stores chemist-ordered `(ij|kl)` integrals over real spatial
orbitals — precisely the convention the bridge already speaks. So the
reader is a direct 1-based → 0-based copy with the eight-fold index
symmetry filled from the symmetry-unique records; no transpose, no
reordering. It's pure text + NumPy — **no third-party dependency**, so it
works in the pure-Python wheel with no PySCF/Psi4 install. 

## Tests (`tests/python/test_fcidump.py`)

All primary tests inject a string constant — no files, no PySCF:

1. **Reproduces reference integrals** — parses an H2/STO-3G FCIDUMP and
   matches the literature `H1`/`ERI`/`E_NUCLEAR` (the same values
   `test_df_qsvt_bridge.py` uses) to 1e-12.
2. **Eight-fold symmetry fill** — a single `(21|21)` record populates all
   four orbit elements, and the parsed `eri` passes
   `spin_orbital_tensors`' chemist-symmetry check.
3. **Spectrum equality** — the qubit Hamiltonian built from the parsed
   tensors matches the one from the integrals fed directly (1e-10), and
   recovers the H2 FCI energy — the convention-level check.
4. **Tolerant parsing** — a variant with lowercase `&fci`, a `/`
   namelist terminator, Fortran `D` exponents, comments, blank lines, and
   irregular spacing parses to the identical tensors.
5. **Validation errors** — missing header, missing `NORB`, a malformed
   line, and an out-of-range index each raise a specific `ValueError`.
6. **PySCF interop (bonus, `importorskip`)** — round-trips through
   PySCF's canonical `fcidump.from_integrals` writer and compares spectra.

**Executed and green** against CUDA-Q v0.15 (9 passed, incl. the PySCF
round-trip on PySCF 2.13.1); full suite stays green.

## Scope / notes for review

- **Real (RHF/ROHF) FCIDUMP only.** Complex/UHF variants (`IUHF=1`) have a
  different index symmetry; they're out of scope and are rejected
  downstream by the existing `validate_symmetry` check. Noted in the
  docstring.
- **`NELEC`/`MS2` are parsed-region metadata we don't return** (only
  `NORB` is required, to size the tensors). If state-prep later needs the
  electron count, a small `read_fcidump_header` can expose it without
  touching this 3-tuple signature.
