### PR TITLE
docs: pin BLAS threads before comparing C-DF runs

### DIFF
--- a/docs/sphinx/conventions.rst
+++ b/docs/sphinx/conventions.rst
@@ -154,6 +154,29 @@ error. All library tests pin `qpp-cpu` (fp64, via `conftest.py`) and
 assert at 1e-10..1e-12. When a probe shows ~1e-7 residuals, suspect the
 target precision before suspecting the code.
 
+BLAS threading and C-DF reproducibility
+----------------------------------------
+
+Compressed double factorization runs an iterative optimization whose
+objective is evaluated through multithreaded BLAS. Thread scheduling
+changes floating-point reduction order, and over a few thousand
+optimizer steps that noise compounds into **different local minima**:
+two runs of *identical* code on identical input can return visibly
+different factorizations (reconstruction errors differing in the second
+digit). This is expected behavior of non-convex optimization on
+non-deterministic arithmetic, not a bug.
+
+Before comparing C-DF outputs across code versions — bisecting a
+regression, validating a refactor, A/B-testing a change — pin the BLAS
+thread count::
+
+   OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+       python your_comparison.py
+
+Under pinned threads, runs of the same code are bit-for-bit
+reproducible, and any remaining difference is attributable to the code
+change. Unpinned comparisons of C-DF results are noise.
+
 Hermiticity
 -----------
 


### PR DESCRIPTION
Adds a conventions-page section on C-DF reproducibility: multithreaded BLAS changes floating-point reduction order run to run, and over a few thousand L-BFGS steps that noise compounds into **different local minima** — identical code on identical input can return factorizations whose reconstruction errors differ in the second digit (measured: 6.7e-2 vs 8.0e-2 on the same commit). Expected behavior of non-convex optimization on non-deterministic arithmetic, not a bug — but anyone bisecting a regression or A/B-testing a C-DF change must pin `OMP/OPENBLAS/MKL_NUM_THREADS=1` first, under which runs are bit-for-bit reproducible.

Surfaced while verifying #38, where unpinned threading briefly made a numerically-neutral change look like it altered results.

Docs-only diff; Sphinx `-W` build clean.