### PR TITLE
Follow-ups from the reviews of #31 and #32

### DIFF
--- a/python/cudaq_algorithms/chemistry.py
+++ b/python/cudaq_algorithms/chemistry.py
@@ -286,6 +286,8 @@ def from_fcidump(contents: str) -> tuple[np.ndarray, np.ndarray, float]:
     if state == "header":
         raise ValueError(
             "FCIDUMP header namelist was never terminated (&END, $END, or /)")
+    if not body_lines:
+        raise ValueError("FCIDUMP contains no integral records")
 
     header = " ".join(header_lines)
     # Unrestricted files store spin-resolved (alpha/beta/mixed) blocks whose

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -195,7 +195,11 @@ def explicit_double_factorization(
     leaf is eigendecomposed, ``L^t = U^t diag(gamma^t) (U^t)^T``, giving the
     rank-one core ``Z^t = outer(gamma^t, gamma^t)`` (scaled by ``lambda_t`` in the
     eigendecomposition case). ``second_factor_threshold`` optionally zeros small
-    ``gamma^t_k`` (importance-weighted, matching OpenFermion's convention).
+    ``gamma^t_k`` (importance-weighted, matching OpenFermion's convention). On
+    the eigendecomposition path the importance includes ``|lambda_t|``, so both
+    paths compare the same absolute quantity -- the mode's contribution to the
+    core one-norm; on the Cholesky path the pivot scale is already carried by
+    the leaf vector's norm.
 
     Returns a :class:`DoubleFactorization` with NumPy arrays.
     """

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -510,6 +510,12 @@ def test_second_factor_threshold_includes_first_factor_eigenvalue(backend):
         first_factorization="eigendecomposition",
         backend=backend)
 
+    # The threshold separates the two criteria: the scale-free importance
+    # of the small mode sits below 0.2 while the scaled one sits above, so
+    # this test fails loudly if the |lambda_t| factor is ever dropped again.
+    small_mode_importance = (0.1 + np.sqrt(0.99)) * 0.1
+    assert small_mode_importance < 0.2 < 100.0 * small_mode_importance
+
     # Both modes must remain because both scaled importance values exceed 0.2.
     assert np.all(np.abs(np.diag(factorization.leaf_cores[0])) > 0.0)
     # Retaining both modes must reconstruct this rank-one ERI to round-off.

--- a/tests/python/test_fcidump.py
+++ b/tests/python/test_fcidump.py
@@ -198,3 +198,11 @@ def test_from_fcidump_rejects_unterminated_header():
     unterminated = H2_STO3G_FCIDUMP.replace("&END\n", "")
     with pytest.raises(ValueError, match="never terminated"):
         chemistry.from_fcidump(unterminated)
+
+
+def test_from_fcidump_rejects_empty_body():
+    # The sibling silent-zero path: a *terminated* header with no integral
+    # records at all must also raise, not return H = 0.
+    header_only = "&FCI NORB=2,NELEC=2,MS2=0,\n&END\n"
+    with pytest.raises(ValueError, match="no integral records"):
+        chemistry.from_fcidump(header_only)


### PR DESCRIPTION
The two review follow-ups promised on #31 and #32, kept out of those PRs only because the allow-edits grant cannot reach a private fork:

- **From the #31 review**: the `explicit_double_factorization` docstring now states that the eigendecomposition path's truncation importance includes `|lambda_t|` — making explicit that both first-factorization paths compare the same absolute quantity (the mode's contribution to the core one-norm). The regression test additionally asserts the scale-free importance falls below the threshold while the scaled one sits above, so the separation the test relies on is itself pinned.
- **From the #32 review**: a terminated header with no integral records took the same silent path as the unterminated header (`NORB` parses, the record loop never runs, all-zero tensors returned). An FCIDUMP with zero records is never meaningful, so it now raises at the same validation boundary, with a matching test.

Full suite: 281 passed / 4 skipped on this branch (280/4 on main; the +1 is the new empty-body test). Both commits were also validated with full-suite runs on top of the original PR heads before those merged.
