### PR TITLE
fix: To fix the displayed version number

### DIFF
--- a/python/cudaq_algorithms/__init__.py
+++ b/python/cudaq_algorithms/__init__.py
@@ -17,7 +17,9 @@ Python package plus NumPy/SciPy.
 def _resolve_version() -> str:
     from importlib.metadata import PackageNotFoundError, version
 
-    for distribution in ("cudaq-algorithms-cu12", "cudaq-algorithms-cu13"):
+    # The shipped wheel is CUDA-agnostic; the -cuNN names are fallbacks.
+    for distribution in ("cudaq-algorithms", "cudaq-algorithms-cu12",
+                         "cudaq-algorithms-cu13"):
         try:
             return f"CUDA-Q Algorithms {version(distribution)}"
         except PackageNotFoundError:

--- a/tests/python/test_import.py
+++ b/tests/python/test_import.py
@@ -1,8 +1,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+
 
 def test_import():
     import cudaq_algorithms
 
     assert "CUDA-Q Algorithms" in cudaq_algorithms.__version__
+
+
+# test_import above also passes on the "(source)" fallback, so an installed
+# wheel that cannot resolve its own name goes unnoticed. Pin to metadata.
+def test_version_reports_the_installed_distribution():
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        installed = version("cudaq-algorithms")
+    except PackageNotFoundError:
+        # A source tree has no metadata; "(source)" is honest there.
+        pytest.skip("cudaq-algorithms is not installed as a distribution")
+
+    import cudaq_algorithms
+
+    # Equality, not containment: the "(source)" fallback must not pass.
+    assert cudaq_algorithms.__version__ == f"CUDA-Q Algorithms {installed}"


### PR DESCRIPTION
This PR tries to fix the displayed/returned version of `cudaq-algorithms`.
Since the lib is built CUDA-agnostic in `0.1.0` release, we will not have `cudaq-algorithms-cu12` or `cudaq-algorithms-cu13`, and the user will get `CUDA-Q Algorithms (source)`, which shows no version info and may block some downstream version checks.