### PR TITLE
Accept the resolver's CUDA variant on CPU wheel-test lanes

### DIFF
--- a/.github/workflows/wheel_algorithms.yaml
+++ b/.github/workflows/wheel_algorithms.yaml
@@ -251,4 +251,5 @@ jobs:
             ${{ matrix.platform }} \
             ${{ matrix.cuda_version }} \
             ${{ inputs.cudaq_wheels == 'Custom' && '0.15.99' || 'SKIP' }} \
-            ${{ inputs.version || '0.15.99' }}
+            ${{ inputs.version || '0.15.99' }} \
+            ${{ matrix.device }}

--- a/scripts/ci/test_wheels.sh
+++ b/scripts/ci/test_wheels.sh
@@ -10,9 +10,10 @@ platform=${2:-}
 cuda_version=${3:-}
 cudaq_version=${4:-}
 algorithms_version=${5:-}
+device=${6:-gpu}
 
 if [[ -z "$python_version" || -z "$platform" || -z "$cuda_version" || -z "$cudaq_version" || -z "$algorithms_version" ]]; then
-    echo "Usage: $0 <python-version> <platform> <cuda-version> <cudaq-version|SKIP> <algorithms-version>" >&2
+    echo "Usage: $0 <python-version> <platform> <cuda-version> <cudaq-version|SKIP> <algorithms-version> [cpu|gpu]" >&2
     exit 1
 fi
 
@@ -29,10 +30,12 @@ if [[ "$cudaq_version" != "SKIP" && -d /cudaq-wheels ]]; then
     $python -m pip install --find-links /cudaq-wheels "cuda-quantum-cu${cuda_major}==${cudaq_version}"
     $python -m pip install --no-deps --find-links /wheels "cudaq-algorithms==${algorithms_version}"
 else
-    # Help CUDA detection in CPU-only validation jobs.
-    $python -m pip install --extra-index-url https://pypi.nvidia.com/ "cuda_toolkit[cudart]==${cuda_version}.*" || true
     # PyPI mode installs the wheel with full deps so `cudaq` resolves a
-    # released cuda-quantum.
+    # released cuda-quantum. (A cudart pre-install used to nudge the
+    # resolver toward the lane's CUDA major on CPU hosts; cudaq >= 0.15.1
+    # ignores it and picks its own default when no driver is present, so
+    # the nudge is gone and the CPU-lane check below accepts whichever
+    # variant the resolver chose.)
     $python -m pip install --find-links /wheels --extra-index-url https://pypi.nvidia.com/ "cudaq-algorithms==${algorithms_version}"
 fi
 
@@ -45,9 +48,25 @@ if ! $python -m pip show cudaq-algorithms >/dev/null 2>&1; then
     echo "::error cudaq-algorithms is not installed." >&2
     exit 1
 fi
-if ! $python -m pip show "cuda-quantum-cu${cuda_major}" >/dev/null 2>&1; then
-    echo "::error Expected cuda-quantum-cu${cuda_major} to be installed." >&2
-    exit 1
+# In Custom mode we installed a specific cuda-quantum-cuNN; on GPU lanes
+# the resolver's detection must match the host's CUDA major. Both get the
+# exact check. On CPU lanes in PyPI mode there is no driver to detect, and
+# which variant the `cudaq` metapackage defaults to is its policy, not this
+# wheel's contract (0.15.1 switched the no-driver default to the newest
+# CUDA): require exactly one cuda-quantum-cuNN, whichever it is.
+if [[ "$cudaq_version" != "SKIP" || "$device" == "gpu" ]]; then
+    if ! $python -m pip show "cuda-quantum-cu${cuda_major}" >/dev/null 2>&1; then
+        echo "::error Expected cuda-quantum-cu${cuda_major} to be installed." >&2
+        exit 1
+    fi
+else
+    resolved=$($python -m pip list --format=freeze 2>/dev/null | grep -i '^cuda-quantum-cu' | cut -d= -f1)
+    variant_count=$(echo "$resolved" | grep -c . || true)
+    if [[ "$variant_count" != "1" ]]; then
+        echo "::error Expected exactly one cuda-quantum-cuNN, found: ${resolved:-none}." >&2
+        exit 1
+    fi
+    echo "cudaq resolved ${resolved} on the CPU lane."
 fi
 
 $python -m pytest -q tests/python


### PR DESCRIPTION
The v0.1.0 release wheel run failed in both CPU test lanes: PyPI mode lets the released `cudaq` metapackage resolve the `cuda-quantum-cuNN` variant, and cudaq 0.15.1 changed the no-driver default to the newest CUDA (cu13), breaking the CPU lanes' pinned `cu12` expectation (the `cuda_toolkit[cudart]` nudge is ignored by the new resolver — confirmed in the run logs, which show the cudart install succeeding and cu13 resolving anyway).

Fix: the exact-variant check stays where it is meaningful — Custom mode (we installed the variant explicitly) and GPU lanes (detection must match the host). CPU lanes in PyPI mode now assert exactly one `cuda-quantum-cuNN` resolved, whichever it is: the resolver's no-driver policy belongs to cudaq, not to this wheel's contract, and the wheel is CUDA-agnostic by design. The lane's `device` rides into the script as a new argument; the inert cudart pre-install is removed.

Verified: branch logic exercised for all three lane shapes (cpu-pypi → any-variant, gpu-pypi → exact, custom → exact); `bash -n` clean; single invocation site updated.

After merge: fast-forward `releases/v0.1.0` to main and re-dispatch the wheels workflow.