### PR TITLE
fix: To include the first-factor eigenvalue scale in second-factor truncation to correct eigendecomposition over-truncation

### DIFF
--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -144,8 +144,9 @@ def _second_factorization(leaf: DeviceArray, scale: ArrayLike,
     gamma, rotation = xp.linalg.eigh(leaf)
     if second_factor_threshold > 0.0:
         importance = xp.sum(xp.abs(gamma))
-        gamma = xp.where(importance * xp.abs(gamma) > second_factor_threshold,
-                         gamma, 0.0)
+        gamma = xp.where(
+            xp.abs(scale) * importance * xp.abs(gamma)
+            > second_factor_threshold, gamma, 0.0)
     core = scale * xp.outer(gamma, gamma)
     return to_numpy(rotation), to_numpy(core)
 

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -495,3 +495,22 @@ def test_pair_swap_asymmetry_rejected():
     eri[0, 0, 1, 1] += 0.05  # breaks (pq|rs) == (rs|pq) only
     with pytest.raises(ValueError, match="chemist symmetries"):
         df.explicit_double_factorization(eri)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_second_factor_threshold_includes_first_factor_eigenvalue(backend):
+    # The small second-factor mode has scaled importance
+    # 100 * (sqrt(0.99) + 0.1) * 0.1 > 0.2, so it must not be truncated.
+    leaf = np.diag([0.1, np.sqrt(0.99)])
+    eri = 100.0 * np.einsum("pq,rs->pqrs", leaf, leaf)
+    factorization = df.explicit_double_factorization(
+        eri,
+        threshold=0.0,
+        second_factor_threshold=0.2,
+        first_factorization="eigendecomposition",
+        backend=backend)
+
+    # Both modes must remain because both scaled importance values exceed 0.2.
+    assert np.all(np.abs(np.diag(factorization.leaf_cores[0])) > 0.0)
+    # Retaining both modes must reconstruct this rank-one ERI to round-off.
+    assert df.factorization_error(eri, factorization) < 1.0e-12


### PR DESCRIPTION
This PR tries to fix [[B] 6595852](https://nvbugspro.nvidia.com/bug/6595852)
It also adds 2 test cases to expose the bug and verify the fix.
Thanks for looking at this PR.

In this suggested fix:
We update the second-factor truncation importance calculation to include the absolute first-factor eigenvalue scale before deciding which second-factor eigenmodes to retain.
In this case, significant modes on the first-factor eigendecomposition path can be retained correctly, avoiding scale-independent truncation and large silent reconstruction errors.

Added/Modified/Deleted test cases:
- test_second_factor_threshold_includes_first_factor_eigenvalue[numpy]:
We set a rank-one ERI with a first-factor eigenvalue of 100 and a small second-factor mode whose scaled importance exceeds the threshold, and then check that both modes remain and the ERI is reconstructed to round-off.
- test_second_factor_threshold_includes_first_factor_eigenvalue[cupy]:
We run the same scale-sensitive case with the CuPy backend and then check that both modes remain and the ERI is reconstructed to round-off.