### PR TITLE
fix: Use the maximum spin degree for PauliLCU width inference to avoid invalid Pauli-word padding

### DIFF
--- a/python/cudaq_algorithms/common_kernels.py
+++ b/python/cudaq_algorithms/common_kernels.py
@@ -34,6 +34,29 @@ def state_from(ket) -> cudaq.State:
     return cudaq.State.from_data(np.asarray(ket, dtype=cudaq.complex()))
 
 
+def _maybe_call(value):
+    """Return ``value()`` if callable (property-vs-method API tolerance)."""
+    return value() if callable(value) else value
+
+
+def _term_qubit_extent(term) -> int:
+    """Register extent a spin term needs: largest targeted qubit + 1.
+
+    Not ``qubit_count``: CUDA-Q's ``qubit_count`` is the number of
+    *distinct* targeted indices, which undercounts whenever the targets
+    are off-zero or gapped (``0.5 * spin.x(1)`` targets one qubit but
+    needs a two-qubit word). One helper for every input path (PauliLCU
+    and Trotter both route through it).
+    """
+    try:
+        max_degree = _maybe_call(getattr(term, "max_degree", -1))
+    except RuntimeError:
+        # An identity term acts on no degrees; CUDA-Q raises rather than
+        # returning a sentinel. It constrains no register extent.
+        return 0
+    return max_degree + 1 if max_degree >= 0 else 0
+
+
 def _real_coefficient(value) -> float:
     """Coerce a Hamiltonian coefficient to float, rejecting complex values.
 

--- a/python/cudaq_algorithms/pauli_lcu.py
+++ b/python/cudaq_algorithms/pauli_lcu.py
@@ -356,10 +356,15 @@ def _terms_from_input(
         # normalize to a one-term operator.
         return _terms_from_input(cudaq.SpinOperator(hamiltonian), num_qubits)
     elif isinstance(hamiltonian, cudaq.SpinOperator):
-        width = num_qubits if num_qubits is not None else int(
-            hamiltonian.qubit_count)
+        terms = list(hamiltonian)
+        extent = max((int(term.max_degree) + 1 for term in terms), default=0)
+        width = extent if num_qubits is None else num_qubits
+        if width < extent:
+            raise ValueError(
+                f"num_qubits={num_qubits} is smaller than Hamiltonian "
+                f"extent {extent}")
         pairs = [(_real_coefficient(term.evaluate_coefficient()),
-                  str(term.get_pauli_word(width))) for term in hamiltonian]
+                  str(term.get_pauli_word(width))) for term in terms]
     elif isinstance(hamiltonian, Iterable) and not isinstance(
             hamiltonian, (str, bytes, bytearray, memoryview)):
         pairs = [(_real_coefficient(c), str(w)) for c, w in hamiltonian]

--- a/python/cudaq_algorithms/pauli_lcu.py
+++ b/python/cudaq_algorithms/pauli_lcu.py
@@ -32,7 +32,8 @@ from typing import TYPE_CHECKING, TypeAlias, Union
 import cudaq
 
 from .common_kernels import (_bit_projector, _real_coefficient,
-                             _validate_power, controlled_reflect_about_zero,
+                             _term_qubit_extent, _validate_power,
+                             controlled_reflect_about_zero,
                              controlled_signal_phase, reflect_about_zero,
                              signal_phase, state_from)
 
@@ -356,15 +357,18 @@ def _terms_from_input(
         # normalize to a one-term operator.
         return _terms_from_input(cudaq.SpinOperator(hamiltonian), num_qubits)
     elif isinstance(hamiltonian, cudaq.SpinOperator):
-        terms = list(hamiltonian)
-        extent = max((int(term.max_degree) + 1 for term in terms), default=0)
-        width = extent if num_qubits is None else num_qubits
-        if width < extent:
+        # The register extent is the largest targeted qubit + 1 -- NOT
+        # ``qubit_count``, which counts *distinct* targets and undercounts
+        # off-zero or gapped operators (0.5 * spin.x(1) needs "IX").
+        required = max((_term_qubit_extent(term) for term in hamiltonian),
+                       default=0)
+        if num_qubits is not None and num_qubits < required:
             raise ValueError(
-                f"num_qubits={num_qubits} is smaller than Hamiltonian "
-                f"extent {extent}")
+                f"num_qubits={num_qubits} is smaller than the operator's "
+                f"register extent {required} (largest targeted qubit + 1)")
+        width = num_qubits if num_qubits is not None else required
         pairs = [(_real_coefficient(term.evaluate_coefficient()),
-                  str(term.get_pauli_word(width))) for term in terms]
+                  str(term.get_pauli_word(width))) for term in hamiltonian]
     elif isinstance(hamiltonian, Iterable) and not isinstance(
             hamiltonian, (str, bytes, bytearray, memoryview)):
         pairs = [(_real_coefficient(c), str(w)) for c, w in hamiltonian]

--- a/python/cudaq_algorithms/trotter.py
+++ b/python/cudaq_algorithms/trotter.py
@@ -36,7 +36,8 @@ from typing import Any, Union
 
 import cudaq
 
-from .common_kernels import _real_coefficient
+from .common_kernels import (_maybe_call, _real_coefficient,
+                             _term_qubit_extent)
 
 #: Supported product-formula orders.
 FIRST_ORDER_TROTTER: int = 1
@@ -121,17 +122,6 @@ def apply_trotter(coefficients: list[float], words: list[cudaq.pauli_word],
 # ============================================================================
 # Host-side term extraction
 # ============================================================================
-
-
-def _maybe_call(value: Any) -> Any:
-    """Return ``value()`` if callable (property-vs-method API tolerance)."""
-    return value() if callable(value) else value
-
-
-def _term_qubit_extent(term: Any) -> int:
-    """Number of qubits a spin term touches (max degree + 1)."""
-    max_degree = _maybe_call(getattr(term, "max_degree", -1))
-    return max_degree + 1 if max_degree >= 0 else 0
 
 
 def _word_pairs_from_input(

--- a/tests/python/test_pauli_lcu.py
+++ b/tests/python/test_pauli_lcu.py
@@ -295,3 +295,34 @@ def test_spin_operator_rejects_explicit_width_below_extent():
     # error identifies the bad argument and the required register extent.
     with pytest.raises(ValueError, match=r"num_qubits=1.*extent 2"):
         PauliLCU(0.5 * spin.x(1), num_qubits=1)
+
+
+def test_spin_operator_off_zero_dense_reference():
+    # Beyond the width and padded words: the encoded block must be the
+    # dense operator itself, not just constructible.
+    off_zero = PauliLCU(0.5 * spin.x(1))
+    assert off_zero.alpha == pytest.approx(0.5)
+    ket = random_ket(2, seed=3)
+    expected = dense_matrix([(0.5, "IX")], 2) @ ket / off_zero.alpha
+    state = np.array(cudaq.get_state(off_zero.encode_kernel(),
+                                     state_from(ket)))
+    np.testing.assert_allclose(state[:4], expected, atol=1e-12)
+
+
+def test_spin_operator_wider_explicit_width_pads():
+    # An explicit num_qubits wider than the extent is legal padding.
+    wider = PauliLCU(spin.x(0) + spin.z(3), num_qubits=6)
+    assert wider.num_system == 6
+
+
+def test_spin_operator_identity_term_extent():
+    # Scalar/arithmetic identity terms act on NO degrees, and CUDA-Q's
+    # max_degree raises on them rather than returning a sentinel; they
+    # must not constrain or crash the register-extent inference. Note
+    # spin.i(0) does NOT exercise this path (it explicitly targets degree
+    # 0) -- only the scalar form does, which is exactly what the chemistry
+    # bridge produces via scalar_offset.
+    op = 0.5 * spin.x(1) + 0.25
+    encoding = PauliLCU(op)
+    assert encoding.num_system == 2
+    assert {word for _, word in encoding.terms} == {"II", "IX"}

--- a/tests/python/test_pauli_lcu.py
+++ b/tests/python/test_pauli_lcu.py
@@ -275,3 +275,23 @@ def test_string_hamiltonian_rejected_with_type_error():
     # TypeError, not a misleading unpack error from the pair branch.
     with pytest.raises(TypeError, match="SpinOperator"):
         PauliLCU("XZ")
+
+
+@pytest.mark.parametrize(
+    "hamiltonian,expected_width,expected_words",
+    [(0.5 * spin.x(1), 2, ["IX"]),
+     (0.3 * spin.x(0) + 0.2 * spin.z(3), 4, ["IIIZ", "XIII"])])
+def test_spin_operator_infers_register_extent(hamiltonian, expected_width,
+                                              expected_words):
+    # Off-zero and gapped indices require max_degree + 1 qubits, not the
+    # number of distinct indices. The width and padded words pin both facts.
+    encoding = PauliLCU(hamiltonian)
+    assert encoding.num_system == expected_width
+    assert sorted(word for _, word in encoding.terms) == expected_words
+
+
+def test_spin_operator_rejects_explicit_width_below_extent():
+    # Validate the requested width before CUDA-Q renders a Pauli word, so the
+    # error identifies the bad argument and the required register extent.
+    with pytest.raises(ValueError, match=r"num_qubits=1.*extent 2"):
+        PauliLCU(0.5 * spin.x(1), num_qubits=1)


### PR DESCRIPTION
This PR tries to fix [[B] 6592649](https://nvbugspro.nvidia.com/bug/6592649).
It also adds 2 test cases to expose this bug and verify the fix.
Thanks for looking at this PR.

In this suggested fix:
We infer the PauliLCU register width from the largest spin-operator degree plus one, and validate an explicit `num_qubits` before rendering Pauli words.
In this case, failures for off-zero or gapped qubit indices can be avoided, while undersized explicit widths produce a clear error.

Added test cases:
- `test_spin_operator_infers_register_extent`:
We use off-zero and gapped spin operators, then check the inferred width and padded Pauli words.
- `test_spin_operator_rejects_explicit_width_below_extent`:
We provide an undersized explicit width, then check that PauliLCU reports the requested and required extents.