### PR TITLE
Move double factorization encoding to examples

### DIFF
--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -64,6 +64,10 @@ jobs:
               - '.github/workflows/pr_workflow.yaml'
               - 'python/**'
               - 'tests/**'
+              # The bring-your-own-encoding example is imported by
+              # tests/python/test_df_encoding.py, so edits to it must run
+              # the test suite like package source.
+              - 'examples/bring_your_own_encoding/**'
               - 'scripts/test_algorithms_build.sh'
               - 'scripts/validation/**'
               - 'pyproject.toml'
@@ -71,6 +75,9 @@ jobs:
               # The wheel is the deliverable, so package-source edits must
               # build and test it (not just run pytest against the source tree).
               - 'python/**'
+              # The wheel test lane runs the same pytest suite from the
+              # checkout, which imports the CI-tested example.
+              - 'examples/bring_your_own_encoding/**'
               - '.github/actions/get-cudaq-wheels/**'
               - '.github/workflows/build_cudaq_wheels.yaml'
               - '.github/workflows/wheel_algorithms.yaml'

--- a/docs/df_block_encoding.md
+++ b/docs/df_block_encoding.md
@@ -78,8 +78,10 @@ construction it reproduces the LCU one-norm of
 alpha = |const| + sum_k |F_k| + sum_t ( sum_{k<l} |Z^t_kl| + 1/4 sum_k |Z^t_kk| )
 ```
 
-Compressing the factorization (fewer leaves) lowers `alpha` and the term
-count together — the knob a flat Pauli expansion does not have. Since
+Compressing the factorization (fewer leaves) shrinks the term count, and
+with it (typically, though not monotonically — dropping a leaf also
+reshapes the one-body singles absorbed into `kappa`) the `alpha` — the
+knob a flat Pauli expansion does not have. Since
 QSVT circuit depth for time evolution scales like `alpha * t`, the
 compression translates directly into shallower circuits, at the price of
 a spectrum shift bounded by the tensor reconstruction error.
@@ -108,7 +110,7 @@ runs the encoding on real molecules (integrals from PySCF —
 `pip install pyscf`), across a menu of configurations:
 
 ```
-python3 df_block_encoding.py [config]
+python3 df_block_encoding.py [config] [--circuits]
 
 h2         H2 / STO-3G           2 orbitals ->  4 system qubits  (default)
 h2o-cas44  H2O / STO-3G CAS(4,4) 4 orbitals ->  8 system qubits

--- a/docs/df_block_encoding.md
+++ b/docs/df_block_encoding.md
@@ -16,6 +16,8 @@ dense-reference test suite (`tests/python/test_df_encoding.py`) stays in
 CI, so the example is held to library-grade correctness.
 
 ```python
+import sys
+sys.path.insert(0, "examples/bring_your_own_encoding")  # from the repo root, or copy the file
 from df_encoding import DoubleFactorizedEncoding   # the example module
 from cudaq_algorithms import Walk, QSVT
 from cudaq_algorithms import double_factorization as df

--- a/docs/df_block_encoding.md
+++ b/docs/df_block_encoding.md
@@ -7,12 +7,12 @@ integrals (von Burg et al., *PRX Quantum* **2**, 030305 (2021);
 expanding it into Pauli words. It satisfies the same `BlockEncoding`
 protocol as `PauliLCU`, so `Walk` and `QSVT` consume it unchanged.
 
-It is intentionally **not part of the package**: it lives at
+It ships as a runnable example —
 [`examples/bring_your_own_encoding/df_encoding.py`](../examples/bring_your_own_encoding/df_encoding.py)
-as the worked, full-scale demonstration that the `BlockEncoding` protocol
-is structural — a complete encoding implemented outside the library,
-against the public API only, plugs into every consumer. Its
-dense-reference test suite (`tests/python/test_df_encoding.py`) stays in
+— and doubles as the worked, full-scale demonstration that the
+`BlockEncoding` protocol is structural: implement the protocol's surface
+against the public API and every consumer accepts the encoding. Its
+dense-reference test suite (`tests/python/test_df_encoding.py`) runs in
 CI, so the example is held to library-grade correctness.
 
 ```python

--- a/docs/df_block_encoding.md
+++ b/docs/df_block_encoding.md
@@ -121,11 +121,11 @@ h2o-631g   H2O / 6-31G          13 orbitals -> 26 system qubits
 ```
 
 Every configuration compares `DoubleFactorizedEncoding` with a `PauliLCU`
-of the same Hamiltonian (alpha, term count, structure), sweeps the
-factorization-truncation dial, and re-optimizes the kept leaves with
-RC-DF at the same budgets (the second dial: optimize, don't just
-truncate -- with a small ridge so the optimizer cannot trade a huge
-one-norm for fit). Small configurations additionally verify
+of the same Hamiltonian (alpha, term count, structure) and sweeps the
+factorization-truncation dial; all but the largest also re-optimize the
+kept leaves with RC-DF at the same budgets (the second dial: optimize,
+don't just truncate -- with a small ridge so the optimizer cannot trade a
+huge one-norm for fit). Small configurations additionally verify
 the encoded block against a sparse Jordan-Wigner reference and measure
 Chebyshev moments through the shared `Walk` consumer; large ones report
 the statevector cost and tell the classical scaling story instead (at

--- a/docs/df_block_encoding.md
+++ b/docs/df_block_encoding.md
@@ -104,7 +104,24 @@ where the qubits are Z positions *in that frame's rotated basis*).
 ## Example
 
 [`examples/bring_your_own_encoding/df_block_encoding.py`](../examples/bring_your_own_encoding/df_block_encoding.py)
-builds a small system, compares `DoubleFactorizedEncoding` with a
-`PauliLCU` of the same Hamiltonian (alpha, term count, structure), sweeps
-factorization truncation, and measures Chebyshev moments through the
-shared `Walk` consumer.
+runs the encoding on real molecules (integrals from PySCF —
+`pip install pyscf`), across a menu of configurations:
+
+```
+python3 df_block_encoding.py [config]
+
+h2         H2 / STO-3G           2 orbitals ->  4 system qubits  (default)
+h2o-cas44  H2O / STO-3G CAS(4,4) 4 orbitals ->  8 system qubits
+h4         linear H4 / STO-3G    4 orbitals ->  8 system qubits
+lih        LiH / STO-3G          6 orbitals -> 12 system qubits
+h2o        H2O / STO-3G          7 orbitals -> 14 system qubits
+h2o-631g   H2O / 6-31G          13 orbitals -> 26 system qubits
+```
+
+Every configuration compares `DoubleFactorizedEncoding` with a `PauliLCU`
+of the same Hamiltonian (alpha, term count, structure) and sweeps the
+factorization-truncation dial. Small configurations additionally verify
+the encoded block against a sparse Jordan-Wigner reference and measure
+Chebyshev moments through the shared `Walk` consumer; large ones report
+the statevector cost and tell the classical scaling story instead (at
+H2O/6-31G the DF alpha is ~32% below the flat expansion's).

--- a/docs/df_block_encoding.md
+++ b/docs/df_block_encoding.md
@@ -119,8 +119,11 @@ h2o-631g   H2O / 6-31G          13 orbitals -> 26 system qubits
 ```
 
 Every configuration compares `DoubleFactorizedEncoding` with a `PauliLCU`
