### PR TITLE
fix: To validate FCIDUMP header termination to avoid silently returning zero Hamiltonians

### DIFF
--- a/python/cudaq_algorithms/chemistry.py
+++ b/python/cudaq_algorithms/chemistry.py
@@ -283,6 +283,9 @@ def from_fcidump(contents: str) -> tuple[np.ndarray, np.ndarray, float]:
     if state == "pre":
         raise ValueError(
             "FCIDUMP contents must begin with an &FCI header namelist")
+    if state == "header":
+        raise ValueError(
+            "FCIDUMP header namelist was never terminated (&END, $END, or /)")
 
     header = " ".join(header_lines)
     # Unrestricted files store spin-resolved (alpha/beta/mixed) blocks whose

--- a/tests/python/test_fcidump.py
+++ b/tests/python/test_fcidump.py
@@ -191,3 +191,10 @@ def test_from_fcidump_interops_with_pyscf_writer(tmp_path):
     np.testing.assert_allclose(_spectrum(one_body, eri, core_energy),
                                _spectrum(H1, ERI, E_NUCLEAR),
                                atol=1e-10)
+
+
+def test_from_fcidump_rejects_unterminated_header():
+    # Integral records after a missing &END must not be returned as H = 0.
+    unterminated = H2_STO3G_FCIDUMP.replace("&END\n", "")
+    with pytest.raises(ValueError, match="never terminated"):
+        chemistry.from_fcidump(unterminated)


### PR DESCRIPTION
This PR tries to fix [[B] 6595943](https://nvbugspro.nvidia.com/bug/6595943).
It also adds 1 test case to expose the bug and verify the fix.
Thanks for looking at this PR.

In this suggested fix:
We add an end-state check to `from_fcidump` so that a header without `&END`, `$END`, or `/` raises a clear `ValueError` before zero-filled integral tensors are returned.
In this case, integral records can no longer be misclassified as header text and silently converted into a zero Hamiltonian.

Added/Modified/Deleted test cases:
- `test_from_fcidump_rejects_unterminated_header` (added):
We remove `&END` from the existing valid H2 FCIDUMP fixture while retaining its integral records, and then check that `from_fcidump` raises a `ValueError` matching `never terminated`, so the silent zero-Hamiltonian bug can be exposed.