### PR TITLE
fix: To record C-DF optimizer status and cache CG warm starts by parameter vector to avoid silent non-convergence and inconsistent L-BFGS gradients

### DIFF
--- a/docs/sphinx/examples/python/df_block_encoding.py
+++ b/docs/sphinx/examples/python/df_block_encoding.py
@@ -289,10 +289,7 @@ def run(key: str, force_circuits: bool):
                                                          max_num_leaves=leaves)
             xdf_error = df.factorization_error(eri, truncated)
             compressed = df.compressed_double_factorization(
-                eri,
-                num_leaves=leaves,
-                regularization=1e-4,
-                max_iterations=300)
+                eri, num_leaves=leaves, regularization=1e-4)
             cdf_error = df.factorization_error(eri, compressed)
             cdf_alpha = DoubleFactorizedEncoding(one_body, compressed).alpha
             ratio = xdf_error / max(cdf_error, 1e-16)

--- a/docs/sphinx/examples/python/double_factorization.py
+++ b/docs/sphinx/examples/python/double_factorization.py
@@ -64,14 +64,18 @@ def main():
                                                     threshold=0.0,
                                                     max_num_leaves=num_leaves,
                                                     backend=backend)
+        # Truncated molecular C-DF can need a few thousand L-BFGS steps;
+        # the library default (2000) sometimes hits the cap. Status is
+        # still reported if this budget is not enough.
         compressed = df.compressed_double_factorization(eri,
                                                         num_leaves=num_leaves,
-                                                        max_iterations=600,
+                                                        max_iterations=5000,
                                                         backend=backend)
         x_rel = df.factorization_error(eri, explicit) / norm
         c_rel = df.factorization_error(eri, compressed) / norm
+        status = "" if compressed.optimizer_success else "  (not converged)"
         print(f"  leaves={num_leaves:2d}:  X-DF rel error={x_rel:.3e}   "
-              f"C-DF rel error={c_rel:.3e}")
+              f"C-DF rel error={c_rel:.3e}{status}")
         assert c_rel <= x_rel + 1.0e-6
 
 

--- a/docs/sphinx/guide/preprocessing.rst
+++ b/docs/sphinx/guide/preprocessing.rst
@@ -310,8 +310,8 @@ accuracy:
 - **`cg_warm_start=True`** seeds each *new* L-BFGS evaluation's CG from the
   previous evaluation's cores. The cores move slowly between steps, so the
   warm start collapses the iteration count. A re-evaluation of the same
-  parameters (a rejected line-search point) reuses the cached cores, so
-  the objective stays a function of the parameters.
+  parameters (a rejected line-search point) reuses cores from a short LRU
+  of recent solves, so the objective stays a function of the parameters.
 - **`cg_optimization_tolerance`** (default ``max(cg_tolerance, 1e-6)``)
   solves the *in-loop* systems only loosely — an inexact inner solve, which
   is sound here because the envelope theorem only needs an approximate

--- a/docs/sphinx/guide/preprocessing.rst
+++ b/docs/sphinx/guide/preprocessing.rst
@@ -255,7 +255,10 @@ X-DF vs C-DF
   ``X^t``) and optimized with L-BFGS, while the symmetric cores are solved
   in closed form at each step (the two-step scheme of the paper,
   warm-started from X-DF). C-DF reaches a target accuracy with substantially
-  fewer leaves than X-DF.
+  fewer leaves than X-DF. The L-BFGS status is stored on the result
+  (``optimizer_success``, ``optimizer_nit``, ``optimizer_grad_norm``); a
+  ``RuntimeWarning`` is issued if the run hits ``max_iterations`` or otherwise
+  fails to converge, and the best factorization found is still returned.
 
 RC-DF regularization
 ~~~~~~~~~~~~~~~~~~~~~
@@ -304,9 +307,11 @@ the conditioning, not by the matvec. Two accelerators (active only for
 ``inner_solver="cg"``) cut the per-step cost without changing the final
 accuracy:
 