-of the same Hamiltonian (alpha, term count, structure) and sweeps the
-factorization-truncation dial. Small configurations additionally verify
+of the same Hamiltonian (alpha, term count, structure), sweeps the
+factorization-truncation dial, and re-optimizes the kept leaves with
+RC-DF at the same budgets (the second dial: optimize, don't just
+truncate -- with a small ridge so the optimizer cannot trade a huge
+one-norm for fit). Small configurations additionally verify
 the encoded block against a sparse Jordan-Wigner reference and measure
 Chebyshev moments through the shared `Walk` consumer; large ones report
 the statevector cost and tell the classical scaling story instead (at

--- a/docs/df_block_encoding.md
+++ b/docs/df_block_encoding.md
@@ -1,14 +1,23 @@
-# Double-Factorized Block Encoding
+# Double-Factorized Block Encoding (bring-your-own-encoding example)
 
-`cudaq_algorithms.DoubleFactorizedEncoding` block-encodes the
+`DoubleFactorizedEncoding` block-encodes the
 electronic-structure Hamiltonian directly from its double-factorized
 integrals (von Burg et al., *PRX Quantum* **2**, 030305 (2021);
 [arXiv:2007.14460](https://arxiv.org/abs/2007.14460)), instead of first
 expanding it into Pauli words. It satisfies the same `BlockEncoding`
 protocol as `PauliLCU`, so `Walk` and `QSVT` consume it unchanged.
 
+It is intentionally **not part of the package**: it lives at
+[`examples/bring_your_own_encoding/df_encoding.py`](../examples/bring_your_own_encoding/df_encoding.py)
+as the worked, full-scale demonstration that the `BlockEncoding` protocol
+is structural — a complete encoding implemented outside the library,
+against the public API only, plugs into every consumer. Its
+dense-reference test suite (`tests/python/test_df_encoding.py`) stays in
+CI, so the example is held to library-grade correctness.
+
 ```python
-from cudaq_algorithms import DoubleFactorizedEncoding, Walk, QSVT
+from df_encoding import DoubleFactorizedEncoding   # the example module
+from cudaq_algorithms import Walk, QSVT
 from cudaq_algorithms import double_factorization as df
 
 factorization = df.compressed_double_factorization(eri, num_leaves=T)
@@ -92,7 +101,7 @@ where the qubits are Z positions *in that frame's rotated basis*).
 
 ## Example
 
-[`examples/double_factorization/df_block_encoding.py`](../examples/double_factorization/df_block_encoding.py)
+[`examples/bring_your_own_encoding/df_block_encoding.py`](../examples/bring_your_own_encoding/df_block_encoding.py)
 builds a small system, compares `DoubleFactorizedEncoding` with a
 `PauliLCU` of the same Hamiltonian (alpha, term count, structure), sweeps
 factorization truncation, and measures Chebyshev moments through the

--- a/docs/double_factorization.md
+++ b/docs/double_factorization.md
@@ -169,7 +169,8 @@ format written by Molpro, PySCF, Psi4, and Block/DMRG codes.
 `chemistry.from_fcidump` parses the *text* of such a file (the caller does
 the file I/O, so the parse stays pure and testable) and returns the
 `(one_body, eri, core_energy)` triple `qubit_hamiltonian` and
-`DoubleFactorizedEncoding` consume, already in chemist `(pq|rs)` notation
+the block encodings (including the `DoubleFactorizedEncoding` example)
+consume, already in chemist `(pq|rs)` notation
 over real spatial orbitals:
 
 ```python
@@ -179,7 +180,8 @@ from cudaq_algorithms import chemistry
 one_body, eri, core = chemistry.from_fcidump(
     Path("molecule.fcidump").read_text())
 h = chemistry.qubit_hamiltonian(one_body, eri, scalar_offset=core)
-# or hand the same tensors to DoubleFactorizedEncoding(one_body, eri, ...)
+# or hand the same tensors to a block encoding, e.g. the
+# DoubleFactorizedEncoding example (examples/bring_your_own_encoding)
 ```
 
 The reader has no third-party dependency (pure text + NumPy) and fills the

--- a/examples/bring_your_own_encoding/df_block_encoding.py
+++ b/examples/bring_your_own_encoding/df_block_encoding.py
@@ -5,13 +5,20 @@
 # This source code and the accompanying materials are made available under     #
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
-"""The double-factorized block encoding, head to head with a flat PauliLCU.
+"""A user-written block encoding, head to head with the built-in PauliLCU.
+
+The point of this example pair: ``DoubleFactorizedEncoding`` is *not* part
+of the package — it lives next door in ``df_encoding.py``, implemented
+against the public ``BlockEncoding`` protocol only. Because the protocol is
+structural, the same ``Walk`` consumer drives the user-written encoding and
+the built-in ``PauliLCU`` identically.
 
 Builds a random two-orbital electronic-structure system (symmetric one-body
 matrix, positive-semidefinite chemist ERI), block-encodes it two ways —
 
-  * ``DoubleFactorizedEncoding``: frames of ancilla-controlled Z words
-    conjugated by uncontrolled Givens networks (von Burg construction),
+  * ``DoubleFactorizedEncoding`` (from ``df_encoding.py`` beside this
+    script): frames of ancilla-controlled Z words conjugated by
+    uncontrolled Givens networks (von Burg construction),
   * ``PauliLCU`` of the same Hamiltonian's flat Pauli expansion —
 
 and compares the normalization ``alpha``, term counts, and circuit
@@ -24,13 +31,20 @@ Runs on the CPU statevector simulator; no compiled extension needed.
 from __future__ import annotations
 
 import itertools
+import pathlib
+import sys
 
 import numpy as np
 
 import cudaq
 
-from cudaq_algorithms import DoubleFactorizedEncoding, PauliLCU, Walk
+from cudaq_algorithms import PauliLCU, Walk
 from cudaq_algorithms import double_factorization as df
+
+# The encoding under demonstration is a sibling example file, not a package
+# module (CUDA-Q kernels need real .py files, so a plain import is fine).
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from df_encoding import DoubleFactorizedEncoding
 
 cudaq.set_target("qpp-cpu")
 

--- a/examples/bring_your_own_encoding/df_block_encoding.py
+++ b/examples/bring_your_own_encoding/df_block_encoding.py
@@ -27,12 +27,13 @@ Integrals come from PySCF (``pip install pyscf``) via
 
 Every configuration tells the classical story: double-factorize the ERI,
 compare the DF encoding's normalization ``alpha`` and term count against
-the flat Pauli-expansion ``PauliLCU`` baseline, sweep the truncation dial
-(fewer leaves -> fewer terms; alpha typically, though not monotonically,
-shrinks -- see the note in the sweep. The flat expansion has no such
-knob), and then re-optimize the kept leaves with RC-DF at the same
-budgets (``compressed_double_factorization`` with a small ridge) -- the
-second dial: optimize, don't just truncate. Small configurations also
+the flat Pauli-expansion ``PauliLCU`` baseline, and sweep the truncation
+dial (fewer leaves -> fewer terms; alpha typically, though not
+monotonically, shrinks -- see the note in the sweep. The flat expansion
+has no such knob). All but the largest configuration then re-optimize the
+kept leaves with RC-DF at the same budgets
+(``compressed_double_factorization`` with a small ridge) -- the second
+dial: optimize, don't just truncate. Small configurations also
 run the circuits: the encoded block is checked against a sparse
 Jordan-Wigner reference Hamiltonian, and the same ``Walk`` consumer
 measures Chebyshev moments through both encodings. Larger configurations
@@ -252,6 +253,7 @@ def run(key: str, force_circuits: bool):
     errors = []
     for leaves in leaf_counts:
         truncated = df.explicit_double_factorization(eri,
+                                                     threshold=0.0,
                                                      max_num_leaves=leaves)
         encoding = DoubleFactorizedEncoding(one_body, truncated)
         error = df.factorization_error(eri, truncated)
@@ -283,9 +285,11 @@ def run(key: str, force_circuits: bool):
         budgets = [b for b in budgets if b < total]  # rank-1: nothing to do
         print("\n  RC-DF at the same leaf budgets (optimize the kept "
               "leaves, don't just truncate):")
+        eri_norm = float(np.linalg.norm(eri))  # scale-invariant gate
         wins = []
         for leaves in budgets:
             truncated = df.explicit_double_factorization(eri,
+                                                         threshold=0.0,
                                                          max_num_leaves=leaves)
             xdf_error = df.factorization_error(eri, truncated)
             compressed = df.compressed_double_factorization(
@@ -307,18 +311,25 @@ def run(key: str, force_circuits: bool):
                 # (sane alpha). The win to assert is at AGGRESSIVE budgets.
                 better = f"{1.0 / ratio:.1f}x worse (ridge bias; X-DF "\
                          "already near-exact here)"
-            if xdf_error > 1e-2:
+            if xdf_error > 1e-2 * eri_norm:
                 wins.append(cdf_error <= xdf_error * 1.001 + 1e-12)
             print(f"    {leaves:3d} leaves: X-DF error {xdf_error:.2e}  "
                   f"RC-DF error {cdf_error:.2e}  ({better}), "
                   f"RC-DF alpha = {cdf_alpha:.4f}")
-        if wins:
-            check(
-                "RC-DF fits at least as well wherever truncation error is "
-                "still significant", all(wins))
+        # Reported, not asserted: L-BFGS guarantees descent of the
+        # REGULARIZED objective, not of the raw fit error, so the win is
+        # empirical (robust in practice at significant truncation error,
+        # but a hard exit here could misfire on someone else's molecule).
+        if wins and all(wins):
+            print("  [check] RC-DF fits at least as well wherever "
+                  "truncation error is still significant ... OK")
+        elif wins:
+            print("  [note] RC-DF trailed truncated X-DF at a "
+                  "significant-error budget -- the ridge trades fit for "
+                  "bounded cores; try a smaller regularization.")
         else:
             print("  (no budget in the significant-error regime; "
-                  "RC-DF win not asserted)")
+                  "RC-DF win not reported)")
     else:
         print("\n  RC-DF comparison skipped at this size (the L-BFGS "
               "optimization is the expensive path; see "

--- a/examples/bring_your_own_encoding/df_block_encoding.py
+++ b/examples/bring_your_own_encoding/df_block_encoding.py
@@ -7,11 +7,11 @@
 # ============================================================================ #
 """A user-written block encoding, head to head with the built-in PauliLCU.
 
-The point of this example pair: ``DoubleFactorizedEncoding`` is *not* part
-of the package — it lives next door in ``df_encoding.py``, implemented
-against the public ``BlockEncoding`` protocol only. Because the protocol is
-structural, the same ``Walk`` consumer drives the user-written encoding and
-the built-in ``PauliLCU`` identically.
+The encoding here is user-level code: ``df_encoding.py`` next door
+implements ``DoubleFactorizedEncoding`` against the public
+``BlockEncoding`` protocol. Because the protocol is structural, the same
+``Walk`` consumer drives the user-written encoding and the built-in
+``PauliLCU`` identically.
 
 Builds a random two-orbital electronic-structure system (symmetric one-body
 matrix, positive-semidefinite chemist ERI), block-encodes it two ways —

--- a/examples/bring_your_own_encoding/df_block_encoding.py
+++ b/examples/bring_your_own_encoding/df_block_encoding.py
@@ -28,8 +28,9 @@ Integrals come from PySCF (``pip install pyscf``) via
 Every configuration tells the classical story: double-factorize the ERI,
 compare the DF encoding's normalization ``alpha`` and term count against
 the flat Pauli-expansion ``PauliLCU`` baseline, sweep the truncation dial
-(fewer leaves -> smaller alpha; the knob the flat expansion does not
-have), and then re-optimize the kept leaves with RC-DF at the same
+(fewer leaves -> fewer terms; alpha typically, though not monotonically,
+shrinks -- see the note in the sweep. The flat expansion has no such
+knob), and then re-optimize the kept leaves with RC-DF at the same
 budgets (``compressed_double_factorization`` with a small ridge) -- the
 second dial: optimize, don't just truncate. Small configurations also
 run the circuits: the encoded block is checked against a sparse
@@ -279,6 +280,7 @@ def run(key: str, force_circuits: bool):
                  for f in (0.25, 0.5, 0.75)} - {total})
         else:
             budgets = [max(1, round(total / 3))]  # L-BFGS gets expensive
+        budgets = [b for b in budgets if b < total]  # rank-1: nothing to do
         print("\n  RC-DF at the same leaf budgets (optimize the kept "
               "leaves, don't just truncate):")
         wins = []
@@ -310,10 +312,13 @@ def run(key: str, force_circuits: bool):
             print(f"    {leaves:3d} leaves: X-DF error {xdf_error:.2e}  "
                   f"RC-DF error {cdf_error:.2e}  ({better}), "
                   f"RC-DF alpha = {cdf_alpha:.4f}")
-        check(
-            "RC-DF fits at least as well wherever truncation error is "
-            "still significant",
-            bool(wins) and all(wins))
+        if wins:
+            check(
+                "RC-DF fits at least as well wherever truncation error is "
+                "still significant", all(wins))
+        else:
+            print("  (no budget in the significant-error regime; "
+                  "RC-DF win not asserted)")
     else:
         print("\n  RC-DF comparison skipped at this size (the L-BFGS "
               "optimization is the expensive path; see "

--- a/examples/bring_your_own_encoding/df_block_encoding.py
+++ b/examples/bring_your_own_encoding/df_block_encoding.py
@@ -27,12 +27,15 @@ Integrals come from PySCF (``pip install pyscf``) via
 
 Every configuration tells the classical story: double-factorize the ERI,
 compare the DF encoding's normalization ``alpha`` and term count against
-the flat Pauli-expansion ``PauliLCU`` baseline, and sweep the truncation
-dial (fewer leaves -> smaller alpha; the knob the flat expansion does not
-have). Small configurations also run the circuits: the encoded block is
-checked against a sparse Jordan-Wigner reference Hamiltonian, and the same
-``Walk`` consumer measures Chebyshev moments through both encodings.
-Larger configurations skip circuit execution (statevector cost is printed)
+the flat Pauli-expansion ``PauliLCU`` baseline, sweep the truncation dial
+(fewer leaves -> smaller alpha; the knob the flat expansion does not
+have), and then re-optimize the kept leaves with RC-DF at the same
+budgets (``compressed_double_factorization`` with a small ridge) -- the
+second dial: optimize, don't just truncate. Small configurations also
+run the circuits: the encoded block is checked against a sparse
+Jordan-Wigner reference Hamiltonian, and the same ``Walk`` consumer
+measures Chebyshev moments through both encodings. Larger configurations
+skip circuit execution (statevector cost is printed)
 -- the classical preprocessing scales; the simulator is what does not.
 ``lih`` sits on the boundary: pass ``--circuits`` to run it anyway
 (hours on a typical CPU).
@@ -139,6 +142,7 @@ CONFIGS = {
         "label": "H2O / 6-31G (full space)",
         "build": lambda: _full_space(_H2O_GEOMETRY, "6-31g"),
         "mode": "classical",
+        "cdf": False,  # L-BFGS at 13 orbitals is a coffee break, not a demo
     },
 }
 
@@ -260,6 +264,60 @@ def run(key: str, force_circuits: bool):
     check("truncation error is non-increasing in leaves",
           all(a >= b - 1e-9 for a, b in zip(errors, errors[1:])))
     check("full-rank X-DF reconstructs the ERI exactly", errors[-1] < 1e-8)
+
+    # RC-DF: the other dial. X-DF truncation keeps the FIRST leaves of an
+    # exact factorization; C-DF re-optimizes the leaves you keep (L-BFGS
+    # over the rotations, closed-form cores) for the same budget. The small
+    # ridge (regularization=1e-4, i.e. RC-DF) matters: unregularized C-DF
+    # can exploit gauge freedom to fit better with ENORMOUS core entries --
+    # alpha blows up by orders of magnitude -- the pathology the
+    # regularized variant exists to prevent.
+    if config.get("cdf", True):
+        if n <= 4:
+            budgets = sorted(
+                {max(1, round(total * f))
+                 for f in (0.25, 0.5, 0.75)} - {total})
+        else:
+            budgets = [max(1, round(total / 3))]  # L-BFGS gets expensive
+        print("\n  RC-DF at the same leaf budgets (optimize the kept "
+              "leaves, don't just truncate):")
+        wins = []
+        for leaves in budgets:
+            truncated = df.explicit_double_factorization(eri,
+                                                         max_num_leaves=leaves)
+            xdf_error = df.factorization_error(eri, truncated)
+            compressed = df.compressed_double_factorization(
+                eri,
+                num_leaves=leaves,
+                regularization=1e-4,
+                max_iterations=300)
+            cdf_error = df.factorization_error(eri, compressed)
+            cdf_alpha = DoubleFactorizedEncoding(one_body, compressed).alpha
+            ratio = xdf_error / max(cdf_error, 1e-16)
+            if cdf_error < 1e-10:
+                better = "exact fit"
+            elif ratio >= 1.0:
+                better = f"{ratio:.1f}x better"
+            else:
+                # Near full rank the truncation error is already ~ the
+                # ridge scale, so the regularization bias dominates: the
+                # ridge trades a small fit penalty for bounded cores
+                # (sane alpha). The win to assert is at AGGRESSIVE budgets.
+                better = f"{1.0 / ratio:.1f}x worse (ridge bias; X-DF "\
+                         "already near-exact here)"
+            if xdf_error > 1e-2:
+                wins.append(cdf_error <= xdf_error * 1.001 + 1e-12)
+            print(f"    {leaves:3d} leaves: X-DF error {xdf_error:.2e}  "
+                  f"RC-DF error {cdf_error:.2e}  ({better}), "
+                  f"RC-DF alpha = {cdf_alpha:.4f}")
+        check(
+            "RC-DF fits at least as well wherever truncation error is "
+            "still significant",
+            bool(wins) and all(wins))
+    else:
+        print("\n  RC-DF comparison skipped at this size (the L-BFGS "
+              "optimization is the expensive path; see "
+              "examples/double_factorization/).")
 
     # --- circuit story (size-gated) ---------------------------------------
     mode = config["mode"]

--- a/examples/bring_your_own_encoding/df_block_encoding.py
+++ b/examples/bring_your_own_encoding/df_block_encoding.py
@@ -5,7 +5,7 @@
 # This source code and the accompanying materials are made available under     #
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
-"""A user-written block encoding, head to head with the built-in PauliLCU.
+"""A user-written block encoding on real molecules, vs the built-in PauliLCU.
 
 The encoding here is user-level code: ``df_encoding.py`` next door
 implements ``DoubleFactorizedEncoding`` against the public
@@ -13,32 +13,44 @@ implements ``DoubleFactorizedEncoding`` against the public
 ``Walk`` consumer drives the user-written encoding and the built-in
 ``PauliLCU`` identically.
 
-Builds a random two-orbital electronic-structure system (symmetric one-body
-matrix, positive-semidefinite chemist ERI), block-encodes it two ways —
+Integrals come from PySCF (``pip install pyscf``) via
+``chemistry.from_pyscf``, for a menu of molecular configurations::
 
-  * ``DoubleFactorizedEncoding`` (from ``df_encoding.py`` beside this
-    script): frames of ancilla-controlled Z words conjugated by
-    uncontrolled Givens networks (von Burg construction),
-  * ``PauliLCU`` of the same Hamiltonian's flat Pauli expansion —
+    python3 df_block_encoding.py [config] [--circuits]
 
-and compares the normalization ``alpha``, term counts, and circuit
-structure. Both are ``BlockEncoding``s, so the same ``Walk`` consumer
-measures Chebyshev moments through either. Truncating the factorization
-shrinks the DF encoding further; the flat expansion has no such knob.
+    h2         H2 / STO-3G           2 orbitals ->  4 system qubits  (default)
+    h2o-cas44  H2O / STO-3G CAS(4,4) 4 orbitals ->  8 system qubits
+    h4         linear H4 / STO-3G    4 orbitals ->  8 system qubits
+    lih        LiH / STO-3G          6 orbitals -> 12 system qubits
+    h2o        H2O / STO-3G          7 orbitals -> 14 system qubits
+    h2o-631g   H2O / 6-31G          13 orbitals -> 26 system qubits
+
+Every configuration tells the classical story: double-factorize the ERI,
+compare the DF encoding's normalization ``alpha`` and term count against
+the flat Pauli-expansion ``PauliLCU`` baseline, and sweep the truncation
+dial (fewer leaves -> smaller alpha; the knob the flat expansion does not
+have). Small configurations also run the circuits: the encoded block is
+checked against a sparse Jordan-Wigner reference Hamiltonian, and the same
+``Walk`` consumer measures Chebyshev moments through both encodings.
+Larger configurations skip circuit execution (statevector cost is printed)
+-- the classical preprocessing scales; the simulator is what does not.
+``lih`` sits on the boundary: pass ``--circuits`` to run it anyway
+(hours on a typical CPU).
 
 Runs on the CPU statevector simulator; no compiled extension needed.
 """
 from __future__ import annotations
 
-import itertools
+import argparse
 import pathlib
 import sys
 
 import numpy as np
+import scipy.sparse as sp
 
 import cudaq
 
-from cudaq_algorithms import PauliLCU, Walk
+from cudaq_algorithms import PauliLCU, Walk, chemistry, state_from
 from cudaq_algorithms import double_factorization as df
 
 # The encoding under demonstration is a sibling example file, not a package
@@ -46,118 +58,278 @@ from cudaq_algorithms import double_factorization as df
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from df_encoding import DoubleFactorizedEncoding
 
-cudaq.set_target("qpp-cpu")
+cudaq.set_target("qpp-cpu")  # fp64: the checks below assert to ~1e-10
+
+try:
+    from pyscf import ao2mo, gto, mcscf, scf
+except ImportError:
+    sys.exit("This example builds its molecules with PySCF: pip install pyscf")
 
 # ----------------------------------------------------------------------
-# A small electronic-structure system (dense JW reference in NumPy)
+# The molecule menu. Each builder returns (one_body, eri, core_energy,
+# mean-field energy) with chemist (pq|rs) MO integrals -- exactly what
+# chemistry.qubit_hamiltonian and DoubleFactorizedEncoding consume.
 # ----------------------------------------------------------------------
 
-rng = np.random.default_rng(7)
-N_ORBITALS = 2
-one_body = rng.normal(size=(N_ORBITALS, N_ORBITALS))
-one_body = 0.5 * (one_body + one_body.T)
-eri = np.zeros((N_ORBITALS, ) * 4)
-for _ in range(2 * N_ORBITALS):
-    s = rng.normal(size=(N_ORBITALS, N_ORBITALS))
-    s = 0.5 * (s + s.T)
-    eri += float(rng.uniform(0.1, 1.0)) * np.einsum('pq,rs->pqrs', s, s)
-
-NUM_QUBITS = 2 * N_ORBITALS
-DIM = 1 << NUM_QUBITS
-
-_I2, _Z2 = np.eye(2), np.diag([1.0, -1.0])
-_LOWER = np.array([[0.0, 1.0], [0.0, 0.0]])
+_H2O_GEOMETRY = """
+O  0.0000  0.0000  0.1173
+H  0.0000  0.7572 -0.4692
+H  0.0000 -0.7572 -0.4692
+"""
 
 
-def annihilator(mode: int) -> np.ndarray:
-    ops = ([_Z2] * mode + [_LOWER] + [_I2] * (NUM_QUBITS - mode - 1))[::-1]
-    out = np.array([[1.0]])
-    for op in ops:
-        out = np.kron(out, op)
+def _rhf(atom: str, basis: str):
+    molecule = gto.M(atom=atom, basis=basis, symmetry=False, verbose=0)
+    return scf.RHF(molecule).run()
+
+
+def _full_space(atom: str, basis: str):
+    mean_field = _rhf(atom, basis)
+    one_body, eri, nuclear = chemistry.from_pyscf(mean_field)
+    return one_body, eri, nuclear, float(mean_field.e_tot)
+
+
+def _h2o_cas44():
+    """H2O in a (4 electron, 4 orbital) active space.
+
+    PySCF's CASCI effective integrals fold the inactive (core) orbitals
+    into a 4-orbital one-body matrix and scalar -- real water at 8 system
+    qubits, small enough for the full dense-checked circuit story.
+    """
+    mean_field = _rhf(_H2O_GEOMETRY, "sto-3g")
+    cas = mcscf.CASCI(mean_field, ncas=4, nelecas=4)
+    one_body, core_energy = cas.get_h1eff()
+    eri = ao2mo.restore(1, cas.get_h2eff(), 4)
+    return (np.asarray(one_body), np.asarray(eri), float(core_energy),
+            float(mean_field.e_tot))
+
+
+_H4_CHAIN = "; ".join(f"H 0 0 {i:.1f}" for i in range(4))
+
+CONFIGS = {
+    "h2": {
+        "label": "H2 / STO-3G",
+        "build": lambda: _full_space("H 0 0 0; H 0 0 0.7414", "sto-3g"),
+        "mode": "full",
+    },
+    "h2o-cas44": {
+        "label": "H2O / STO-3G, CAS(4e,4o) active space",
+        "build": _h2o_cas44,
+        "mode": "full",
+    },
+    "h4": {
+        # Smallest system where leaf truncation shows a real alpha-vs-error
+        # trade-off; a standard strong-correlation benchmark (stretched
+        # chain: 1.0 A spacing vs 0.74 A equilibrium).
+        "label": "linear H4 (1.0 A spacing) / STO-3G",
+        "build": lambda: _full_space(_H4_CHAIN, "sto-3g"),
+        "mode": "full",
+    },
+    "lih": {
+        "label": "LiH / STO-3G",
+        "build": lambda: _full_space("Li 0 0 0; H 0 0 1.595", "sto-3g"),
+        "mode": "flagged",  # circuits only with --circuits (hours)
+    },
+    "h2o": {
+        "label": "H2O / STO-3G (full space)",
+        "build": lambda: _full_space(_H2O_GEOMETRY, "sto-3g"),
+        "mode": "classical",
+    },
+    "h2o-631g": {
+        "label": "H2O / 6-31G (full space)",
+        "build": lambda: _full_space(_H2O_GEOMETRY, "6-31g"),
+        "mode": "classical",
+    },
+}
+
+# ----------------------------------------------------------------------
+# Sparse Jordan-Wigner reference (interleaved spins, qubit 0 least
+# significant -- the library's convention). Sparse matrices keep the
+# reference cheap out to the 12-qubit LiH configuration.
+# ----------------------------------------------------------------------
+
+
+def _sparse_annihilators(num_qubits: int) -> list[sp.csr_matrix]:
+    z2 = sp.csr_matrix(np.diag([1.0, -1.0]))
+    identity = sp.identity(2, format="csr")
+    lowering = sp.csr_matrix(np.array([[0.0, 1.0], [0.0, 0.0]]))
+    out = []
+    for mode in range(num_qubits):
+        ops = ([z2] * mode + [lowering] + [identity] *
+               (num_qubits - mode - 1))[::-1]
+        matrix = sp.identity(1, format="csr")
+        for op in ops:
+            matrix = sp.kron(matrix, op, format="csr")
+        out.append(matrix)
     return out
 
 
-lower = [annihilator(j) for j in range(NUM_QUBITS)]
-raise_ = [a.conj().T for a in lower]
+def reference_hamiltonian(one_body: np.ndarray,
+                          eri: np.ndarray) -> sp.csr_matrix:
+    """H = sum h_pq E_pq + 1/2 sum (pq|rs) (E_pq E_rs - delta_qr E_ps)."""
+    n = one_body.shape[0]
+    num_qubits = 2 * n
+    lower = _sparse_annihilators(num_qubits)
+    raise_ = [op.conj().T.tocsr() for op in lower]
+
+    def excite(p, q):
+        return (raise_[2 * p] @ lower[2 * q] +
+                raise_[2 * p + 1] @ lower[2 * q + 1])
+
+    excitations = [[excite(p, q) for q in range(n)] for p in range(n)]
+    dim = 1 << num_qubits
+    h = sp.csr_matrix((dim, dim), dtype=complex)
+    for p in range(n):
+        for q in range(n):
+            h = h + one_body[p, q] * excitations[p][q]
+            for r in range(n):
+                for s in range(n):
+                    term = excitations[p][q] @ excitations[r][s]
+                    if q == r:
+                        term = term - excitations[p][s]
+                    h = h + 0.5 * eri[p, q, r, s] * term
+    return h.tocsr()
 
 
-def excite(p, q):
-    return (raise_[2 * p] @ lower[2 * q] +
-            raise_[2 * p + 1] @ lower[2 * q + 1])
+def chebyshev_moment(h_scaled: sp.csr_matrix, ket: np.ndarray,
+                     order: int) -> float:
+    """<ket| T_k(H/alpha) |ket> by the vector three-term recurrence."""
+    t_prev, t_cur = ket, h_scaled @ ket
+    if order == 0:
+        return float(np.real(ket.conj() @ t_prev))
+    for _ in range(order - 1):
+        t_prev, t_cur = t_cur, 2.0 * (h_scaled @ t_cur) - t_prev
+    return float(np.real(ket.conj() @ t_cur))
 
 
-hamiltonian = np.zeros((DIM, DIM), dtype=complex)
-for p, q in itertools.product(range(N_ORBITALS), repeat=2):
-    hamiltonian += one_body[p, q] * excite(p, q)
-    for r, s in itertools.product(range(N_ORBITALS), repeat=2):
-        hamiltonian += 0.5 * eri[p, q, r, s] * (excite(p, q) @ excite(r, s) -
-                                                (q == r) * excite(p, s))
+def check(label: str, condition: bool):
+    print(f"  [check] {label} ... {'OK' if condition else 'FAILED'}")
+    if not condition:
+        sys.exit(1)
 
-# Flat Pauli expansion of the same Hamiltonian, for the PauliLCU baseline.
-_PAULI = {
-    "I": _I2,
-    "X": np.array([[0, 1], [1, 0]]),
-    "Y": np.array([[0, -1j], [1j, 0]]),
-    "Z": _Z2
-}
-pauli_terms = {}
-for word in itertools.product("IXYZ", repeat=NUM_QUBITS):
-    matrix = np.array([[1.0]])
-    for ch in reversed(word):  # qubit 0 least significant
-        matrix = np.kron(matrix, _PAULI[ch])
-    coefficient = float(np.real(np.trace(matrix @ hamiltonian))) / DIM
-    if abs(coefficient) > 1e-12:
-        pauli_terms["".join(word)] = coefficient
 
 # ----------------------------------------------------------------------
-# The two encodings, and truncated variants
+# The story, per configuration
 # ----------------------------------------------------------------------
 
-flat = PauliLCU(pauli_terms)
-factorized = DoubleFactorizedEncoding(one_body, eri)
 
-print(f"System: {N_ORBITALS} spatial orbitals -> {NUM_QUBITS} qubits")
-print(f"  PauliLCU:                 alpha = {flat.alpha:.4f}, "
-      f"{flat.num_terms} Pauli terms")
-print(f"  DoubleFactorizedEncoding: alpha = {factorized.alpha:.4f}, "
-      f"{factorized.num_terms} Z-word terms in {factorized.num_frames} "
-      f"frames, {factorized.num_givens_rotations} Givens rotations")
+def run(key: str, force_circuits: bool):
+    config = CONFIGS[key]
+    one_body, eri, core_energy, scf_energy = config["build"]()
+    n = one_body.shape[0]
+    num_system = 2 * n
 
-print("\nTruncating the factorization (the knob PauliLCU does not have):")
-for leaves in range(1, factorized.factorization.num_leaves + 1):
-    truncated = df.explicit_double_factorization(eri, max_num_leaves=leaves)
-    enc = DoubleFactorizedEncoding(one_body, truncated)
-    error = df.factorization_error(eri, truncated)
-    print(f"  {leaves} leaves: alpha = {enc.alpha:.4f}, "
-          f"{enc.num_terms} terms, {enc.num_frames} frames, "
-          f"tensor error {error:.2e}")
+    print(f"=== {key}: {config['label']} ===")
+    print(f"RHF energy {scf_energy:.6f} Ha; core/nuclear constant "
+          f"{core_energy:.6f} Ha (added classically, not encoded)")
+    print(f"{n} spatial orbitals -> {num_system} system qubits")
 
-# ----------------------------------------------------------------------
-# Same consumer, either encoding: Chebyshev moments via Walk
-# ----------------------------------------------------------------------
+    # --- classical story: both encodings, and the truncation dial --------
+    flat = PauliLCU(chemistry.qubit_hamiltonian(one_body, eri))
+    factorization = df.explicit_double_factorization(eri, threshold=0.0)
+    factorized = DoubleFactorizedEncoding(one_body, factorization)
 
-ket = rng.normal(size=DIM) + 1.0j * rng.normal(size=DIM)
-ket = (ket / np.linalg.norm(ket)).astype(np.complex128)
+    print(f"\n  flat PauliLCU:            alpha = {flat.alpha:10.4f}, "
+          f"{flat.num_terms} Pauli terms, {flat.num_ancilla} ancillas")
+    print(f"  DoubleFactorizedEncoding: alpha = {factorized.alpha:10.4f}, "
+          f"{factorized.num_terms} Z-word terms in {factorized.num_frames} "
+          f"frames ({factorization.num_leaves} leaves), "
+          f"{factorized.num_givens_rotations} Givens rotations, "
+          f"{factorized.num_ancilla} ancillas")
 
-print("\nEven Chebyshev moments <T_k(H/alpha)> through Walk (same consumer,"
-      "\ndifferent alpha, so values differ; both descend from the same H):")
-for order in (0, 2, 4):
-    scaled_flat = hamiltonian / flat.alpha
-    scaled_df = hamiltonian / factorized.alpha
+    print("\n  Truncating the factorization (the knob PauliLCU lacks):")
+    total = factorization.num_leaves
+    if total <= 12:
+        leaf_counts = list(range(1, total + 1))
+    else:
+        leaf_counts = sorted(
+            set(np.linspace(1, total, 10).astype(int).tolist()))
+    errors = []
+    for leaves in leaf_counts:
+        truncated = df.explicit_double_factorization(eri,
+                                                     max_num_leaves=leaves)
+        encoding = DoubleFactorizedEncoding(one_body, truncated)
+        error = df.factorization_error(eri, truncated)
+        errors.append(error)
+        print(f"    {leaves:3d} leaves: alpha = {encoding.alpha:10.4f}, "
+              f"{encoding.num_terms:5d} terms, tensor error {error:.2e}")
+    # Note: alpha is NOT guaranteed monotone in the leaf count -- dropping a
+    # leaf also reshapes the one-body singles absorbed into kappa, so alpha
+    # can overshoot at intermediate truncations. The tensor error IS
+    # monotone (nested pivoted-Cholesky truncation).
+    check("truncation error is non-increasing in leaves",
+          all(a >= b - 1e-9 for a, b in zip(errors, errors[1:])))
+    check("full-rank X-DF reconstructs the ERI exactly", errors[-1] < 1e-8)
 
-    def chebyshev(matrix, k):
-        t_prev, t_cur = np.eye(DIM, dtype=complex), matrix.copy()
-        if k == 0:
-            return t_prev
-        for _ in range(k - 1):
-            t_prev, t_cur = t_cur, 2.0 * matrix @ t_cur - t_prev
-        return t_cur
+    # --- circuit story (size-gated) ---------------------------------------
+    mode = config["mode"]
+    total_qubits = num_system + factorized.num_ancilla
+    if mode == "classical" or (mode == "flagged" and not force_circuits):
+        amplitudes = f"2^{total_qubits}"
+        print(f"\n  Circuit execution skipped: {num_system} system + "
+              f"{factorized.num_ancilla} ancilla = {total_qubits} qubits "
+              f"({amplitudes} amplitudes per state).")
+        if mode == "flagged":
+            print("  Rerun with --circuits to run them anyway "
+                  "(hours on a typical CPU).")
+        print("  The classical preprocessing above is the part that scales;"
+              " the statevector simulator is the part that does not.")
+        return
 
-    measured_flat = Walk(flat).moment(ket, order)
-    measured_df = Walk(factorized).moment(ket, order)
-    exact_flat = float(
-        np.real(ket.conj() @ chebyshev(scaled_flat, order) @ ket))
-    exact_df = float(np.real(ket.conj() @ chebyshev(scaled_df, order) @ ket))
-    print(f"  T_{order}:  PauliLCU {measured_flat:+.8f} (exact "
-          f"{exact_flat:+.8f})   DF {measured_df:+.8f} (exact "
-          f"{exact_df:+.8f})")
+    print(f"\n  Circuits: {num_system} system + {factorized.num_ancilla} "
+          f"ancilla = {total_qubits} qubits")
+    dim = 1 << num_system
+    hamiltonian = reference_hamiltonian(one_body, eri)
+    rng = np.random.default_rng(7)
+    ket = rng.normal(size=dim) + 1.0j * rng.normal(size=dim)
+    ket = (ket / np.linalg.norm(ket)).astype(np.complex128)
+
+    # The encoded block <0|U|0> must equal H/alpha, on a random state,
+    # against the independent sparse Jordan-Wigner reference.
+    state = np.array(
+        cudaq.get_state(factorized.encode_kernel(), state_from(ket)))
+    block = state[:dim]
+    expected = (hamiltonian @ ket) / factorized.alpha
+    block_error = float(np.max(np.abs(block - expected)))
+    print(f"  encoded block vs sparse JW reference: max |diff| = "
+          f"{block_error:.2e}")
+    check("<0|U|0> == H/alpha", block_error < 1e-10)
+
+    print("\n  Even Chebyshev moments <T_k(H/alpha)> through Walk (same"
+          "\n  consumer, either encoding; alphas differ, H is the same):")
+    for order in (0, 2, 4):
+        measured_flat = Walk(flat).moment(ket, order)
+        measured_df = Walk(factorized).moment(ket, order)
+        exact_flat = chebyshev_moment(hamiltonian / flat.alpha, ket, order)
+        exact_df = chebyshev_moment(hamiltonian / factorized.alpha, ket, order)
+        print(f"    T_{order}:  PauliLCU {measured_flat:+.8f} "
+              f"(exact {exact_flat:+.8f})   DF {measured_df:+.8f} "
+              f"(exact {exact_df:+.8f})")
+        check(
+            f"T_{order} moments match the reference",
+            abs(measured_flat - exact_flat) < 1e-8
+            and abs(measured_df - exact_df) < 1e-8)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="configurations:\n" +
+        "\n".join(f"  {key:10s} {config['label']}"
+                  for key, config in CONFIGS.items()))
+    parser.add_argument("config",
+                        nargs="?",
+                        default="h2",
+                        choices=sorted(CONFIGS),
+                        help="molecular configuration (default: h2)")
+    parser.add_argument("--circuits",
+                        action="store_true",
+                        help="run circuits on boundary-size configurations "
+                        "(lih; hours on a typical CPU)")
+    arguments = parser.parse_args()
+    run(arguments.config, arguments.circuits)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/bring_your_own_encoding/df_encoding.py
+++ b/examples/bring_your_own_encoding/df_encoding.py
@@ -14,8 +14,8 @@ the documented kernel factories (``prepare_kernel``, ``apply_kernel``,
 ``walk_step_kernel``, the controlled/adjoint variants, ...) plugs into
 qubitization and QSVT unchanged. This example is a full-scale
 demonstration: a *double-factorized* encoding of the electronic-structure
-Hamiltonian, implemented outside the package against the public API only,
-and validated against an independent dense reference by
+Hamiltonian, built entirely on the public ``cudaq_algorithms`` API and
+validated against an independent dense reference by
 ``tests/python/test_df_encoding.py``. Use it as the template for writing
 your own encoding; ``df_block_encoding.py`` in this directory drives it
 head to head with the built-in ``PauliLCU`` through the same ``Walk``.
@@ -92,9 +92,10 @@ __all__ = [
 ]
 
 # ----------------------------------------------------------------------
-# Small host-side helpers, inlined so the example depends only on the
-# public package surface (the library keeps private twins of these; the
-# dense-reference tests pin both to the same behavior).
+# Small host-side helpers (input guard + state-preparation angle tree),
+# kept local so this file is self-contained on the public
+# ``cudaq_algorithms`` surface and can be copied wholesale as the
+# starting point for a new encoding.
 # ----------------------------------------------------------------------
 
 

--- a/examples/bring_your_own_encoding/df_encoding.py
+++ b/examples/bring_your_own_encoding/df_encoding.py
@@ -5,7 +5,20 @@
 # This source code and the accompanying materials are made available under     #
 # the terms of the Apache License 2.0 which accompanies this distribution.     #
 # ============================================================================ #
-"""Double-factorized block encoding: a ``BlockEncoding`` built from integrals.
+"""Bring your own block encoding: a complete, worked ``BlockEncoding``.
+
+``cudaq_algorithms`` consumers (``Walk``, ``QSVT``) are generic over the
+structural ``BlockEncoding`` protocol — no inheritance, no registration.
+Any object that exposes ``num_system`` / ``num_ancilla`` / ``alpha`` and
+the documented kernel factories (``prepare_kernel``, ``apply_kernel``,
+``walk_step_kernel``, the controlled/adjoint variants, ...) plugs into
+qubitization and QSVT unchanged. This example is a full-scale
+demonstration: a *double-factorized* encoding of the electronic-structure
+Hamiltonian, implemented outside the package against the public API only,
+and validated against an independent dense reference by
+``tests/python/test_df_encoding.py``. Use it as the template for writing
+your own encoding; ``df_block_encoding.py`` in this directory drives it
+head to head with the built-in ``PauliLCU`` through the same ``Walk``.
 
 Encodes the electronic-structure Hamiltonian directly from its
 double-factorized form (von Burg et al., PRX Quantum 2, 030305 (2021);
@@ -58,12 +71,13 @@ from numpy.typing import ArrayLike
 
 import cudaq
 
-from .block_encoding import Kernel
-from .common_kernels import _validate_power, reflect_about_zero
-from .double_factorization import (DoubleFactorization,
-                                   explicit_double_factorization)
-from .pauli_lcu import (_prepare_angles, controlled_reflect_about_prepare,
-                        prepare, reflect_about_prepare, unprepare)
+from cudaq_algorithms.block_encoding import Kernel
+from cudaq_algorithms.common_kernels import reflect_about_zero
+from cudaq_algorithms.double_factorization import (
+    DoubleFactorization, explicit_double_factorization)
+from cudaq_algorithms.pauli_lcu import (controlled_reflect_about_prepare,
+                                        prepare, reflect_about_prepare,
+                                        unprepare)
 
 __all__ = [
     "DoubleFactorizedEncoding",
@@ -76,6 +90,47 @@ __all__ = [
     "controlled_walk",
     "controlled_adjoint_walk",
 ]
+
+# ----------------------------------------------------------------------
+# Small host-side helpers, inlined so the example depends only on the
+# public package surface (the library keeps private twins of these; the
+# dense-reference tests pin both to the same behavior).
+# ----------------------------------------------------------------------
+
+
+def _validate_power(power: int) -> int:
+    """Require a non-negative integral walk power (no silent truncation)."""
+    steps = int(power)
+    if steps != power or steps < 0:
+        raise ValueError("power must be a non-negative integer")
+    return steps
+
+
+def _prepare_angles(probabilities) -> list[float]:
+    """Rotation angles for the binary state-preparation tree."""
+    n_leaves = len(probabilities)
+    if n_leaves & (n_leaves - 1):
+        raise ValueError("probability vector size must be a power of 2")
+    n_qubits = n_leaves.bit_length() - 1
+
+    angles = []
+    for layer in range(n_qubits):
+        step = n_leaves >> (layer + 1)
+        for node in range(1 << layer):
+            start = node * step * 2
+            total = sum(probabilities[start:start + 2 * step])
+            if total == 0.0:
+                # Exactly-zero subtree: only power-of-two padding, since
+                # every retained term contributes strictly positive
+                # probability. (A threshold here would zero the split of
+                # genuinely tiny sibling terms and silently encode a
+                # different operator.)
+                angles.append(0.0)
+            else:
+                right = sum(probabilities[start + step:start + 2 * step])
+                angles.append(2.0 * math.asin(math.sqrt(right / total)))
+    return angles
+
 
 # ============================================================================
 # Device kernels (module level, composable from user kernels)

--- a/python/cudaq_algorithms/__init__.py
+++ b/python/cudaq_algorithms/__init__.py
@@ -49,7 +49,7 @@ from .trotter import Trotter, TrotterOrdering, TrotterResourceEstimate
 # cudaq_algorithms.common_kernels.reflect_about_zero, .signal_phase, ...):
 # their names are too generic to export from the package root.
 #
-# The double-factorized encoding (DoubleFactorizedEncoding) is not part of
-# the package: it lives in examples/bring_your_own_encoding/df_encoding.py
-# as the worked demonstration of implementing the BlockEncoding protocol
-# against the public API (dense-validated by tests/python/test_df_encoding.py).
+# A worked, full-scale implementation of the BlockEncoding protocol — the
+# double-factorized encoding — ships as a runnable example at
+# examples/bring_your_own_encoding/df_encoding.py (dense-validated by
+# tests/python/test_df_encoding.py).

--- a/python/cudaq_algorithms/__init__.py
+++ b/python/cudaq_algorithms/__init__.py
@@ -33,12 +33,11 @@ def _resolve_version() -> str:
 __version__ = _resolve_version()
 del _resolve_version
 
-from . import (block_encoding, chemistry, common_kernels, df_encoding,
-               double_factorization, fermion, pauli_lcu, qsvt, qubitization,
-               sim_utils, stateprep, trotter)
+from . import (block_encoding, chemistry, common_kernels, double_factorization,
+               fermion, pauli_lcu, qsvt, qubitization, sim_utils, stateprep,
+               trotter)
 from .block_encoding import BlockEncoding
 from .common_kernels import state_from
-from .df_encoding import DoubleFactorizedEncoding
 from .pauli_lcu import PauliLCU, select_observable
 from .qsvt import (ADJOINT, FORWARD, PhaseSequence, QSVT,
                    recover_real_time_evolution)
@@ -49,3 +48,8 @@ from .trotter import Trotter, TrotterOrdering, TrotterResourceEstimate
 # (cudaq_algorithms.pauli_lcu.prepare, .select, .apply_phase_sequence, ...;
 # cudaq_algorithms.common_kernels.reflect_about_zero, .signal_phase, ...):
 # their names are too generic to export from the package root.
+#
+# The double-factorized encoding (DoubleFactorizedEncoding) is not part of
+# the package: it lives in examples/bring_your_own_encoding/df_encoding.py
+# as the worked demonstration of implementing the BlockEncoding protocol
+# against the public API (dense-validated by tests/python/test_df_encoding.py).

--- a/python/cudaq_algorithms/chemistry.py
+++ b/python/cudaq_algorithms/chemistry.py
@@ -241,7 +241,7 @@ def from_fcidump(contents: str) -> tuple[np.ndarray, np.ndarray, float]:
     ``(pq|rs)`` two-electron tensor (all eight symmetry partners of each
     stored record populated), and the scalar core/constant energy -- the
     ``(one_body, eri, core_energy)`` triple, in the exact convention
-    ``qubit_hamiltonian`` and ``DoubleFactorizedEncoding`` consume::
+    ``qubit_hamiltonian`` and the block encodings consume::
 
         one_body, eri, core = from_fcidump(text)
         hamiltonian = qubit_hamiltonian(one_body, eri, scalar_offset=core)

--- a/tests/python/test_df_encoding.py
+++ b/tests/python/test_df_encoding.py
@@ -7,11 +7,20 @@
 # ============================================================================ #
 """DoubleFactorizedEncoding: correctness against dense fermionic references.
 
+The encoding under test is the bring-your-own-encoding example
+(``examples/bring_your_own_encoding/df_encoding.py``) — a complete
+``BlockEncoding`` implemented outside the package against the public API.
+Keeping its dense-reference suite in CI both validates the example and
+pins the ``BlockEncoding`` protocol from a consumer's perspective.
+
 The reference Hamiltonian is built from dense Jordan-Wigner ladder
 operators (interleaved spins, qubit 0 least significant — the convention
 of ``cudaq_algorithms.chemistry``), entirely in NumPy, so these tests
 need no compiled extension and no external chemistry package.
 """
+
+import pathlib
+import sys
 
 import numpy as np
 import pytest
@@ -21,7 +30,13 @@ import cudaq
 import cudaq_algorithms as algorithms
 from cudaq_algorithms import BlockEncoding, PhaseSequence, QSVT, Walk
 from cudaq_algorithms.common_kernels import state_from
-from cudaq_algorithms.df_encoding import DoubleFactorizedEncoding
+
+# The encoding lives in the examples tree, not the package (CUDA-Q kernels
+# need real .py files, so a plain path-based import works).
+_EXAMPLE_DIR = (pathlib.Path(__file__).resolve().parents[2] / "examples" /
+                "bring_your_own_encoding")
+sys.path.insert(0, str(_EXAMPLE_DIR))
+from df_encoding import DoubleFactorizedEncoding
 
 df = algorithms.double_factorization
 

--- a/tests/python/test_df_encoding.py
+++ b/tests/python/test_df_encoding.py
@@ -530,8 +530,12 @@ def test_example_prepare_angles_keep_tiny_sibling_terms():
 
 
 def test_walk_kernel_rejects_negative_power():
-    # Pins the example's inlined _validate_power (mirrors the package twin).
+    # Pins the example's inlined _validate_power (mirrors the package twin):
+    # both rejection branches, so a copy "simplified" to int(power) plus a
+    # negativity check cannot silently truncate fractional powers.
     one_body, eri = random_system(7)
     encoding = DoubleFactorizedEncoding(one_body, eri)
     with pytest.raises(ValueError, match="non-negative integer"):
         encoding.walk_kernel(power=-1)
+    with pytest.raises(ValueError, match="non-negative integer"):
+        encoding.walk_kernel(power=1.5)

--- a/tests/python/test_df_encoding.py
+++ b/tests/python/test_df_encoding.py
@@ -19,6 +19,7 @@ of ``cudaq_algorithms.chemistry``), entirely in NumPy, so these tests
 need no compiled extension and no external chemistry package.
 """
 
+import math
 import pathlib
 import sys
 
@@ -504,3 +505,33 @@ def test_single_ancilla_negative_sign_select():
     ket = random_ket(1 << encoding.num_system)
     block = encoded_block(encoding, encoding.encode_kernel(), ket)
     np.testing.assert_allclose(block, -ket, atol=1e-10)  # constant/alpha = -1
+
+
+# ----------------------------------------------------------------------
+# Pins for the example's inlined helper copies (the package keeps private
+# twins; these mirror the package-side tests so the copies cannot silently
+# diverge on load-bearing behavior).
+# ----------------------------------------------------------------------
+
+
+def test_example_prepare_angles_keep_tiny_sibling_terms():
+    # Mirror of test_pauli_lcu.test_prepare_angles_keep_tiny_sibling_terms
+    # against the example's inlined copy: the zero-subtree guard must fire
+    # only for exact-zero (padded) subtrees; two retained sibling terms whose
+    # combined probability is below any threshold still split 50/50.
+    from df_encoding import _prepare_angles
+    kept = [2e-12, 2e-12, 1e6]
+    total = sum(kept)
+    probabilities = [c / total for c in kept] + [0.0]
+    angles = _prepare_angles(probabilities)
+    assert angles[1] == pytest.approx(2.0 * math.asin(math.sqrt(0.5)))
+    # Exact-zero padding subtrees still produce zero rotations.
+    assert _prepare_angles([0.5, 0.5, 0.0, 0.0])[2] == 0.0
+
+
+def test_walk_kernel_rejects_negative_power():
+    # Pins the example's inlined _validate_power (mirrors the package twin).
+    one_body, eri = random_system(7)
+    encoding = DoubleFactorizedEncoding(one_body, eri)
+    with pytest.raises(ValueError, match="non-negative integer"):
+        encoding.walk_kernel(power=-1)

--- a/tests/python/test_df_encoding.py
+++ b/tests/python/test_df_encoding.py
@@ -9,9 +9,9 @@
 
 The encoding under test is the bring-your-own-encoding example
 (``examples/bring_your_own_encoding/df_encoding.py``) — a complete
-``BlockEncoding`` implemented outside the package against the public API.
-Keeping its dense-reference suite in CI both validates the example and
-pins the ``BlockEncoding`` protocol from a consumer's perspective.
+``BlockEncoding`` built on the public API. Keeping its dense-reference
+suite in CI both validates the example and pins the ``BlockEncoding``
+protocol from a consumer's perspective.
 
 The reference Hamiltonian is built from dense Jordan-Wigner ladder
 operators (interleaved spins, qubit 0 least significant — the convention
@@ -32,8 +32,8 @@ import cudaq_algorithms as algorithms
 from cudaq_algorithms import BlockEncoding, PhaseSequence, QSVT, Walk
 from cudaq_algorithms.common_kernels import state_from
 
-# The encoding lives in the examples tree, not the package (CUDA-Q kernels
-# need real .py files, so a plain path-based import works).
+# The encoding under test is the bring-your-own-encoding example (CUDA-Q
+# kernels need real .py files, so a plain path-based import works).
 _EXAMPLE_DIR = (pathlib.Path(__file__).resolve().parents[2] / "examples" /
                 "bring_your_own_encoding")
 sys.path.insert(0, str(_EXAMPLE_DIR))


### PR DESCRIPTION
Move the double-factorized encoding to a bring-your-own-encoding example, on real molecules

## Description

`DoubleFactorizedEncoding` leaves the package surface and becomes
[`examples/bring_your_own_encoding/df_encoding.py`](examples/bring_your_own_encoding/df_encoding.py):
a complete, runnable demonstration that the `BlockEncoding` protocol is
structural — implement the protocol's surface against the public API and
`Walk`/`QSVT` accept the encoding unchanged. Its companion demo drives the
encoding head to head with the built-in `PauliLCU` on **real molecules**
(integrals built live from PySCF), across a six-configuration menu.

**Motivation.** The frame-cancellation construction at the heart of this
encoding relies on a shared orthogonal frame per leaf, which is specific to
the double-factorized form and does not generalize to the THC family the
library is converging toward. Rather than carry two DF encodings on the API
long-term, this repositions the original as the extension-protocol
showcase, preserving its pedagogical value and its full validation suite.

### What changed

- `python/cudaq_algorithms/df_encoding.py` →
  `examples/bring_your_own_encoding/df_encoding.py`. The example depends
  only on the public package surface: relative imports become absolute, and
  the two small private helpers it used (`_validate_power`,
  `_prepare_angles`) are inlined, so the file can be copied wholesale as
  the starting point for a new encoding.
- `cudaq_algorithms.DoubleFactorizedEncoding` and the `df_encoding`
  submodule are removed from the package root (pointer comment left in
  `__init__.py`). The classical `double_factorization` preprocessing
  package is untouched and remains public.
- The companion demo (`df_block_encoding.py`, formerly under
  `examples/double_factorization/`) moves beside the encoding and is
  rebuilt around a **PySCF molecule menu** (`pip install pyscf`):

  ```
  h2         H2 / STO-3G           2 orbitals ->  4 system qubits  (default)
  h2o-cas44  H2O / STO-3G CAS(4,4) 4 orbitals ->  8 system qubits
  h4         linear H4 / STO-3G    4 orbitals ->  8 system qubits
  lih        LiH / STO-3G          6 orbitals -> 12 system qubits
  h2o        H2O / STO-3G          7 orbitals -> 14 system qubits
  h2o-631g   H2O / 6-31G          13 orbitals -> 26 system qubits
  ```

  Every configuration tells the classical story: DF vs flat-`PauliLCU`
  alpha and term counts, the leaf-truncation dial, and an **RC-DF row**
  (re-optimize the kept leaves at the same budgets — complementing the
  classical C-DF-vs-X-DF comparison in `examples/double_factorization/`
  with the encoding-side view, and the first *regularized* (RC-DF) use
  in an example). Small
  configurations also run the circuits, self-verified against a sparse
  Jordan–Wigner reference (~1e-15) with Chebyshev moments through the
  shared `Walk`; larger ones print the statevector cost and skip execution.
  The active-space entry runs the **fully verified circuit story on real
  water** via PySCF's CASCI effective integrals. At H2O/6-31G the DF alpha
  is 145.1 vs 212.3 for the flat expansion (~32% lower).
- Docs updated (`docs/df_block_encoding.md` — retitled, menu documented;
  `docs/double_factorization.md`; a `chemistry.py` docstring mention).

### Compatibility notes

- **API removal** (pre-1.0): `from cudaq_algorithms import
  DoubleFactorizedEncoding` no longer works; the class is imported from the
  example file instead (snippet in `docs/df_block_encoding.md`).
- The wheel loses the `df_encoding` module (that is the disclosed API
  removal); nothing else in the artifact changes — examples and tests were
  never packaged, and nothing remaining in the shipped package depended on
  it.
- PySCF is an **example-only** dependency (friendly import error points to
  `pip install pyscf`); the test suite does not import the demo, so CI
  needs no new dependency.

### Validation

- Full suite on the branch: **269 passed, 3 skipped** (fp64 `qpp-cpu`);
  every touched file clean under the CI-pinned yapf 0.43.0.
- All six demo configurations run green with their self-checks
  (h2 4 s; h2o-cas44 30 s; h4 ~2 min; lih 23 s; h2o 42 s; h2o-631g 3 s).
- Two independent review rounds on the move itself; all findings addressed
  (the CI paths-filter gap and the helper divergence pins above).