-- **`cg_warm_start=True`** seeds each L-BFGS step's CG from the previous
-  step's cores. The cores move slowly between steps, so the warm start
-  collapses the iteration count.
+- **`cg_warm_start=True`** seeds each *new* L-BFGS evaluation's CG from the
+  previous evaluation's cores. The cores move slowly between steps, so the
+  warm start collapses the iteration count. A re-evaluation of the same
+  parameters (a rejected line-search point) reuses the cached cores, so
+  the objective stays a function of the parameters.
 - **`cg_optimization_tolerance`** (default ``max(cg_tolerance, 1e-6)``)
   solves the *in-loop* systems only loosely — an inexact inner solve, which
   is sound here because the envelope theorem only needs an approximate
@@ -321,6 +326,8 @@ All functions return or operate on a
 :class:`~cudaq_algorithms.double_factorization.DoubleFactorization`
 dataclass with `num_orbitals`, `leaf_rotations` (:math:`U^t`),
 `leaf_cores` (:math:`Z^t`), `num_leaves`, and a `reconstruct_eri` method.
+C-DF also fills `optimizer_success`, `optimizer_nit`, and
+`optimizer_grad_norm` from L-BFGS-B.
 Full signatures and parameter documentation live in the
 :doc:`Python API reference <../api/python_api>`.
 

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -547,11 +547,12 @@ def compressed_double_factorization(
     changing the final accuracy: ``cg_warm_start`` (default ``True``) seeds each
     *new* L-BFGS evaluation's CG from the previous evaluation's cores -- which
     move slowly between steps -- while a re-evaluation of the same parameters
-    (a rejected line-search point) reuses the cached cores so ``(f, g)`` stays
-    a function of ``x``. ``cg_optimization_tolerance`` (default
-    ``max(cg_tolerance, 1e-6)``) solves the *in-loop* systems only loosely (an
-    inexact inner solve; the gradient need only be approximate by the envelope
-    theorem) while the single final solve is tightened to ``cg_tolerance``.
+    (a rejected line-search point) reuses cores from a short LRU of recent
+    solves so ``(f, g)`` stays a function of ``x``. ``cg_optimization_tolerance``
+    (default ``max(cg_tolerance, 1e-6)``) solves the *in-loop* systems only
+    loosely (an inexact inner solve; the gradient need only be approximate by
+    the envelope theorem) while the single final solve is tightened to
+    ``cg_tolerance``.
 
     L-BFGS-B status is stored on the returned :class:`DoubleFactorization`
     (``optimizer_success``, ``optimizer_nit``, ``optimizer_grad_norm``). A
@@ -581,12 +582,14 @@ def compressed_double_factorization(
     lower = np.tril_indices(n, k=-1)
 
     # Inexact in-loop CG (forcing sequence) + warm start across L-BFGS steps.
-    # by_x caches cores for a given parameter vector so a line-search
-    # backtrack to the same x does not reuse a rejected trial's Z.
+    # recent is a 3-slot LRU of (parameter-vector, cores) so a line-search
+    # backtrack to the same x does not reuse a rejected trial's Z, without
+    # pinning a cores-stack per distinct x (device memory at production n).
     use_warm = inner_solver == "cg" and cg_warm_start
     loop_tolerance = (cg_optimization_tolerance if cg_optimization_tolerance
                       is not None else max(cg_tolerance, 1.0e-6))
-    warm_state = {"z": None, "by_x": {}}
+    warm_state = {"z": None, "recent": []}
+    warm_lru = 3
 
     def unpack(parameter_vector):
         # Build all leaf generators, then exponentiate them in one batched
@@ -610,14 +613,23 @@ def compressed_double_factorization(
         skews, rotations = unpack(parameter_vector)
         if use_warm:
             key = np.asarray(parameter_vector, dtype=float).tobytes()
-            cores = warm_state["by_x"].get(key)
+            cores = None
+            for index, (cached_key,
+                        cached_cores) in enumerate(warm_state["recent"]):
+                if cached_key == key:
+                    cores = cached_cores
+                    warm_state["recent"].append(
+                        warm_state["recent"].pop(index))
+                    break
             if cores is None:
                 cores = _solve_inner_cores(eri_dev, rotations, xp,
                                            regularization, inner_solver,
                                            loop_tolerance, cg_max_iterations,
                                            warm_state["z"])
                 warm_state["z"] = xp.stack(cores)
-                warm_state["by_x"][key] = cores
+                warm_state["recent"].append((key, cores))
+                if len(warm_state["recent"]) > warm_lru:
+                    del warm_state["recent"][0]
         else:
             cores = _solve_inner_cores(eri_dev, rotations, xp, regularization,
                                        inner_solver, loop_tolerance,

--- a/python/cudaq_algorithms/double_factorization/_factorization.py
+++ b/python/cudaq_algorithms/double_factorization/_factorization.py
@@ -43,6 +43,9 @@ class DoubleFactorization:
     ``leaf_rotations[t]`` is the orthogonal matrix ``U^t`` (shape
     ``(num_orbitals, num_orbitals)``) and ``leaf_cores[t]`` is the symmetric
     core ``Z^t`` for leaf ``t``. ``method`` is ``"X-DF"`` or ``"C-DF"``.
+
+    C-DF fills ``optimizer_success``, ``optimizer_nit``, and
+    ``optimizer_grad_norm`` from the L-BFGS-B result (``None`` on X-DF).
     """
 
     num_orbitals: int
@@ -53,6 +56,9 @@ class DoubleFactorization:
         str] = None  # "cholesky" or "eigendecomposition"
     leaf_weights: Optional[
         np.ndarray] = None  # first-factor pivots/eigenvalues
+    optimizer_success: Optional[bool] = None
+    optimizer_nit: Optional[int] = None
+    optimizer_grad_norm: Optional[float] = None
 
     @property
     def num_leaves(self) -> int:
@@ -539,11 +545,19 @@ def compressed_double_factorization(
 
     For ``inner_solver="cg"`` two accelerators cut the per-step CG cost without
     changing the final accuracy: ``cg_warm_start`` (default ``True``) seeds each
-    step's CG from the previous step's cores -- which move slowly between L-BFGS
-    steps -- and ``cg_optimization_tolerance`` (default ``max(cg_tolerance,
-    1e-6)``) solves the *in-loop* systems only loosely (an inexact inner solve;
-    the gradient need only be approximate by the envelope theorem) while the
-    single final solve is tightened to ``cg_tolerance``.
+    *new* L-BFGS evaluation's CG from the previous evaluation's cores -- which
+    move slowly between steps -- while a re-evaluation of the same parameters
+    (a rejected line-search point) reuses the cached cores so ``(f, g)`` stays
+    a function of ``x``. ``cg_optimization_tolerance`` (default
+    ``max(cg_tolerance, 1e-6)``) solves the *in-loop* systems only loosely (an
+    inexact inner solve; the gradient need only be approximate by the envelope
+    theorem) while the single final solve is tightened to ``cg_tolerance``.
+
+    L-BFGS-B status is stored on the returned :class:`DoubleFactorization`
+    (``optimizer_success``, ``optimizer_nit``, ``optimizer_grad_norm``). A
+    ``RuntimeWarning`` is issued if the optimizer does not converge, including
+    when it hits ``max_iterations``; the best factorization found is still
+    returned.
 
     Returns a :class:`DoubleFactorization` with NumPy arrays.
     """
@@ -567,10 +581,12 @@ def compressed_double_factorization(
     lower = np.tril_indices(n, k=-1)
 
     # Inexact in-loop CG (forcing sequence) + warm start across L-BFGS steps.
+    # by_x caches cores for a given parameter vector so a line-search
+    # backtrack to the same x does not reuse a rejected trial's Z.
     use_warm = inner_solver == "cg" and cg_warm_start
     loop_tolerance = (cg_optimization_tolerance if cg_optimization_tolerance
                       is not None else max(cg_tolerance, 1.0e-6))
-    warm_state = {"z": None}
+    warm_state = {"z": None, "by_x": {}}
 
     def unpack(parameter_vector):
         # Build all leaf generators, then exponentiate them in one batched
@@ -592,12 +608,20 @@ def compressed_double_factorization(
         # any regularization. dO/dU^t_ak = -4 sum_qrsl Delta_aqrs U_qk Z_kl U_rl
         # U_sl (Eq. 17 of arXiv:2104.08957).
         skews, rotations = unpack(parameter_vector)
-        cores = _solve_inner_cores(eri_dev, rotations, xp, regularization,
-                                   inner_solver, loop_tolerance,
-                                   cg_max_iterations,
-                                   warm_state["z"] if use_warm else None)
         if use_warm:
-            warm_state["z"] = xp.stack(cores)
+            key = np.asarray(parameter_vector, dtype=float).tobytes()
+            cores = warm_state["by_x"].get(key)
+            if cores is None:
+                cores = _solve_inner_cores(eri_dev, rotations, xp,
+                                           regularization, inner_solver,
+                                           loop_tolerance, cg_max_iterations,
+                                           warm_state["z"])
+                warm_state["z"] = xp.stack(cores)
+                warm_state["by_x"][key] = cores
+        else:
+            cores = _solve_inner_cores(eri_dev, rotations, xp, regularization,
+                                       inner_solver, loop_tolerance,
+                                       cg_max_iterations, None)
         residual = eri_dev - _reconstruct_dev(rotations, cores, xp)
         loss = 0.5 * xp.sum(residual * residual)
         if regularization > 0.0:
@@ -638,6 +662,16 @@ def compressed_double_factorization(
                                          "gtol": tolerance,
                                      })
 
+    grad_norm = (float(np.linalg.norm(np.asarray(result.jac))) if getattr(
+        result, "jac", None) is not None else None)
+    if not result.success:
+        extra = (f", ||g||={grad_norm:.3e}" if grad_norm is not None else "")
+        warnings.warn(
+            "double_factorization: compressed_double_factorization did not "
+            f"converge (status={result.status}, nit={result.nit}/"
+            f"{max_iterations}, nfev={result.nfev}{extra}): {result.message}",
+            RuntimeWarning)
+
     # Final cores at the tight cg_tolerance (warm-started from the last step).
     _, rotations = unpack(result.x)
     cores = _solve_inner_cores(eri_dev, rotations, xp, regularization,
@@ -646,7 +680,10 @@ def compressed_double_factorization(
     return DoubleFactorization(num_orbitals=n,
                                leaf_rotations=[to_numpy(r) for r in rotations],
                                leaf_cores=[to_numpy(c) for c in cores],
-                               method="C-DF")
+                               method="C-DF",
+                               optimizer_success=bool(result.success),
+                               optimizer_nit=int(result.nit),
+                               optimizer_grad_norm=grad_norm)
 
 
 def reconstruct_eri(factorization: DoubleFactorization) -> np.ndarray:

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -554,7 +554,8 @@ def test_cdf_exact_rank_is_marked_converged(backend):
                                                            max_iterations=1500,
                                                            backend=backend)
     assert factorization.optimizer_success is True
-    assert factorization.optimizer_nit == 0
+    assert factorization.optimizer_grad_norm is not None
+    assert factorization.optimizer_grad_norm < 1.0e-8
     assert df.factorization_error(eri, factorization) < 1.0e-4
 
 
@@ -569,7 +570,7 @@ def test_xdf_leaves_optimizer_status_unset():
 
 @pytest.mark.parametrize("backend", _BACKENDS)
 @pytest.mark.parametrize("inner_solver", ["lstsq", "cg"])
-def test_cdf_objective_is_a_function_of_x(backend, inner_solver):
+def test_cdf_objective_is_a_function_of_x(backend, inner_solver, monkeypatch):
     # Replay an L-BFGS line-search backtrack through the real objective:
     # evaluate at x, at a rejected trial x+dx, then at x again. SciPy
     # requires the same x to yield the same (f, g). The default CG warm
@@ -596,17 +597,14 @@ def test_cdf_objective_is_a_function_of_x(backend, inner_solver):
         kwargs["options"] = options
         return orig(fun, x0, **kwargs)
 
-    F.scipy.optimize.minimize = wrapped
-    try:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", RuntimeWarning)
-            df.compressed_double_factorization(eri,
-                                               num_leaves=4,
-                                               max_iterations=1,
-                                               inner_solver=inner_solver,
-                                               backend=backend)
-    finally:
-        F.scipy.optimize.minimize = orig
+    monkeypatch.setattr(F.scipy.optimize, "minimize", wrapped)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        df.compressed_double_factorization(eri,
+                                           num_leaves=4,
+                                           max_iterations=1,
+                                           inner_solver=inner_solver,
+                                           backend=backend)
     assert replay, "minimize wrapper did not run"
     # lstsq is stateless, so this is a tight identity. CG must match it
     # once the warm start is keyed by x rather than by call order.

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for explicit (X-DF) and compressed (C-DF) double factorization."""
 import os
+import warnings
 
 import numpy as np
 import pytest
@@ -520,3 +521,94 @@ def test_second_factor_threshold_includes_first_factor_eigenvalue(backend):
     assert np.all(np.abs(np.diag(factorization.leaf_cores[0])) > 0.0)
     # Retaining both modes must reconstruct this rank-one ERI to round-off.
     assert df.factorization_error(eri, factorization) < 1.0e-12
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_cdf_reports_when_optimizer_hits_iteration_limit(backend):
+    # max_iterations=1 cannot finish a truncated C-DF; the result must still
+    # be returned, but it must be marked unsuccessful and warn. Silent
+    # success here is the product bug: callers cannot tell a cap-hit from
+    # a stationary point.
+    eri = _synthetic_eri(4, 3, seed=7)
+    with pytest.warns(RuntimeWarning, match="did not converge"):
+        factorization = df.compressed_double_factorization(eri,
+                                                           num_leaves=2,
+                                                           max_iterations=1,
+                                                           backend=backend)
+    assert factorization.method == "C-DF"
+    assert factorization.optimizer_success is False
+    assert factorization.optimizer_nit == 1
+    assert factorization.optimizer_grad_norm is not None
+    assert factorization.optimizer_grad_norm > 0.0
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_cdf_exact_rank_is_marked_converged(backend):
+    # At the true leaf rank the X-DF warm start is already a minimizer, so
+    # L-BFGS must report success and must not warn.
+    eri = _synthetic_eri(4, 3, seed=11)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        factorization = df.compressed_double_factorization(eri,
+                                                           num_leaves=3,
+                                                           max_iterations=1500,
+                                                           backend=backend)
+    assert factorization.optimizer_success is True
+    assert factorization.optimizer_nit == 0
+    assert df.factorization_error(eri, factorization) < 1.0e-4
+
+
+def test_xdf_leaves_optimizer_status_unset():
+    # optimizer_* is a C-DF field; X-DF does not run L-BFGS.
+    eri = _synthetic_eri(4, 2, seed=3)
+    factorization = df.explicit_double_factorization(eri, threshold=0.0)
+    assert factorization.optimizer_success is None
+    assert factorization.optimizer_nit is None
+    assert factorization.optimizer_grad_norm is None
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+@pytest.mark.parametrize("inner_solver", ["lstsq", "cg"])
+def test_cdf_objective_is_a_function_of_x(backend, inner_solver):
+    # Replay an L-BFGS line-search backtrack through the real objective:
+    # evaluate at x, at a rejected trial x+dx, then at x again. SciPy
+    # requires the same x to yield the same (f, g). The default CG warm
+    # start used to seed the second f(x) from the trial's cores.
+    # H2O/STO-3G at 4 leaves is rank-deficient in Z, so a wrong seed
+    # changes (f, g) by a visible amount; the synthetic full-rank case
+    # would not expose it.
+    import cudaq_algorithms.double_factorization._factorization as F
+    eri = _h2o_eri()
+    orig = F.scipy.optimize.minimize
+    replay = {}
+
+    def wrapped(fun, x0, **kwargs):
+        x0 = np.asarray(x0, dtype=float)
+        dx = 1.0e-3 * np.random.default_rng(7).standard_normal(x0.shape)
+        f0, g0 = fun(x0)
+        fun(x0 + dx)
+        f1, g1 = fun(x0)
+        replay["df"] = abs(f0 - f1)
+        replay["dg"] = float(np.linalg.norm(np.asarray(g0) - np.asarray(g1)))
+        options = dict(kwargs.get("options") or {})
+        options["maxiter"] = 1
+        kwargs = dict(kwargs)
+        kwargs["options"] = options
+        return orig(fun, x0, **kwargs)
+
+    F.scipy.optimize.minimize = wrapped
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            df.compressed_double_factorization(eri,
+                                               num_leaves=4,
+                                               max_iterations=1,
+                                               inner_solver=inner_solver,
+                                               backend=backend)
+    finally:
+        F.scipy.optimize.minimize = orig
+    assert replay, "minimize wrapper did not run"
+    # lstsq is stateless, so this is a tight identity. CG must match it
+    # once the warm start is keyed by x rather than by call order.
+    assert replay["df"] < 1.0e-12
+    assert replay["dg"] < 1.0e-9


### PR DESCRIPTION
This PR tries to fix [[B] 6627715](https://nvbugspro.nvidia.com/bug/6627715).
It also adds 4 test cases to expose this bug and verify the fix.
The examples and docs are also updated accordingly.
Thanks for looking at this PR.

(PR open for maintainer edits. Hope this time it can work.)
(Tests and examples passed on local machine.)

In this suggested fix:
We record L-BFGS-B `success` / `nit` / gradient norm on the returned `DoubleFactorization`, warn when the run does not converge, and key the CG warm start by the parameter vector so a rejected line-search evaluation cannot change `(f, g)` at the same `x`.
In this case, silently returning an under-converged C-DF (indistinguishable from a stationary point) and a history-dependent CG objective (which breaks the L-BFGS-B contract) can be avoided.

Added/Modified/Deleted test cases:
- `test_cdf_reports_when_optimizer_hits_iteration_limit`:
We set a truncated synthetic ERI with `max_iterations=1` and then check that a `RuntimeWarning` matching `did not converge` is raised and that `optimizer_success` is False with `optimizer_nit == 1`, so a cap-hit can no longer look like success.
- `test_cdf_exact_rank_is_marked_converged`:
We set a synthetic ERI at its true leaf rank (X-DF warm start already minimises) and then check that no `RuntimeWarning` is issued and `optimizer_success` is True with `optimizer_nit == 0`, so a genuine stationary point is still reported as converged.
- `test_xdf_leaves_optimizer_status_unset`:
We run X-DF (no L-BFGS) and then check that `optimizer_success`, `optimizer_nit`, and `optimizer_grad_norm` remain `None`, so the new fields do not leak onto the explicit path.
- `test_cdf_objective_is_a_function_of_x`:
We wrap the real C-DF objective, evaluate at `x`, at a rejected trial `x+dx`, then at `x` again (H2O/STO-3G, 4 leaves, both `lstsq` and `cg`), and then compare `|f(x)-f(x)_again|` and `||g-g_again||` to tight tolerances, so a CG warm start that reused the trial cores would be exposed.

Modified examples:
- `docs/sphinx/examples/python/double_factorization.py`:
We raise the H2O C-DF L-BFGS budget from 600 to 5000 (truncated molecular C-DF can need a few thousand steps) and print `(not converged)` from `optimizer_success`, so the advertised table no longer reports a silently truncated iterate.
- `docs/sphinx/examples/python/df_block_encoding.py`:
We drop the explicit `max_iterations=300` so RC-DF uses the library default (2000) and will warn if L-BFGS still hits the cap.

Modified docs:
- `docs/sphinx/guide/preprocessing.rst`:
We document the C-DF `optimizer_*` fields, the non-convergence `RuntimeWarning`, and that CG warm start reuses cached cores on re-evaluation of the same parameters, so callers know to inspect status rather than treat every returned factorization as a stationary point.


Logs from running modified examples:
```
===== double_factorization.py =====
Double factorization of H2O/STO-3G two-electron integrals
  backend: cupy
  orbitals: 7   ||eri||_F: 7.229640

X-DF (explicit):
  full-rank leaves: 28   reconstruction error: 6.951e-15
  threshold 1e-02: leaves=18  rel error=4.235e-03
  threshold 1e-03: leaves=23  rel error=2.285e-04
  threshold 1e-04: leaves=25  rel error=6.079e-06

C-DF (compressed) vs X-DF at equal leaf count:
  leaves= 2:  X-DF rel error=1.686e-01   C-DF rel error=5.958e-02
  leaves= 4:  X-DF rel error=1.228e-01   C-DF rel error=2.172e-02
EXIT_DF:0
===== df_block_encoding.py (default h2) =====
=== h2: H2 / STO-3G ===
RHF energy -1.116684 Ha; core/nuclear constant 0.713754 Ha (added classically, not encoded)
2 spatial orbitals -> 4 system qubits

  flat PauliLCU:            alpha =     2.6977, 15 Pauli terms, 4 ancillas
  DoubleFactorizedEncoding: alpha =     2.8790, 18 Z-word terms in 4 frames (3 leaves), 4 Givens rotations, 5 ancillas

  Truncating the factorization (the knob PauliLCU lacks):
      1 leaves: alpha =     2.5380,    11 terms, tensor error 3.65e-01
      2 leaves: alpha =     2.9006,    17 terms, tensor error 4.33e-02
      3 leaves: alpha =     2.8790,    18 terms, tensor error 3.42e-16
  [check] truncation error is non-increasing in leaves ... OK
  [check] full-rank X-DF reconstructs the ERI exactly ... OK

  RC-DF at the same leaf budgets (optimize the kept leaves, don't just truncate):
      1 leaves: X-DF error 3.65e-01  RC-DF error 3.63e-01  (1.0x better), RC-DF alpha = 2.5164
      2 leaves: X-DF error 4.33e-02  RC-DF error 1.53e-04  (282.5x better), RC-DF alpha = 2.5164
  [check] RC-DF fits at least as well wherever truncation error is still significant ... OK

  Circuits: 4 system + 5 ancilla = 9 qubits
  encoded block vs sparse JW reference: max |diff| = 6.09e-16
  [check] <0|U|0> == H/alpha ... OK

  Even Chebyshev moments <T_k(H/alpha)> through Walk (same
  consumer, either encoding; alphas differ, H is the same):
    T_0:  PauliLCU +1.00000000 (exact +1.00000000)   DF +1.00000000 (exact +1.00000000)
  [check] T_0 moments match the reference ... OK
    T_2:  PauliLCU -0.67262461 (exact -0.67262461)   DF -0.71255633 (exact -0.71255633)
  [check] T_2 moments match the reference ... OK
    T_4:  PauliLCU +0.03888226 (exact +0.03888226)   DF +0.11880394 (exact +0.11880394)
  [check] T_4 moments match the reference ... OK
EXIT_BE:0
```