### PR TITLE
Add unary-iteration and QROM primitives

### DIFF
--- a/docs/sphinx/api/python_api.rst
+++ b/docs/sphinx/api/python_api.rst
@@ -44,6 +44,12 @@ Trotter
 .. automodule:: cudaq_algorithms.trotter
    :members:
 
+Circuit primitives
+==================
+
+.. automodule:: cudaq_algorithms.primitives
+   :members:
+
 Preprocessing
 =============
 

--- a/python/cudaq_algorithms/primitives/__init__.py
+++ b/python/cudaq_algorithms/primitives/__init__.py
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 """Fault-tolerant circuit primitives: unary iteration and QROM.
 
-``unary_iteration_kernels`` mints the fused tree walk of Babbush et al.
-(`arXiv:1805.03662`, Fig. 7) — apply a per-address body exactly when the
-address register equals ``k`` — and ``QROM`` builds coherent
+``unary_iteration_kernels`` mints unary iteration (Babbush et al.,
+`arXiv:1805.03662`, Fig. 7) in its strictly unitary form — no
+measurement-based uncomputation, i.e. the fused select(V) walk of
+Childs et al. (`arXiv:1711.10980`, Appendix G.4) — applying a
+per-address body exactly when the address register equals ``k``.
+``QROM`` builds coherent
 classical-table lookups on top of it, either as the plain
 unary-iteration SELECT or as the SELECT-SWAP / QROAM construction of
 Low, Kliuchnikov and Schaeffer (`arXiv:1812.00954`).

--- a/python/cudaq_algorithms/primitives/__init__.py
+++ b/python/cudaq_algorithms/primitives/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Fault-tolerant circuit primitives: unary iteration and QROM.
+
+``unary_iteration_kernels`` mints the fused tree walk of Babbush et al.
+(`arXiv:1805.03662`, Fig. 7) — apply a per-address body exactly when the
+address register equals ``k`` — and ``QROM`` builds coherent
+classical-table lookups on top of it, either as the plain
+unary-iteration SELECT or as the SELECT-SWAP / QROAM construction of
+Low, Kliuchnikov and Schaeffer (`arXiv:1812.00954`).
+
+Everything here is strictly unitary: the papers' headline Toffoli counts
+assume measurement-based ancilla uncomputation, which this library does
+not use (primitives must stay statevector-testable and
+inverse-composable); the module docstrings state the coherent costs the
+minted kernels actually have, and the resource tests pin them against
+the compiler.
+
+Import the subpackage directly (``from cudaq_algorithms.primitives
+import QROM``); nothing here is re-exported from the package root.
+"""
+
+from ._qrom import QROM
+from ._unary_iteration import UnaryIterationKernels, unary_iteration_kernels
+
+__all__ = [
+    "QROM",
+    "UnaryIterationKernels",
+    "unary_iteration_kernels",
+]

--- a/python/cudaq_algorithms/primitives/_qrom.py
+++ b/python/cudaq_algorithms/primitives/_qrom.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""QROM: coherent classical-table lookup, two constructions in one surface.
+
+``QROM(data, address_bits, output_bits)`` mints the lookup
+``|k>|y> -> |k>|y XOR data[k]>`` behind one kernel signature
+``(address: qview, ladder: qview, output: qview)`` — all little-endian
+(qubit 0 = LSB, ``docs/conventions.md``), ``ladder`` being ``num_ladder``
+clean ancillas (|0> in, |0> out). Addresses ``k >= len(data)`` read as
+zero. Two constructions sit behind ``variant=``:
+
+- ``"select"`` — the plain unary-iteration QROM (Babbush et al.,
+  `arXiv:1805.03662`): one fused tree walk over the address register
+  whose per-address body CNOTs the set bits of ``data[k]`` into the
+  output. ``num_ladder = address_bits``.
+- ``"select_swap"`` — SELECT-SWAP / QROAM (Low, Kliuchnikov, Schaeffer,
+  `arXiv:1812.00954`): the table is split into ``ceil(N / B)`` blocks of
+  ``B = block_size`` entries; one unary-iteration walk over the *block
+  index* (the high ``address_bits - log2(B)`` address bits) writes the
+  visited block's ``B`` entries into ``B`` clean ``output_bits``-wide
+  block registers, a swap network controlled on the low ``log2(B)``
+  address bits routes the selected entry's register into block slot 0,
+  and CNOTs copy slot 0 into the output. The routing and the writes are
+  then undone unitarily. ``num_ladder = (address_bits - log2(B)) +
+  B * output_bits`` (walk lines first, then the block registers).
+- ``"auto"`` (default) — price both variants (and every power-of-two
+  ``block_size``) with the exact Toffoli model below and take the
+  cheapest, preferring ``"select"`` on ties (fewer ancillas).
+
+Toffoli accounting (documented contract, pinned by the resource tests;
+``W(n, m)`` is the fused walk count from
+:mod:`cudaq_algorithms.primitives._unary_iteration`, ``3 * 2^n / 2 - 5``
+on full uncontrolled trees):
+
+- ``"select"``: ``W(address_bits, len(data))``.
+- ``"select_swap"``: ``2 * W(address_bits - log2(B), ceil(len(data)/B))
+  + 2 * output_bits * (B - 1)``. Each controlled register swap is
+  ``output_bits`` Fredkins, each Fredkin one Toffoli plus two CNOTs; the
+  binary routing network is ``B - 1`` register swaps per direction, and
+  both the routing and the block writes run twice (compute + unitary
+  uncompute).
+
+The papers' headline counts (``N - 1`` lookup Toffolis for SELECT,
+``ceil(N/B) + output_bits * (B - 1)`` for QROAM) price ancilla
+uncomputation at zero via measurement-and-fixup. These primitives stay
+strictly unitary (house rules: statevector-testable, inverse-composable,
+no mid-circuit measurement), so the coherent counts above are what the
+minted kernels actually cost; the default ``block_size`` optimizes the
+coherent model (``~ sqrt(3 N / (2 output_bits))`` rather than the
+papers' ``~ sqrt(N / output_bits)``).
+
+Both variants are exactly their own inverse: the write phase is X-only,
+so the ``"select"`` walk XORs the same table twice, and the
+``"select_swap"`` sandwich ``U = W S C S^-1 W`` squares to identity
+(``W`` and ``C`` are involutions and the copy commutes with itself
+through the routing). Apply ``kernel()`` again to uncompute; the
+property is pinned by ``tests/python/test_primitives_qrom.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ._unary_iteration import (_OP_BODY_X, _OP_CCX, _OP_CCX_ADDR_ADDR,
+                               _OP_CCX_CTRL, _OP_CX_ADDR_ADDR,
+                               _OP_CX_ADDR_LADDER, _OP_CX_LADDER_LADDER,
+                               _OP_CX_LADDER_TARGET, _OP_X_ADDR,
+                               _TOFFOLI_OPCODES, _emit_walk, _mint_interpreter,
+                               _walk_toffoli_count, unary_iteration_kernels)
+
+__all__ = ["QROM"]
+
+_VARIANTS = ("auto", "select", "select_swap")
+
+# Walk opcodes whose (a, b) operands index the address register, used to
+# shift the block-index walk onto the high address bits.
+_ADDRESS_OPERANDS = {
+    _OP_X_ADDR: (0, ),
+    _OP_CX_ADDR_LADDER: (0, ),
+    _OP_CCX: (1, ),
+    _OP_CCX_CTRL: (1, ),
+    _OP_CX_ADDR_ADDR: (0, 1),
+    _OP_CCX_ADDR_ADDR: (0, 1),
+}
+
+
+def _select_swap_cost(address_bits: int, num_entries: int, output_bits: int,
+                      block_size: int) -> int:
+    """Documented Toffoli price of the select_swap variant."""
+    high_bits = address_bits - (block_size.bit_length() - 1)
+    num_blocks = -(-num_entries // block_size)
+    return (2 * _walk_toffoli_count(high_bits, num_blocks) + 2 * output_bits *
+            (block_size - 1))
+
+
+class QROM:
+    """Coherent lookup of a classical integer table (see module docstring).
+
+    Parameters
+    ----------
+    data
+        The table: non-negative integers, one per address, each fitting
+        in ``output_bits`` bits.
+    address_bits
+        Address register width (``len(data) <= 2^address_bits``).
+    output_bits
+        Output register width.
+    variant
+        ``"auto"`` (default), ``"select"`` or ``"select_swap"`` — see the
+        module docstring for the constructions and their exact prices.
+    block_size
+        SELECT-SWAP block size: a power of two in
+        ``[2, 2^(address_bits - 1)]``. Only valid with
+        ``variant="select_swap"``; ``None`` there picks the power of two
+        minimizing the documented Toffoli count.
+
+    The three views of the minted kernel may live anywhere (no contiguity
+    requirement between them), which is what lets callers weave the QROM
+    into their own ancilla layouts. Whatever the variant, the kernel is
+    exactly self-inverse — apply it again to uncompute.
+    """
+
+    def __init__(self,
+                 data: Sequence[int],
+                 address_bits: int,
+                 output_bits: int,
+                 *,
+                 variant: str = "auto",
+                 block_size: int | None = None) -> None:
+        if int(address_bits) != address_bits or address_bits < 1:
+            raise ValueError("address_bits must be a positive integer")
+        if int(output_bits) != output_bits or output_bits < 1:
+            raise ValueError("output_bits must be a positive integer")
+        address_bits = int(address_bits)
+        output_bits = int(output_bits)
+        entries = [int(v) for v in data]
+        if len(entries) == 0:
+            raise ValueError("data must be non-empty")
+        if any(int(v) != v for v in data):
+            raise ValueError("data entries must be integers")
+        if len(entries) > (1 << address_bits):
+            raise ValueError(
+                f"data has {len(entries)} entries but address_bits="
+                f"{address_bits} addresses only {1 << address_bits}")
+        if any(v < 0 for v in entries):
+            raise ValueError("data entries must be non-negative")
+        if max(entries) >= (1 << output_bits):
+            raise ValueError(
+                f"data entry {max(entries)} does not fit in output_bits="
+                f"{output_bits} bits (max representable "
+                f"{(1 << output_bits) - 1})")
+        if variant not in _VARIANTS:
+            raise ValueError(
+                f"variant must be one of {_VARIANTS}, got {variant!r}")
+        if block_size is not None:
+            if variant != "select_swap":
+                raise ValueError(
+                    "block_size is only valid with variant='select_swap', "
+                    f"got variant={variant!r}")
+            if (int(block_size) != block_size or block_size < 2
+                    or block_size & (block_size - 1) != 0):
+                raise ValueError("block_size must be a power of two >= 2, got "
+                                 f"{block_size}")
+            block_size = int(block_size)
+            if block_size > (1 << (address_bits - 1)):
+                raise ValueError(
+                    f"block_size {block_size} needs at least one block-"
+                    f"index address bit: max is 2^(address_bits - 1) = "
+                    f"{1 << (address_bits - 1)}")
+
+        select_cost = _walk_toffoli_count(address_bits, len(entries))
+        swap_candidates = [1 << s for s in range(1, address_bits)
+                           ] if block_size is None else [block_size]
+        swap_costs = {
+            size: _select_swap_cost(address_bits, len(entries), output_bits,
+                                    size)
+            for size in swap_candidates
+        }
+        if variant == "auto":
+            best_size = min(swap_costs,
+                            key=lambda size: (swap_costs[size], size),
+                            default=None)
+            if best_size is None or select_cost <= swap_costs[best_size]:
+                variant = "select"
+                block_size = None
+            else:
+                variant = "select_swap"
+                block_size = best_size
+        elif variant == "select_swap":
+            block_size = min(swap_costs,
+                             key=lambda size: (swap_costs[size], size))
+
+        self._data = tuple(entries)
+        self._num_address = address_bits
+        self._output_bits = output_bits
+        self._variant = variant
+        self._block_size = block_size
+        if variant == "select":
+            self._build_select()
+        else:
+            self._build_select_swap()
+
+    def _build_select(self) -> None:
+        entries = self._data
+        output_bits = self._output_bits
+
+        def body(k: int) -> list[tuple[str, int]]:
+            return [("x", t) for t in range(output_bits)
+                    if (entries[k] >> t) & 1]
+
+        # X-only body: the walk is an involution, skip the adjoint mint.
+        walk = unary_iteration_kernels(self._num_address,
+                                       len(entries),
+                                       body,
+                                       include_adjoint=False)
+        self._kernel = walk.kernel
+        self._num_ladder = walk.num_ladder
+        self._toffoli_count = walk.toffoli_count
+
+    def _build_select_swap(self) -> None:
+        entries = self._data
+        b = self._output_bits
+        size = self._block_size
+        low_bits = size.bit_length() - 1
+        high_bits = self._num_address - low_bits
+        num_blocks = -(-len(entries) // size)
+
+        def block_write(j: int) -> list[tuple[str, int]]:
+            gates = []
+            for i in range(size):
+                k = j * size + i
+                word = entries[k] if k < len(entries) else 0
+                gates.extend(
+                    ("x", i * b + t) for t in range(b) if (word >> t) & 1)
+            return gates
+
+        walk_ops = _emit_walk(high_bits, num_blocks, False, block_write)
+        # Rebase the walk onto the combined kernel: block-index address
+        # wires sit above the low routing bits, and the walk's "target"
+        # (the block registers) lives in the ladder view after the walk
+        # lines, so the leaf-controlled body X becomes a ladder-to-ladder
+        # CNOT.
+        ops = []
+        for op in walk_ops:
+            opcode, a, bb, c = op
+            if opcode == _OP_BODY_X:
+                ops.append((_OP_CX_LADDER_LADDER, a, high_bits + bb, 0))
+                continue
+            operands = [a, bb, c]
+            for position in _ADDRESS_OPERANDS.get(opcode, ()):
+                operands[position] += low_bits
+            ops.append((opcode, *operands))
+        walk_ops = ops
+
+        # Binary routing network: after stage s (controlled on
+        # address[s]), block slot i (i = 0 mod 2^(s+1)) holds the entry
+        # at low-address offset (i + a_s 2^s + ... + a_0); slot 0 ends
+        # holding the selected entry. Each controlled register swap is b
+        # Fredkins: cswap(c; u, v) = cx(v, u) ccx(c, u, v) cx(v, u).
+        swap_ops = []
+        for s in range(low_bits):
+            for i in range(0, size, 1 << (s + 1)):
+                for t in range(b):
+                    u = high_bits + i * b + t
+                    v = high_bits + (i + (1 << s)) * b + t
+                    swap_ops.append((_OP_CX_LADDER_LADDER, v, u, 0))
+                    swap_ops.append((_OP_CCX, u, s, v))
+                    swap_ops.append((_OP_CX_LADDER_LADDER, v, u, 0))
+        copy_ops = [(_OP_CX_LADDER_TARGET, high_bits + t, t, 0)
+                    for t in range(b)]
+
+        # W S C S^-1 W: write, route, copy, unroute, unwrite — clean
+        # ancillas and an exactly self-inverse lookup.
+        ops = (walk_ops + swap_ops + copy_ops + list(reversed(swap_ops)) +
+               walk_ops)
+        self._kernel = _mint_interpreter(ops, controlled=False, has_work=False)
+        self._num_ladder = high_bits + size * b
+        self._toffoli_count = sum(1 for op in ops if op[0] in _TOFFOLI_OPCODES)
+
+    @property
+    def data(self) -> tuple[int, ...]:
+        return self._data
+
+    @property
+    def num_address(self) -> int:
+        return self._num_address
+
+    @property
+    def num_ladder(self) -> int:
+        """Clean ancillas the kernel needs (|0> in, |0> out).
+
+        ``address_bits`` walk lines for ``"select"``; walk lines plus the
+        ``block_size * output_bits`` block registers for
+        ``"select_swap"``.
+        """
+        return self._num_ladder
+
+    @property
+    def num_output(self) -> int:
+        return self._output_bits
+
+    @property
+    def variant(self) -> str:
+        """The construction actually minted: 'select' or 'select_swap'."""
+        return self._variant
+
+    @property
+    def block_size(self) -> int | None:
+        """SELECT-SWAP block size (``None`` for the select variant)."""
+        return self._block_size
+
+    @property
+    def toffoli_count(self) -> int:
+        return self._toffoli_count
+
+    def kernel(self):
+        """The lookup kernel ``(address, ladder, output)`` — self-inverse."""
+        return self._kernel
+
+    def __repr__(self) -> str:
+        return (f"QROM(entries={len(self._data)}, "
+                f"address_bits={self.num_address}, "
+                f"output_bits={self.num_output}, "
+                f"variant={self._variant!r}, "
+                f"block_size={self._block_size}, "
+                f"toffolis={self.toffoli_count})")

--- a/python/cudaq_algorithms/primitives/_qrom.py
+++ b/python/cudaq_algorithms/primitives/_qrom.py
@@ -6,7 +6,7 @@
 ``|k>|y> -> |k>|y XOR data[k]>`` behind one kernel signature
 ``(address: qview, ladder: qview, output: qview)`` — all little-endian
 (qubit 0 = LSB, ``docs/conventions.md``), ``ladder`` being ``num_ladder``
-clean ancillas (|0> in, |0> out). Addresses ``k >= len(data)`` read as
+clean ancillas (``|0>`` in, ``|0>`` out). Addresses ``k >= len(data)`` read as
 zero. Two constructions sit behind ``variant=``:
 
 - ``"select"`` — the plain unary-iteration QROM (Babbush et al.,
@@ -295,7 +295,7 @@ class QROM:
 
     @property
     def num_ladder(self) -> int:
-        """Clean ancillas the kernel needs (|0> in, |0> out).
+        """Clean ancillas the kernel needs (``|0>`` in, ``|0>`` out).
 
         ``address_bits`` walk lines for ``"select"``; walk lines plus the
         ``block_size * output_bits`` block registers for

--- a/python/cudaq_algorithms/primitives/_qrom.py
+++ b/python/cudaq_algorithms/primitives/_qrom.py
@@ -55,6 +55,68 @@ so the ``"select"`` walk XORs the same table twice, and the
 (``W`` and ``C`` are involutions and the copy commutes with itself
 through the routing). Apply ``kernel()`` again to uncompute; the
 property is pinned by ``tests/python/test_primitives_qrom.py``.
+
+Implementation notes: register layout and the ``ladder`` view
+------------------------------------------------------------------------
+
+Every minted kernel has the same signature, ``(address, ladder,
+output)``, and ``ladder`` is simply **the clean-ancilla register** —
+its contents differ per variant, and for ``select_swap`` the name is
+looser than the physics:
+
+- ``"select"``: ``ladder`` really is the walk's ladder —
+  ``address_bits`` lines, one per tree level.
+- ``"select_swap"``: ``ladder`` bundles two conceptually different
+  things, walk lines first, block registers after::
+
+      ladder[0 .. h)                 the block-index walk's ladder lines
+                                     (h = address_bits - log2(B))
+      ladder[h + i*b .. h + (i+1)*b) block register i, i = 0 .. B-1
+                                     (the "cache line" slots)
+
+  ``num_ladder = h + B * b``. Both groups are clean (|0> in, |0> out),
+  which is why they share one register; the price is that ``ladder``
+  qubits above ``h`` are cache-line storage, not ladder lines.
+
+The address register is likewise split by convention, low bits first:
+``address[0 .. low)`` are the routing bits (low = log2(B)),
+``address[low ..)`` the block index the walk iterates. The block-index
+walk is emitted by ``_emit_walk`` as if its address register started at
+wire 0, then *rebased*: every address operand is shifted up by ``low``
+(the ``_ADDRESS_OPERANDS`` table names which operand slots to shift).
+
+**Why "ladder-to-ladder CNOTs" appear** (``_OP_CX_LADDER_LADDER``):
+the interpreter's opcodes name *registers*, not roles, so this one
+opcode serves three distinct jobs:
+
+1. In the plain walk: parent-line -> child-line CNOTs (sibling
+   crossings) — genuinely ladder-to-ladder.
+2. In the ``select_swap`` write stage: ``_emit_walk`` emits the block
+   writes as leaf-controlled body X's onto its *target* register, but
+   here the write destination is the block registers, which live in
+   the ``ladder`` view — so each ``_OP_BODY_X`` is rewritten to a
+   ladder-to-ladder CNOT from the word line onto a block-register
+   qubit (the rebase loop in ``_build_select_swap``).
+3. In the routing network: each controlled register swap is ``b``
+   Fredkins, decomposed ``cswap(c; u, v) = cx(v,u) ccx(u,c,v)
+   cx(v,u)`` — the outer CNOTs connect two block-register qubits,
+   again both inside ``ladder``. The middle Toffoli reuses the walk's
+   ``_OP_CCX`` shape with a low address bit as its second control.
+
+End-to-end, ``select_swap`` is the five-step program (with
+``h + low = address_bits``, ``B = 2^low`` entries per block):
+
+1. walk the block index (high bits) on ``ladder[0..h)``, writing each
+   visited block's ``B`` entries into the block registers;
+2. route: ``low`` rounds of Fredkins controlled on the low address
+   bits bring the selected entry's register into block slot 0;
+3. copy block slot 0 into ``output`` (plain CNOTs);
+4. un-route (the same Fredkins, reversed order);
+5. un-write (the X-only walk again — XOR is self-inverse).
+
+Steps 1/2/4/5 touch only ``address`` + ``ladder``; step 3 is the only
+place ``output`` is written, which is what makes the sandwich exactly
+self-inverse and the ancillas exactly clean.
 """
 
 from __future__ import annotations

--- a/python/cudaq_algorithms/primitives/_qrom.py
+++ b/python/cudaq_algorithms/primitives/_qrom.py
@@ -133,11 +133,14 @@ class QROM:
             raise ValueError("output_bits must be a positive integer")
         address_bits = int(address_bits)
         output_bits = int(output_bits)
-        entries = [int(v) for v in data]
-        if len(entries) == 0:
+        # Materialize first: a single-pass iterable must not be consumed
+        # by one check and leave the others looking at an empty iterator.
+        raw = list(data)
+        if len(raw) == 0:
             raise ValueError("data must be non-empty")
-        if any(int(v) != v for v in data):
+        if any(int(v) != v for v in raw):
             raise ValueError("data entries must be integers")
+        entries = [int(v) for v in raw]
         if len(entries) > (1 << address_bits):
             raise ValueError(
                 f"data has {len(entries)} entries but address_bits="
@@ -152,6 +155,11 @@ class QROM:
         if variant not in _VARIANTS:
             raise ValueError(
                 f"variant must be one of {_VARIANTS}, got {variant!r}")
+        if variant == "select_swap" and address_bits < 2:
+            raise ValueError(
+                "variant='select_swap' requires address_bits >= 2 (no "
+                "block-index bit exists at address_bits=1); use "
+                "variant='select' or 'auto'")
         if block_size is not None:
             if variant != "select_swap":
                 raise ValueError(
@@ -313,6 +321,7 @@ class QROM:
     def toffoli_count(self) -> int:
         return self._toffoli_count
 
+    @property
     def kernel(self):
         """The lookup kernel ``(address, ladder, output)`` — self-inverse."""
         return self._kernel

--- a/python/cudaq_algorithms/primitives/_qrom.py
+++ b/python/cudaq_algorithms/primitives/_qrom.py
@@ -293,7 +293,7 @@ class QROM:
         size = self._block_size
         low_bits = size.bit_length() - 1
         high_bits = self._num_address - low_bits
-        num_blocks = -(-len(entries) // size)
+        num_blocks = (len(entries) + size - 1) // size  # ceil division
 
         def block_write(j: int) -> list[tuple[str, int]]:
             gates = []
@@ -305,11 +305,18 @@ class QROM:
             return gates
 
         walk_ops = _emit_walk(high_bits, num_blocks, False, block_write)
-        # Rebase the walk onto the combined kernel: block-index address
-        # wires sit above the low routing bits, and the walk's "target"
-        # (the block registers) lives in the ladder view after the walk
-        # lines, so the leaf-controlled body X becomes a ladder-to-ladder
-        # CNOT.
+        # This IS the textbook SELECT-SWAP: a unary-iteration walk over
+        # the high (block-index) bits whose leaf action writes each
+        # block, then a low-bit-controlled swap network routes the
+        # selected entry. We reuse the walk EMITTER rather than a minted
+        # walk kernel because CUDA-Q kernels cannot call kernels: the
+        # whole lookup must be one flat tape, so the walk's instructions
+        # are rebased into the combined kernel's wire layout here.
+        # In that layout (see "select_swap register layout" in
+        # _unary_iteration's docstring) the block registers ride in the
+        # ladder VIEW after the walk lines — "ladder" names the wire
+        # bundle, not a role — so the walk's leaf-controlled block-write
+        # X lands as a CNOT between two ladder-view wires.
         ops = []
         for op in walk_ops:
             opcode, a, bb, c = op
@@ -327,6 +334,10 @@ class QROM:
         # at low-address offset (i + a_s 2^s + ... + a_0); slot 0 ends
         # holding the selected entry. Each controlled register swap is b
         # Fredkins: cswap(c; u, v) = cx(v, u) ccx(c, u, v) cx(v, u).
+        # u and v are block-register wires (which live in the ladder
+        # view — see the rebase note above), so the outer CNOTs of each
+        # Fredkin appear as _OP_CX_LADDER_LADDER: CNOTs purely between
+        # the data blocks, exactly the routing network's own gates.
         swap_ops = []
         for s in range(low_bits):
             for i in range(0, size, 1 << (s + 1)):

--- a/python/cudaq_algorithms/primitives/_unary_iteration.py
+++ b/python/cudaq_algorithms/primitives/_unary_iteration.py
@@ -213,6 +213,32 @@ _WORK_OPERANDS = {
     _OP_BODY_Z_W: (1, ),
 }
 
+# Human-readable templates for describe(); {a}/{b}/{c} are the operands.
+_OP_DESCRIPTIONS = {
+    _OP_X_ADDR: "x(address[{a}])",
+    _OP_X_LADDER: "x(ladder[{a}])",
+    _OP_CX_ADDR_LADDER: "cx(address[{a}] -> ladder[{b}])",
+    _OP_CX_LADDER_LADDER: "cx(ladder[{a}] -> ladder[{b}])",
+    _OP_CCX: "ccx(ladder[{a}], address[{b}] -> ladder[{c}])  # Toffoli",
+    _OP_BODY_X: "x(target[{b}]) ctrl ladder[{a}]",
+    _OP_BODY_Y: "y(target[{b}]) ctrl ladder[{a}]",
+    _OP_BODY_Z: "z(target[{b}]) ctrl ladder[{a}]",
+    _OP_CX_CTRL_LADDER: "cx(control[0] -> ladder[{b}])",
+    _OP_CCX_CTRL: "ccx(control[0], address[{b}] -> ladder[{c}])  # Toffoli",
+    _OP_FREE_X: "x(target[{a}])",
+    _OP_FREE_CX: "cx(target[{a}] -> target[{b}])",
+    _OP_AND_TT: "ccx(target[{a}], target[{b}] -> work[{c}])  # Toffoli",
+    _OP_AND_WT: "ccx(work[{a}], target[{b}] -> work[{c}])  # Toffoli",
+    _OP_COPY_TW: "cx(target[{a}] -> work[{b}])",
+    _OP_BODY_X_W: "x(target[{c}]) ctrl ladder[{a}], work[{b}]  # Toffoli",
+    _OP_BODY_Z_W: "z(work[{b}]) ctrl ladder[{a}]",
+    _OP_Z_LADDER: "z(ladder[{a}])",
+    _OP_CX_ADDR_ADDR: "cx(address[{a}] -> address[{b}])",
+    _OP_CCX_ADDR_ADDR:
+    "ccx(address[{a}], address[{b}] -> ladder[{c}])  # Toffoli",
+    _OP_CX_LADDER_TARGET: "cx(ladder[{a}] -> target[{b}])",
+}
+
 
 @dataclass(frozen=True)
 class UnaryIterationKernels:
@@ -243,6 +269,26 @@ class UnaryIterationKernels:
     controlled: bool
     toffoli_count: int
     num_work: int = 0
+    ops: Any = None
+
+    def describe(self) -> str:
+        """Decode the instruction tape into a human-readable gate listing.
+
+        One line per gate, in execution order — exactly what the
+        interpreter kernel replays. Lines tagged ``# Toffoli`` are the
+        gates ``toffoli_count`` counts. This is the intended way to
+        *read* a minted walk; the kernel source itself is a generic
+        interpreter and shows nothing about any particular circuit.
+        """
+        control = ", controlled" if self.controlled else ""
+        header = (f"unary-iteration walk: {self.num_items} addresses over "
+                  f"{self.num_address} bits{control}; "
+                  f"{self.toffoli_count} Toffolis")
+        lines = [
+            _OP_DESCRIPTIONS[op].format(a=a, b=b, c=c)
+            for op, a, b, c in self.ops
+        ]
+        return "\n".join([header] + lines)
 
 
 def _trailing_ones(k: int) -> int:
@@ -487,7 +533,8 @@ def unary_iteration_kernels(
                                  num_items=num_items,
                                  controlled=bool(controlled),
                                  toffoli_count=toffolis,
-                                 num_work=num_work)
+                                 num_work=num_work,
+                                 ops=tuple(ops))
 
 
 def _mint_interpreter(ops: list, controlled: bool, has_work: bool):

--- a/python/cudaq_algorithms/primitives/_unary_iteration.py
+++ b/python/cudaq_algorithms/primitives/_unary_iteration.py
@@ -2,34 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unary iteration: apply a per-address body once for each address value.
 
-``unary_iteration_kernels`` mints a flat device kernel that walks a binary
-tree over the address register (Babbush et al., `arXiv:1805.03662`,
-Fig. 7): one clean ladder ancilla per address bit carries the "this
-subtree is active" line, and the caller's body gates for address ``k``
-fire controlled on the leaf line — i.e. exactly when the address register
-equals ``k``. The walk descends once, iterates the leaves in address
-order, and retraces once; sibling transitions reuse the parent line with
-a CNOT, and deeper transitions fuse the uncompute of the old path with
-the compute of the new one through a single guard Toffoli on
-CNOT-conjugated address wires.
+Implements unary iteration (Babbush et al., arXiv:1805.03662, Fig. 7)
+without measurement-based uncomputation of the temporary logical ANDs —
+this corresponds to the strictly unitary select(V) walk of Childs et
+al., arXiv:1711.10980, Appendix G.4 (Lemma G.7): a binary-tree walk with
+one clean ladder ancilla per address bit, whose sibling and deeper
+transitions are fused into in-place rewrites of the active line. The
+caller's body gates for address ``k`` fire controlled on the leaf line,
+exactly when the address register equals ``k``, so the minted kernel
+implements ``sum_k |k><k| (x) U_k``.
 
-Toffoli cost (unitary-uncompute accounting — see below): a full tree of
-``N = 2^num_address_bits`` addresses costs exactly ``3 N / 2 - 5``
-Toffolis uncontrolled (``N >= 8``; 2 at ``N = 4``, 0 at ``N = 2``) and
-``3 N / 2 - 1`` controlled. Partial trees (``num_items < N``) cost less;
-the emitter reports the exact number as ``toffoli_count``. The paper's
-headline count for unary iteration is ``N - 1`` Toffolis, but that
-figure prices the AND-ancilla *uncomputation* at zero via
-measurement-and-fixup. This library keeps every primitive strictly
-unitary (statevector-testable, inverse-composable, no mid-circuit
-measurement), and with unitary uncomputation the fused walk's
-``3 N / 2 + O(1)`` is the best we found: an exhaustive search over
-CNOT/Toffoli circuits (arbitrary CNOT-conjugated controls, dirty address
-wires, extra ancillas) proves 2 Toffolis minimal for the controlled
-two-address walk, 5 for the controlled four-address walk and 2 for the
-uncontrolled four-address walk — all matched by this construction, and
-all above the measurement-assisted ``N - 1``. The naive
-compute/uncompute walk costs ``2 N - 4``.
+Toffoli cost: exactly ``3 N / 2 - 5`` uncontrolled for a full tree of
+``N = 2^num_address_bits`` addresses (``N >= 8``; 2 at ``N = 4``, 0 at
+``N = 2``) and ``3 N / 2 - 1`` controlled; partial trees
+(``num_items < N``) cost less, and the emitter reports the exact number
+as ``toffoli_count``. Babbush et al. reach ``N - 1`` Toffolis by pricing
+the AND uncomputation at zero via measurement-and-fixup (Gidney,
+arXiv:1709.06648); this library keeps every primitive strictly unitary
+(statevector-testable, inverse-composable, ``cudaq.control``-safe), and
+under that constraint the fused walk is the standard construction. The
+naive compute/uncompute walk costs ``2 N - 4``.
 
 T-count caveat (so the comparison stays honest under either metric):
 roughly a third of this walk's Toffolis are the fused ones, whose
@@ -37,8 +29,8 @@ target is a *dirty* ladder line and therefore cost the generic 7 T,
 while a compute-from-``|0>`` AND costs 4 T (Gidney, arXiv:1709.06648).
 In T gates the fused walk is therefore ~7.5 N against the naive
 unitary walk's ~8 N — a ~6% advantage, not the 25% the Toffoli count
-suggests. Both numbers beat nothing measured: the literature's
-measured walk is 4 N T.
+suggests. Both numbers beat nothing measured: the measured walk of
+Babbush et al. is 4 N T.
 
 The callback pattern (READ THIS — it is the template for QROM and for
 factory-composed SELECTs)
@@ -417,6 +409,39 @@ def _emit_walk(num_address_bits: int, num_items: int, controlled: bool,
         else:
             emit(_OP_X_LADDER, 0)
 
+    def sibling_flip(level: int) -> None:
+        """Move the level line to its sibling: left XOR right = parent.
+
+        Exactly one of the two sibling indicators is active given the
+        parent, so one CNOT from the parent line retargets the child
+        line in place. ``level == n`` is the leaf/word-line transition
+        between even and odd addresses; ``level == 1`` has no parent
+        line and degenerates to ``root_flip``.
+        """
+        if level == 1:
+            root_flip()
+        else:
+            emit(_OP_CX_LADDER_LADDER, level - 2, level - 1)
+
+    def unguarded_root_crossing() -> None:
+        """Rewrite levels 1-3 across an uncontrolled root, Toffoli-free
+        at levels 1-2.
+
+        With no guard line above the root, the fused differences at
+        levels 2 and 3 are (b1^b2) and (b1^b2)(b1^b3) of the top address
+        bits: level 2 moves by two free CNOTs, level 3 by one Toffoli on
+        two CNOT-conjugated address wires, and level 1 by ``root_flip``.
+        """
+        w1, w2, w3 = wire(1), wire(2), wire(3)
+        emit(_OP_CX_ADDR_ADDR, w1, w2)
+        emit(_OP_CX_ADDR_ADDR, w1, w3)
+        emit(_OP_CCX_ADDR_ADDR, w2, w3, 2)
+        emit(_OP_CX_ADDR_ADDR, w1, w3)
+        emit(_OP_CX_ADDR_ADDR, w1, w2)
+        emit(_OP_CX_ADDR_LADDER, w1, 1)
+        emit(_OP_CX_ADDR_LADDER, w2, 1)
+        root_flip()
+
     # Descent to leaf 0 (all address bits 0).
     for level in range(1, n + 1):
         set_line(level, False)
@@ -425,26 +450,11 @@ def _emit_walk(num_address_bits: int, num_items: int, controlled: bool,
     for k in range(num_items - 1):
         t = _trailing_ones(k)
         if t == 0:
-            # Sibling flip at the deepest level: left XOR right = parent.
-            if n == 1:
-                root_flip()
-            else:
-                emit(_OP_CX_LADDER_LADDER, n - 2, n - 1)
+            sibling_flip(n)
         elif n - t == 1 and not controlled and t >= 2:
-            # Unguarded root crossing: the fused differences at levels 2
-            # and 3 are (b1^b2) and (b1^b2)(b1^b3) of the top address
-            # bits — free CNOTs and one two-conjugated-wire Toffoli.
             for level in range(n, 3, -1):
                 set_line(level, True)  # unclamp against old parents
-            w1, w2, w3 = wire(1), wire(2), wire(3)
-            emit(_OP_CX_ADDR_ADDR, w1, w2)
-            emit(_OP_CX_ADDR_ADDR, w1, w3)
-            emit(_OP_CCX_ADDR_ADDR, w2, w3, 2)
-            emit(_OP_CX_ADDR_ADDR, w1, w3)
-            emit(_OP_CX_ADDR_ADDR, w1, w2)
-            emit(_OP_CX_ADDR_LADDER, w1, 1)
-            emit(_OP_CX_ADDR_LADDER, w2, 1)
-            root_flip()
+            unguarded_root_crossing()
             for level in range(4, n + 1):
                 set_line(level, False)  # reclamp against new parents
         else:
@@ -463,11 +473,7 @@ def _emit_walk(num_address_bits: int, num_items: int, controlled: bool,
                 else:
                     emit(_OP_CCX, d - 2, wd1, d)
                 emit(_OP_CX_ADDR_ADDR, wd, wd1)
-            # Flip level d to the sibling subtree.
-            if d == 1:
-                root_flip()
-            else:
-                emit(_OP_CX_LADDER_LADDER, d - 2, d - 1)
+            sibling_flip(d)
             for level in range(d + 2, n + 1):
                 set_line(level, False)  # reclamp against new parents
         emit_body(n - 1, k + 1)
@@ -498,9 +504,16 @@ def unary_iteration_kernels(
         2^num_address_bits``); addresses ``k >= num_items`` are never
         entered and the walk acts as the identity on them.
     body
-        Factory-time callback ``k -> sequence of (gate, target)`` (see
-        the module docstring). Called exactly once per address, in
-        address order, during this factory call.
+        The payload table of the SELECT: a factory-time callback mapping
+        each address ``k`` to the gate list ``U_k`` that the walk applies
+        when the address register holds ``k`` — i.e. the minted kernel
+        implements ``sum_k |k><k| (x) U_k``. Each entry is an opcode
+        tuple such as ``("x", t)`` / ``("y", t)`` / ``("z", t)``
+        (leaf-controlled Pauli on ``target[t]``) or one of the extended
+        gates in the module docstring; an empty list means ``U_k = I``.
+        Called exactly once per address, in address order, during this
+        factory call — the gates are baked into the kernel, so ``body``
+        itself never runs at circuit time.
     controlled
         Mint the externally controlled walk (leading one-qubit view).
     include_adjoint

--- a/python/cudaq_algorithms/primitives/_unary_iteration.py
+++ b/python/cudaq_algorithms/primitives/_unary_iteration.py
@@ -552,6 +552,32 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
         # (cuda-quantum#4847): pad with one never-dispatched entry.
         opcodes, ops_a, ops_b, ops_c = [-1], [0], [0], [0]
 
+    # Kernel-visible opcode names: kernel code cannot reference Python
+    # enums or module globals, but it does capture enclosing-scope ints,
+    # so the module's _OP_* constants are bound as locals here to keep
+    # the dispatch below readable.
+    op_x_addr = _OP_X_ADDR
+    op_x_ladder = _OP_X_LADDER
+    op_cx_addr_ladder = _OP_CX_ADDR_LADDER
+    op_cx_ladder_ladder = _OP_CX_LADDER_LADDER
+    op_ccx = _OP_CCX
+    op_body_x = _OP_BODY_X
+    op_body_y = _OP_BODY_Y
+    op_body_z = _OP_BODY_Z
+    op_cx_ctrl_ladder = _OP_CX_CTRL_LADDER
+    op_ccx_ctrl = _OP_CCX_CTRL
+    op_free_x = _OP_FREE_X
+    op_free_cx = _OP_FREE_CX
+    op_and_tt = _OP_AND_TT
+    op_and_wt = _OP_AND_WT
+    op_copy_tw = _OP_COPY_TW
+    op_body_x_w = _OP_BODY_X_W
+    op_body_z_w = _OP_BODY_Z_W
+    op_z_ladder = _OP_Z_LADDER
+    op_cx_addr_addr = _OP_CX_ADDR_ADDR
+    op_ccx_addr_addr = _OP_CCX_ADDR_ADDR
+    op_cx_ladder_target = _OP_CX_LADDER_TARGET
+
     if controlled and has_work:
 
         @cudaq.kernel
@@ -565,47 +591,47 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
                 a = ops_a[i]
                 b = ops_b[i]
                 c = ops_c[i]
-                if op == 0:
+                if op == op_x_addr:
                     x(address[a])
-                if op == 1:
+                if op == op_x_ladder:
                     x(ladder[a])
-                if op == 2:
+                if op == op_cx_addr_ladder:
                     cx(address[a], ladder[b])
-                if op == 3:
+                if op == op_cx_ladder_ladder:
                     cx(ladder[a], ladder[b])
-                if op == 4:
+                if op == op_ccx:
                     x.ctrl(ladder[a], address[b], ladder[c])
-                if op == 5:
+                if op == op_body_x:
                     x.ctrl(ladder[a], target[b])
-                if op == 6:
+                if op == op_body_y:
                     y.ctrl(ladder[a], target[b])
-                if op == 7:
+                if op == op_body_z:
                     z.ctrl(ladder[a], target[b])
-                if op == 8:
+                if op == op_cx_ctrl_ladder:
                     cx(control[0], ladder[b])
-                if op == 9:
+                if op == op_ccx_ctrl:
                     x.ctrl(control[0], address[b], ladder[c])
-                if op == 10:
+                if op == op_free_x:
                     x(target[a])
-                if op == 11:
+                if op == op_free_cx:
                     cx(target[a], target[b])
-                if op == 12:
+                if op == op_and_tt:
                     x.ctrl(target[a], target[b], work[c])
-                if op == 13:
+                if op == op_and_wt:
                     x.ctrl(work[a], target[b], work[c])
-                if op == 14:
+                if op == op_copy_tw:
                     cx(target[a], work[b])
-                if op == 15:
+                if op == op_body_x_w:
                     x.ctrl(ladder[a], work[b], target[c])
-                if op == 16:
+                if op == op_body_z_w:
                     z.ctrl(ladder[a], work[b])
-                if op == 17:
+                if op == op_z_ladder:
                     z(ladder[a])
-                if op == 18:
+                if op == op_cx_addr_addr:
                     cx(address[a], address[b])
-                if op == 19:
+                if op == op_ccx_addr_addr:
                     x.ctrl(address[a], address[b], ladder[c])
-                if op == 20:
+                if op == op_cx_ladder_target:
                     cx(ladder[a], target[b])
 
         _retain(primitives_unary_walk_work_ctrl)
@@ -622,43 +648,43 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
                 a = ops_a[i]
                 b = ops_b[i]
                 c = ops_c[i]
-                if op == 0:
+                if op == op_x_addr:
                     x(address[a])
-                if op == 1:
+                if op == op_x_ladder:
                     x(ladder[a])
-                if op == 2:
+                if op == op_cx_addr_ladder:
                     cx(address[a], ladder[b])
-                if op == 3:
+                if op == op_cx_ladder_ladder:
                     cx(ladder[a], ladder[b])
-                if op == 4:
+                if op == op_ccx:
                     x.ctrl(ladder[a], address[b], ladder[c])
-                if op == 5:
+                if op == op_body_x:
                     x.ctrl(ladder[a], target[b])
-                if op == 6:
+                if op == op_body_y:
                     y.ctrl(ladder[a], target[b])
-                if op == 7:
+                if op == op_body_z:
                     z.ctrl(ladder[a], target[b])
-                if op == 10:
+                if op == op_free_x:
                     x(target[a])
-                if op == 11:
+                if op == op_free_cx:
                     cx(target[a], target[b])
-                if op == 12:
+                if op == op_and_tt:
                     x.ctrl(target[a], target[b], work[c])
-                if op == 13:
+                if op == op_and_wt:
                     x.ctrl(work[a], target[b], work[c])
-                if op == 14:
+                if op == op_copy_tw:
                     cx(target[a], work[b])
-                if op == 15:
+                if op == op_body_x_w:
                     x.ctrl(ladder[a], work[b], target[c])
-                if op == 16:
+                if op == op_body_z_w:
                     z.ctrl(ladder[a], work[b])
-                if op == 17:
+                if op == op_z_ladder:
                     z(ladder[a])
-                if op == 18:
+                if op == op_cx_addr_addr:
                     cx(address[a], address[b])
-                if op == 19:
+                if op == op_ccx_addr_addr:
                     x.ctrl(address[a], address[b], ladder[c])
-                if op == 20:
+                if op == op_cx_ladder_target:
                     cx(ladder[a], target[b])
 
         _retain(primitives_unary_walk_work)
@@ -676,37 +702,37 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
                 a = ops_a[i]
                 b = ops_b[i]
                 c = ops_c[i]
-                if op == 0:
+                if op == op_x_addr:
                     x(address[a])
-                if op == 1:
+                if op == op_x_ladder:
                     x(ladder[a])
-                if op == 2:
+                if op == op_cx_addr_ladder:
                     cx(address[a], ladder[b])
-                if op == 3:
+                if op == op_cx_ladder_ladder:
                     cx(ladder[a], ladder[b])
-                if op == 4:
+                if op == op_ccx:
                     x.ctrl(ladder[a], address[b], ladder[c])
-                if op == 5:
+                if op == op_body_x:
                     x.ctrl(ladder[a], target[b])
-                if op == 6:
+                if op == op_body_y:
                     y.ctrl(ladder[a], target[b])
-                if op == 7:
+                if op == op_body_z:
                     z.ctrl(ladder[a], target[b])
-                if op == 8:
+                if op == op_cx_ctrl_ladder:
                     cx(control[0], ladder[b])
-                if op == 9:
+                if op == op_ccx_ctrl:
                     x.ctrl(control[0], address[b], ladder[c])
-                if op == 10:
+                if op == op_free_x:
                     x(target[a])
-                if op == 11:
+                if op == op_free_cx:
                     cx(target[a], target[b])
-                if op == 17:
+                if op == op_z_ladder:
                     z(ladder[a])
-                if op == 18:
+                if op == op_cx_addr_addr:
                     cx(address[a], address[b])
-                if op == 19:
+                if op == op_ccx_addr_addr:
                     x.ctrl(address[a], address[b], ladder[c])
-                if op == 20:
+                if op == op_cx_ladder_target:
                     cx(ladder[a], target[b])
 
         _retain(primitives_unary_walk_ctrl)
@@ -720,33 +746,33 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
             a = ops_a[i]
             b = ops_b[i]
             c = ops_c[i]
-            if op == 0:
+            if op == op_x_addr:
                 x(address[a])
-            if op == 1:
+            if op == op_x_ladder:
                 x(ladder[a])
-            if op == 2:
+            if op == op_cx_addr_ladder:
                 cx(address[a], ladder[b])
-            if op == 3:
+            if op == op_cx_ladder_ladder:
                 cx(ladder[a], ladder[b])
-            if op == 4:
+            if op == op_ccx:
                 x.ctrl(ladder[a], address[b], ladder[c])
-            if op == 5:
+            if op == op_body_x:
                 x.ctrl(ladder[a], target[b])
-            if op == 6:
+            if op == op_body_y:
                 y.ctrl(ladder[a], target[b])
-            if op == 7:
+            if op == op_body_z:
                 z.ctrl(ladder[a], target[b])
-            if op == 10:
+            if op == op_free_x:
                 x(target[a])
-            if op == 11:
+            if op == op_free_cx:
                 cx(target[a], target[b])
-            if op == 17:
+            if op == op_z_ladder:
                 z(ladder[a])
-            if op == 18:
+            if op == op_cx_addr_addr:
                 cx(address[a], address[b])
-            if op == 19:
+            if op == op_ccx_addr_addr:
                 x.ctrl(address[a], address[b], ladder[c])
-            if op == 20:
+            if op == op_cx_ladder_target:
                 cx(ladder[a], target[b])
 
     _retain(primitives_unary_walk)

--- a/python/cudaq_algorithms/primitives/_unary_iteration.py
+++ b/python/cudaq_algorithms/primitives/_unary_iteration.py
@@ -1,0 +1,697 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unary iteration: apply a per-address body once for each address value.
+
+``unary_iteration_kernels`` mints a flat device kernel that walks a binary
+tree over the address register (Babbush et al., `arXiv:1805.03662`,
+Fig. 7): one clean ladder ancilla per address bit carries the "this
+subtree is active" line, and the caller's body gates for address ``k``
+fire controlled on the leaf line — i.e. exactly when the address register
+equals ``k``. The walk descends once, iterates the leaves in address
+order, and retraces once; sibling transitions reuse the parent line with
+a CNOT, and deeper transitions fuse the uncompute of the old path with
+the compute of the new one through a single guard Toffoli on
+CNOT-conjugated address wires.
+
+Toffoli cost (unitary-uncompute accounting — see below): a full tree of
+``N = 2^num_address_bits`` addresses costs exactly ``3 N / 2 - 5``
+Toffolis uncontrolled (``N >= 8``; 2 at ``N = 4``, 0 at ``N = 2``) and
+``3 N / 2 - 1`` controlled. Partial trees (``num_items < N``) cost less;
+the emitter reports the exact number as ``toffoli_count``. The paper's
+headline count for unary iteration is ``N - 1`` Toffolis, but that
+figure prices the AND-ancilla *uncomputation* at zero via
+measurement-and-fixup. This library keeps every primitive strictly
+unitary (statevector-testable, inverse-composable, no mid-circuit
+measurement), and with unitary uncomputation the fused walk's
+``3 N / 2 + O(1)`` is the best we found: an exhaustive search over
+CNOT/Toffoli circuits (arbitrary CNOT-conjugated controls, dirty address
+wires, extra ancillas) proves 2 Toffolis minimal for the controlled
+two-address walk, 5 for the controlled four-address walk and 2 for the
+uncontrolled four-address walk — all matched by this construction, and
+all above the measurement-assisted ``N - 1``. The naive
+compute/uncompute walk costs ``2 N - 4``.
+
+The callback pattern (READ THIS — it is the template for QROM and for
+factory-composed SELECTs)
+------------------------------------------------------------------------
+
+CUDA-Q kernels are compiled from fixed Python source, so a callback can
+never execute *inside* a kernel. The callback therefore runs at **factory
+time**: ``body(k)`` is called once per address on the host and must return
+the gate list for that address as data. The emitter flattens the whole
+tree walk (ladder gadgets + body gates) into parallel opcode/operand
+integer lists, and the minted kernel is a single flat interpreter loop
+over those captured lists. Flatness is load-bearing: CUDA-Q's
+control-variant generation rejects kernels that call other kernels, so
+anything built this way stays ``cudaq.control``-compatible and can sit
+inside a controlled SELECT.
+
+Body instruction set. Each item is a tuple whose head names the gate;
+``target``/``work`` operands index the target/work registers. The three
+original gates are implicitly controlled on the address-``k`` leaf line:
+
+- ``("x", t)`` / ``("y", t)`` / ``("z", t)`` — leaf-controlled Pauli on
+  ``target[t]``.
+
+The extended vocabulary (for SELECTs whose term unitaries are
+multi-controlled bit flips and phases) has two families. *Free* gates
+carry **no** leaf control and execute for every address — they are only
+sound as conjugation pairs closed inside the same body (pre-ops,
+leaf-controlled core, reversed pre-ops), where they cancel exactly on
+inactive addresses:
+
+- ``("free_x", t)`` — ``x(target[t])``;
+- ``("free_cx", a, b)`` — ``cx(target[a], target[b])``;
+- ``("and_tt", a, b, w)`` — Toffoli ``target[a], target[b] -> work[w]``;
+- ``("and_wt", v, t, w)`` — Toffoli ``work[v], target[t] -> work[w]``;
+- ``("copy_tw", t, w)`` — ``cx(target[t], work[w])``.
+
+Leaf-referencing core gates:
+
+- ``("x_w", w, t)`` — ``x.ctrl(leaf, work[w], target[t])``;
+- ``("z_w", w)`` — ``z.ctrl(leaf, work[w])``;
+- ``("sign",)`` — ``z(leaf)``: a ``-1`` phase exactly on the
+  address-``k`` branch (term-sign carrier).
+
+Any body that uses ``work`` operands makes the minted kernels take a
+trailing ``work: qview`` (clean, |0> in / |0> out — each body must
+uncompute its own work usage); ``num_work`` on the result records the
+required width (0 means no work view in the signature).
+
+Kernel signatures (all registers little-endian, qubit 0 = LSB, per
+``docs/conventions.md``):
+
+- ``kernel(address: qview, ladder: qview, target: qview[, work: qview])``
+  — walk with the body applied at each active address (the ``work`` view
+  appears only when ``num_work > 0``).
+- with ``controlled=True``: the same signatures with a leading
+  ``control: qview``, a one-qubit view rooting the tree — the whole walk
+  acts as the identity when the control is |0>. (A separate one-qubit
+  view, not a leading qubit of a combined register, so callers never mix
+  a qview with a bare qubit in one control set. Free body gates still
+  execute at control |0>, but their conjugation pairing cancels them.)
+
+``kernel_adj`` is the hand-written inverse (``cudaq.adjoint`` is
+off-limits, cuda-quantum#4897/#4898): every emitted gate is self-inverse
+(X/CX/CCX and controlled Paulis), so the inverse is the same interpreter
+over the reversed instruction list. When the body gates at every address
+mutually commute and square to identity (e.g. the X-only QROM write), the
+walk itself is an involution and ``include_adjoint=False`` skips minting
+the redundant inverse.
+
+The walk circuit
+----------------
+
+Level ``r`` (1-based, from the root) examines address bit
+``address[num_address_bits - r]`` (level 1 = MSB) and owns ladder line
+``ladder[r - 1]``; the invariant at leaf ``k`` is that ``ladder[r - 1]``
+holds the indicator "top ``r`` address bits equal those of ``k``" (AND
+the external control, if any), so the leaf/body line is always
+``ladder[num_address_bits - 1]``. The transition from leaf ``k`` to
+``k + 1`` (with ``t`` trailing ones in ``k``, flip level ``d = n - t``):
+
+- ``t = 0``: one CNOT from the parent line onto the leaf line — exactly
+  one of the two siblings is active given the parent, so their XOR is
+  the parent itself.
+- ``t >= 1``: unclamp levels ``n .. d + 2`` with Toffolis against the
+  still-old parents, XOR the fused difference
+  ``guard AND (bit_d XOR bit_{d+1})`` into level ``d + 1`` with a single
+  Toffoli on a CNOT-conjugated address wire (the old and new level-
+  ``(d+1)`` indicators are disjoint given the guard, so their XOR
+  factors), CNOT-flip level ``d``, and reclamp levels ``d + 2 .. n``
+  against the new parents: ``2 t - 1`` Toffolis. When the flip level is
+  the unguarded root, the fused difference is linear (free CNOTs) and
+  the first reclamp pair collapses into one Toffoli on two conjugated
+  address wires: ``max(2 t - 3, 0)`` Toffolis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Sequence
+
+import cudaq
+
+__all__ = ["UnaryIterationKernels", "unary_iteration_kernels"]
+
+# Keep-alive registry for factory-minted kernels. CUDA-Q identifies a
+# kernel by ``<function name>..<hex(id(decorator))>`` and retains compiled
+# modules under that key without unretaining on deallocation; when a
+# same-named factory kernel is created at a recycled ``id()`` of a dead
+# one, the stale module collides with the new kernel and compilation fails
+# with arbitrary errors. Pinning every minted kernel for the process
+# lifetime keeps the ids from recycling; the cost is a few KB per factory
+# call. The kernel names below are unique to this subpackage so they can
+# never collide with other subpackages' registries.
+_LIVE_KERNELS: list = []
+
+
+def _retain(*kernels) -> None:
+    _LIVE_KERNELS.extend(kernels)
+
+
+# Interpreter opcodes (operands a, b, c index the signature's registers).
+_OP_X_ADDR = 0  # x(address[a])
+_OP_X_LADDER = 1  # x(ladder[a])
+_OP_CX_ADDR_LADDER = 2  # cx(address[a], ladder[b])
+_OP_CX_LADDER_LADDER = 3  # cx(ladder[a], ladder[b])
+_OP_CCX = 4  # x.ctrl(ladder[a], address[b], ladder[c])
+_OP_BODY_X = 5  # x.ctrl(ladder[a], target[b])
+_OP_BODY_Y = 6  # y.ctrl(ladder[a], target[b])
+_OP_BODY_Z = 7  # z.ctrl(ladder[a], target[b])
+_OP_CX_CTRL_LADDER = 8  # cx(control[0], ladder[b])
+_OP_CCX_CTRL = 9  # x.ctrl(control[0], address[b], ladder[c])
+_OP_FREE_X = 10  # x(target[a])
+_OP_FREE_CX = 11  # cx(target[a], target[b])
+_OP_AND_TT = 12  # x.ctrl(target[a], target[b], work[c])
+_OP_AND_WT = 13  # x.ctrl(work[a], target[b], work[c])
+_OP_COPY_TW = 14  # cx(target[a], work[b])
+_OP_BODY_X_W = 15  # x.ctrl(ladder[a], work[b], target[c])
+_OP_BODY_Z_W = 16  # z.ctrl(ladder[a], work[b])
+_OP_Z_LADDER = 17  # z(ladder[a])
+_OP_CX_ADDR_ADDR = 18  # cx(address[a], address[b])
+_OP_CCX_ADDR_ADDR = 19  # x.ctrl(address[a], address[b], ladder[c])
+_OP_CX_LADDER_TARGET = 20  # cx(ladder[a], target[b])
+
+_BODY_OPCODES = {"x": _OP_BODY_X, "y": _OP_BODY_Y, "z": _OP_BODY_Z}
+
+# Extended body gates: name -> (opcode, operand kinds, leaf line slot).
+# Operand kinds: "t" = target index, "w" = work index; the leaf slot names
+# which operand position (0-based, in the emitted (a, b, c)) receives the
+# active ladder line, or None for free (uncontrolled) gates.
+_EXTENDED_BODY_GATES = {
+    "free_x": (_OP_FREE_X, ("t", ), None),
+    "free_cx": (_OP_FREE_CX, ("t", "t"), None),
+    "and_tt": (_OP_AND_TT, ("t", "t", "w"), None),
+    "and_wt": (_OP_AND_WT, ("w", "t", "w"), None),
+    "copy_tw": (_OP_COPY_TW, ("t", "w"), None),
+    "x_w": (_OP_BODY_X_W, ("w", "t"), 0),
+    "z_w": (_OP_BODY_Z_W, ("w", ), 0),
+    "sign": (_OP_Z_LADDER, (), 0),
+}
+
+_TOFFOLI_OPCODES = (_OP_CCX, _OP_CCX_CTRL, _OP_AND_TT, _OP_AND_WT,
+                    _OP_BODY_X_W, _OP_CCX_ADDR_ADDR)
+
+# Opcode -> operand positions (within (a, b, c)) that index the work
+# register, used to infer the required work width from the emitted ops.
+_WORK_OPERANDS = {
+    _OP_AND_TT: (2, ),
+    _OP_AND_WT: (0, 2),
+    _OP_COPY_TW: (1, ),
+    _OP_BODY_X_W: (1, ),
+    _OP_BODY_Z_W: (1, ),
+}
+
+
+@dataclass(frozen=True)
+class UnaryIterationKernels:
+    """The minted walk (see the module docstring for signatures).
+
+    Attributes
+    ----------
+    kernel, kernel_adj
+        The walk and its hand-written inverse (``kernel_adj`` is ``None``
+        when minted with ``include_adjoint=False``).
+    num_address, num_ladder, num_items
+        Register widths (``num_ladder == num_address`` clean ancillas)
+        and the number of iterated addresses.
+    controlled
+        Whether ``kernel`` takes the leading one-qubit control view.
+    num_work
+        Width of the trailing clean ``work`` view (0: no work view in the
+        signature).
+    toffoli_count
+        Toffolis in one application (cost accounting).
+    """
+
+    kernel: Any
+    kernel_adj: Any
+    num_address: int
+    num_ladder: int
+    num_items: int
+    controlled: bool
+    toffoli_count: int
+    num_work: int = 0
+
+
+def _trailing_ones(k: int) -> int:
+    t = 0
+    while k & 1:
+        t += 1
+        k >>= 1
+    return t
+
+
+def _walk_toffoli_count(num_address_bits: int,
+                        num_items: int,
+                        controlled: bool = False) -> int:
+    """Exact Toffoli count of the fused walk, without emitting it.
+
+    Cross-checked against the emitted instruction stream by the resource
+    tests; used by ``QROM`` to price variants before minting anything.
+    """
+    n = num_address_bits
+    extra = 1 if controlled else 0
+    total = 2 * (n - 1 + extra)  # descent + unwind
+    for k in range(num_items - 1):
+        t = _trailing_ones(k)
+        if t == 0:
+            continue
+        if n - t == 1 and not controlled:  # unguarded root crossing
+            total += max(2 * t - 3, 0)
+        else:
+            total += 2 * t - 1
+    return total
+
+
+def _emit_walk(num_address_bits: int, num_items: int, controlled: bool,
+               body: Callable[[int], Sequence[tuple[str, int]]]) -> list:
+    """Flatten the fused tree walk into (opcode, a, b, c) instructions."""
+    n = num_address_bits
+    ops: list[tuple[int, int, int, int]] = []
+
+    def emit(opcode: int, a: int = 0, b: int = 0, c: int = 0) -> None:
+        ops.append((opcode, a, b, c))
+
+    def emit_body(line: int, k: int) -> None:
+        for item in body(k):
+            gate = item[0]
+            operands = item[1:]
+            if gate in _BODY_OPCODES:
+                if len(operands) != 1:
+                    raise ValueError(f"body({k}) returned {gate!r} with "
+                                     f"{len(operands)} operands (expected 1)")
+                target = operands[0]
+                if int(target) != target or target < 0:
+                    raise ValueError(f"body({k}) returned an invalid target "
+                                     f"qubit index {target!r}")
+                emit(_BODY_OPCODES[gate], line, int(target))
+            elif gate in _EXTENDED_BODY_GATES:
+                opcode, kinds, leaf_slot = _EXTENDED_BODY_GATES[gate]
+                if len(operands) != len(kinds):
+                    raise ValueError(
+                        f"body({k}) returned {gate!r} with {len(operands)} "
+                        f"operands (expected {len(kinds)})")
+                slots = [0, 0, 0]
+                cursor = 0
+                if leaf_slot is not None:
+                    slots[leaf_slot] = line
+                    cursor = leaf_slot + 1
+                for kind, operand in zip(kinds, operands):
+                    if int(operand) != operand or operand < 0:
+                        name = "target" if kind == "t" else "work"
+                        raise ValueError(
+                            f"body({k}) returned an invalid {name} "
+                            f"qubit index {operand!r}")
+                    slots[cursor] = int(operand)
+                    cursor += 1
+                emit(opcode, slots[0], slots[1], slots[2])
+            else:
+                raise ValueError(
+                    f"body({k}) returned unsupported gate {gate!r}: the "
+                    "unary-iteration body instruction set is 'x', 'y', 'z' "
+                    "plus the extended gates documented in "
+                    "cudaq_algorithms.primitives._unary_iteration")
+
+    def wire(level: int) -> int:
+        """Address wire examined at 1-based tree level ``level``."""
+        return n - level
+
+    def set_line(level: int, bit_is_one: bool) -> None:
+        """ladder[level-1] ^= parent AND (address bit == value).
+
+        Self-inverse: emitted both to compute a line (from |0>) and to
+        clear it (against the same parent value); the descent, the
+        unclamp/reclamp halves of deep transitions and the final unwind
+        are all built from this one gadget.
+        """
+        a = wire(level)
+        if not bit_is_one:
+            emit(_OP_X_ADDR, a)
+        if level == 1:
+            if controlled:
+                emit(_OP_CCX_CTRL, 0, a, 0)
+            else:
+                emit(_OP_CX_ADDR_LADDER, a, 0)
+        else:
+            emit(_OP_CCX, level - 2, a, level - 1)
+        if not bit_is_one:
+            emit(_OP_X_ADDR, a)
+
+    def root_flip() -> None:
+        """Flip the level-1 line between the two root siblings."""
+        if controlled:
+            emit(_OP_CX_CTRL_LADDER, 0, 0)
+        else:
+            emit(_OP_X_LADDER, 0)
+
+    # Descent to leaf 0 (all address bits 0).
+    for level in range(1, n + 1):
+        set_line(level, False)
+    emit_body(n - 1, 0)
+
+    for k in range(num_items - 1):
+        t = _trailing_ones(k)
+        if t == 0:
+            # Sibling flip at the deepest level: left XOR right = parent.
+            if n == 1:
+                root_flip()
+            else:
+                emit(_OP_CX_LADDER_LADDER, n - 2, n - 1)
+        elif n - t == 1 and not controlled and t >= 2:
+            # Unguarded root crossing: the fused differences at levels 2
+            # and 3 are (b1^b2) and (b1^b2)(b1^b3) of the top address
+            # bits — free CNOTs and one two-conjugated-wire Toffoli.
+            for level in range(n, 3, -1):
+                set_line(level, True)  # unclamp against old parents
+            w1, w2, w3 = wire(1), wire(2), wire(3)
+            emit(_OP_CX_ADDR_ADDR, w1, w2)
+            emit(_OP_CX_ADDR_ADDR, w1, w3)
+            emit(_OP_CCX_ADDR_ADDR, w2, w3, 2)
+            emit(_OP_CX_ADDR_ADDR, w1, w3)
+            emit(_OP_CX_ADDR_ADDR, w1, w2)
+            emit(_OP_CX_ADDR_LADDER, w1, 1)
+            emit(_OP_CX_ADDR_LADDER, w2, 1)
+            root_flip()
+            for level in range(4, n + 1):
+                set_line(level, False)  # reclamp against new parents
+        else:
+            d = n - t  # flip level
+            for level in range(n, d + 1, -1):
+                set_line(level, True)  # unclamp against old parents
+            # Fused level d+1: XOR in guard AND (bit_d ^ bit_{d+1}).
+            wd, wd1 = wire(d), wire(d + 1)
+            if d == 1 and not controlled:
+                emit(_OP_CX_ADDR_LADDER, wd, d)
+                emit(_OP_CX_ADDR_LADDER, wd1, d)
+            else:
+                emit(_OP_CX_ADDR_ADDR, wd, wd1)
+                if d == 1:
+                    emit(_OP_CCX_CTRL, 0, wd1, d)
+                else:
+                    emit(_OP_CCX, d - 2, wd1, d)
+                emit(_OP_CX_ADDR_ADDR, wd, wd1)
+            # Flip level d to the sibling subtree.
+            if d == 1:
+                root_flip()
+            else:
+                emit(_OP_CX_LADDER_LADDER, d - 2, d - 1)
+            for level in range(d + 2, n + 1):
+                set_line(level, False)  # reclamp against new parents
+        emit_body(n - 1, k + 1)
+
+    # Unwind from the last visited leaf.
+    last = num_items - 1
+    for level in range(n, 0, -1):
+        set_line(level, ((last >> wire(level)) & 1) == 1)
+    return ops
+
+
+def unary_iteration_kernels(
+        num_address_bits: int,
+        num_items: int,
+        body: Callable[[int], Sequence[tuple]],
+        *,
+        controlled: bool = False,
+        include_adjoint: bool = True,
+        num_work: int | None = None) -> UnaryIterationKernels:
+    """Mint the unary-iteration walk for a factory-time body callback.
+
+    Parameters
+    ----------
+    num_address_bits
+        Address register width (>= 1).
+    num_items
+        Number of iterated addresses (``1 <= num_items <=
+        2^num_address_bits``); addresses ``k >= num_items`` are never
+        entered and the walk acts as the identity on them.
+    body
+        Factory-time callback ``k -> sequence of (gate, target)`` (see
+        the module docstring). Called exactly once per address, in
+        address order, during this factory call.
+    controlled
+        Mint the externally controlled walk (leading one-qubit view).
+    include_adjoint
+        Mint ``kernel_adj``; pass ``False`` when the walk is known to be
+        an involution (commuting self-inverse body, e.g. X-only QROM).
+    num_work
+        Width of the trailing clean ``work`` view. ``None`` (default)
+        infers the width from the body's work usage (0 keeps the original
+        work-less signatures); an explicit value must cover that usage
+        and forces the work view into the signature even when unused.
+    """
+    if int(num_address_bits) != num_address_bits or num_address_bits < 1:
+        raise ValueError("num_address_bits must be a positive integer")
+    num_address_bits = int(num_address_bits)
+    capacity = 1 << num_address_bits
+    if int(num_items) != num_items or not 1 <= num_items <= capacity:
+        raise ValueError(
+            f"num_items must be an integer in [1, 2^num_address_bits = "
+            f"{capacity}], got {num_items}")
+    num_items = int(num_items)
+
+    ops = _emit_walk(num_address_bits, num_items, bool(controlled), body)
+    required_work = 0
+    for op in ops:
+        for position in _WORK_OPERANDS.get(op[0], ()):
+            required_work = max(required_work, op[1 + position] + 1)
+    if num_work is None:
+        num_work = required_work
+    if int(num_work) != num_work or num_work < required_work:
+        raise ValueError(
+            f"num_work must be an integer >= the body's work usage "
+            f"({required_work}), got {num_work}")
+    num_work = int(num_work)
+
+    toffolis = sum(1 for op in ops if op[0] in _TOFFOLI_OPCODES)
+    kernel = _mint_interpreter(ops, bool(controlled), num_work > 0)
+    kernel_adj = None
+    if include_adjoint:
+        kernel_adj = _mint_interpreter(list(reversed(ops)), bool(controlled),
+                                       num_work > 0)
+    return UnaryIterationKernels(kernel=kernel,
+                                 kernel_adj=kernel_adj,
+                                 num_address=num_address_bits,
+                                 num_ladder=num_address_bits,
+                                 num_items=num_items,
+                                 controlled=bool(controlled),
+                                 toffoli_count=toffolis,
+                                 num_work=num_work)
+
+
+def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
+    """Mint the flat interpreter kernel over a flattened instruction list.
+
+    Every emitted gate is self-inverse, so the inverse walk is this same
+    interpreter over the reversed list — how ``kernel_adj`` is minted.
+    """
+    num_ops = len(ops)
+    opcodes = [op[0] for op in ops]
+    ops_a = [op[1] for op in ops]
+    ops_b = [op[2] for op in ops]
+    ops_c = [op[3] for op in ops]
+    if num_ops == 0:
+        # An empty list must never cross the kernel boundary
+        # (cuda-quantum#4847): pad with one never-dispatched entry.
+        opcodes, ops_a, ops_b, ops_c = [-1], [0], [0], [0]
+
+    if controlled and has_work:
+
+        @cudaq.kernel
+        def primitives_unary_walk_work_ctrl(control: cudaq.qview,
+                                            address: cudaq.qview,
+                                            ladder: cudaq.qview,
+                                            target: cudaq.qview,
+                                            work: cudaq.qview):
+            for i in range(num_ops):
+                op = opcodes[i]
+                a = ops_a[i]
+                b = ops_b[i]
+                c = ops_c[i]
+                if op == 0:
+                    x(address[a])
+                if op == 1:
+                    x(ladder[a])
+                if op == 2:
+                    cx(address[a], ladder[b])
+                if op == 3:
+                    cx(ladder[a], ladder[b])
+                if op == 4:
+                    x.ctrl(ladder[a], address[b], ladder[c])
+                if op == 5:
+                    x.ctrl(ladder[a], target[b])
+                if op == 6:
+                    y.ctrl(ladder[a], target[b])
+                if op == 7:
+                    z.ctrl(ladder[a], target[b])
+                if op == 8:
+                    cx(control[0], ladder[b])
+                if op == 9:
+                    x.ctrl(control[0], address[b], ladder[c])
+                if op == 10:
+                    x(target[a])
+                if op == 11:
+                    cx(target[a], target[b])
+                if op == 12:
+                    x.ctrl(target[a], target[b], work[c])
+                if op == 13:
+                    x.ctrl(work[a], target[b], work[c])
+                if op == 14:
+                    cx(target[a], work[b])
+                if op == 15:
+                    x.ctrl(ladder[a], work[b], target[c])
+                if op == 16:
+                    z.ctrl(ladder[a], work[b])
+                if op == 17:
+                    z(ladder[a])
+                if op == 18:
+                    cx(address[a], address[b])
+                if op == 19:
+                    x.ctrl(address[a], address[b], ladder[c])
+                if op == 20:
+                    cx(ladder[a], target[b])
+
+        _retain(primitives_unary_walk_work_ctrl)
+        return primitives_unary_walk_work_ctrl
+
+    if has_work:
+
+        @cudaq.kernel
+        def primitives_unary_walk_work(address: cudaq.qview,
+                                       ladder: cudaq.qview,
+                                       target: cudaq.qview, work: cudaq.qview):
+            for i in range(num_ops):
+                op = opcodes[i]
+                a = ops_a[i]
+                b = ops_b[i]
+                c = ops_c[i]
+                if op == 0:
+                    x(address[a])
+                if op == 1:
+                    x(ladder[a])
+                if op == 2:
+                    cx(address[a], ladder[b])
+                if op == 3:
+                    cx(ladder[a], ladder[b])
+                if op == 4:
+                    x.ctrl(ladder[a], address[b], ladder[c])
+                if op == 5:
+                    x.ctrl(ladder[a], target[b])
+                if op == 6:
+                    y.ctrl(ladder[a], target[b])
+                if op == 7:
+                    z.ctrl(ladder[a], target[b])
+                if op == 10:
+                    x(target[a])
+                if op == 11:
+                    cx(target[a], target[b])
+                if op == 12:
+                    x.ctrl(target[a], target[b], work[c])
+                if op == 13:
+                    x.ctrl(work[a], target[b], work[c])
+                if op == 14:
+                    cx(target[a], work[b])
+                if op == 15:
+                    x.ctrl(ladder[a], work[b], target[c])
+                if op == 16:
+                    z.ctrl(ladder[a], work[b])
+                if op == 17:
+                    z(ladder[a])
+                if op == 18:
+                    cx(address[a], address[b])
+                if op == 19:
+                    x.ctrl(address[a], address[b], ladder[c])
+                if op == 20:
+                    cx(ladder[a], target[b])
+
+        _retain(primitives_unary_walk_work)
+        return primitives_unary_walk_work
+
+    if controlled:
+
+        @cudaq.kernel
+        def primitives_unary_walk_ctrl(control: cudaq.qview,
+                                       address: cudaq.qview,
+                                       ladder: cudaq.qview,
+                                       target: cudaq.qview):
+            for i in range(num_ops):
+                op = opcodes[i]
+                a = ops_a[i]
+                b = ops_b[i]
+                c = ops_c[i]
+                if op == 0:
+                    x(address[a])
+                if op == 1:
+                    x(ladder[a])
+                if op == 2:
+                    cx(address[a], ladder[b])
+                if op == 3:
+                    cx(ladder[a], ladder[b])
+                if op == 4:
+                    x.ctrl(ladder[a], address[b], ladder[c])
+                if op == 5:
+                    x.ctrl(ladder[a], target[b])
+                if op == 6:
+                    y.ctrl(ladder[a], target[b])
+                if op == 7:
+                    z.ctrl(ladder[a], target[b])
+                if op == 8:
+                    cx(control[0], ladder[b])
+                if op == 9:
+                    x.ctrl(control[0], address[b], ladder[c])
+                if op == 10:
+                    x(target[a])
+                if op == 11:
+                    cx(target[a], target[b])
+                if op == 17:
+                    z(ladder[a])
+                if op == 18:
+                    cx(address[a], address[b])
+                if op == 19:
+                    x.ctrl(address[a], address[b], ladder[c])
+                if op == 20:
+                    cx(ladder[a], target[b])
+
+        _retain(primitives_unary_walk_ctrl)
+        return primitives_unary_walk_ctrl
+
+    @cudaq.kernel
+    def primitives_unary_walk(address: cudaq.qview, ladder: cudaq.qview,
+                              target: cudaq.qview):
+        for i in range(num_ops):
+            op = opcodes[i]
+            a = ops_a[i]
+            b = ops_b[i]
+            c = ops_c[i]
+            if op == 0:
+                x(address[a])
+            if op == 1:
+                x(ladder[a])
+            if op == 2:
+                cx(address[a], ladder[b])
+            if op == 3:
+                cx(ladder[a], ladder[b])
+            if op == 4:
+                x.ctrl(ladder[a], address[b], ladder[c])
+            if op == 5:
+                x.ctrl(ladder[a], target[b])
+            if op == 6:
+                y.ctrl(ladder[a], target[b])
+            if op == 7:
+                z.ctrl(ladder[a], target[b])
+            if op == 10:
+                x(target[a])
+            if op == 11:
+                cx(target[a], target[b])
+            if op == 17:
+                z(ladder[a])
+            if op == 18:
+                cx(address[a], address[b])
+            if op == 19:
+                x.ctrl(address[a], address[b], ladder[c])
+            if op == 20:
+                cx(ladder[a], target[b])
+
+    _retain(primitives_unary_walk)
+    return primitives_unary_walk

--- a/python/cudaq_algorithms/primitives/_unary_iteration.py
+++ b/python/cudaq_algorithms/primitives/_unary_iteration.py
@@ -31,6 +31,16 @@ uncontrolled four-address walk — all matched by this construction, and
 all above the measurement-assisted ``N - 1``. The naive
 compute/uncompute walk costs ``2 N - 4``.
 
+T-count caveat (so the comparison stays honest under either metric):
+roughly a third of this walk's Toffolis are the fused ones, whose
+target is a *dirty* ladder line and therefore cost the generic 7 T,
+while a compute-from-|0> AND costs 4 T (Gidney, arXiv:1709.06648).
+In T gates the fused walk is therefore ~7.5 N against the naive
+unitary walk's ~8 N — a ~6% advantage, not the 25% the Toffoli count
+suggests. Both numbers beat nothing measured: the literature's
+measured walk is 4 N T. A ``t_count`` attribute reporting this
+per-instance is planned alongside ``toffoli_count``.
+
 The callback pattern (READ THIS — it is the template for QROM and for
 factory-composed SELECTs)
 ------------------------------------------------------------------------

--- a/python/cudaq_algorithms/primitives/_unary_iteration.py
+++ b/python/cudaq_algorithms/primitives/_unary_iteration.py
@@ -202,6 +202,22 @@ _EXTENDED_BODY_GATES = {
 _TOFFOLI_OPCODES = (_OP_CCX, _OP_CCX_CTRL, _OP_AND_TT, _OP_AND_WT,
                     _OP_BODY_X_W, _OP_CCX_ADDR_ADDR)
 
+# Dispatch coverage of the four interpreter variants (_mint_interpreter):
+# every variant handles the base set; the control/work bundles are
+# handled only by kernels whose signature carries that register view.
+# An opcode outside the minted variant's set would be SILENTLY SKIPPED
+# by the dispatch loop, so _mint_interpreter rejects such tapes at mint
+# time; test_primitives_interpreter.py pins each opcode's action under
+# every variant that supports it.
+_BASE_OPS = frozenset({
+    _OP_X_ADDR, _OP_X_LADDER, _OP_CX_ADDR_LADDER, _OP_CX_LADDER_LADDER,
+    _OP_CCX, _OP_BODY_X, _OP_BODY_Y, _OP_BODY_Z, _OP_FREE_X, _OP_FREE_CX,
+    _OP_Z_LADDER, _OP_CX_ADDR_ADDR, _OP_CCX_ADDR_ADDR, _OP_CX_LADDER_TARGET
+})
+_CONTROL_OPS = frozenset({_OP_CX_CTRL_LADDER, _OP_CCX_CTRL})
+_WORK_OPS = frozenset(
+    {_OP_AND_TT, _OP_AND_WT, _OP_COPY_TW, _OP_BODY_X_W, _OP_BODY_Z_W})
+
 # Opcode -> operand positions (within (a, b, c)) that index the work
 # register, used to infer the required work width from the emitted ops.
 _WORK_OPERANDS = {
@@ -541,7 +557,24 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
 
     Every emitted gate is self-inverse, so the inverse walk is this same
     interpreter over the reversed list — how ``kernel_adj`` is minted.
+
+    The tape is validated against the variant's supported opcode set
+    (``_BASE_OPS`` plus the control/work bundles the signature carries):
+    the dispatch loop would silently skip an unknown opcode — the worst
+    failure mode available — so an out-of-set tape is a mint-time error.
     """
+    supported = _BASE_OPS
+    if controlled:
+        supported = supported | _CONTROL_OPS
+    if has_work:
+        supported = supported | _WORK_OPS
+    unsupported = sorted({op[0] for op in ops} - supported)
+    if unsupported:
+        raise ValueError(
+            f"instruction tape contains opcodes {unsupported} outside the "
+            f"interpreter variant's dispatch set (controlled={controlled}, "
+            f"has_work={has_work}); the dispatch loop would silently skip "
+            "them")
     num_ops = len(ops)
     opcodes = [op[0] for op in ops]
     ops_a = [op[1] for op in ops]

--- a/python/cudaq_algorithms/primitives/_unary_iteration.py
+++ b/python/cudaq_algorithms/primitives/_unary_iteration.py
@@ -34,7 +34,7 @@ compute/uncompute walk costs ``2 N - 4``.
 T-count caveat (so the comparison stays honest under either metric):
 roughly a third of this walk's Toffolis are the fused ones, whose
 target is a *dirty* ladder line and therefore cost the generic 7 T,
-while a compute-from-|0> AND costs 4 T (Gidney, arXiv:1709.06648).
+while a compute-from-``|0>`` AND costs 4 T (Gidney, arXiv:1709.06648).
 In T gates the fused walk is therefore ~7.5 N against the naive
 unitary walk's ~8 N — a ~6% advantage, not the 25% the Toffoli count
 suggests. Both numbers beat nothing measured: the literature's
@@ -95,10 +95,10 @@ Kernel signatures (all registers little-endian, qubit 0 = LSB, per
   appears only when ``num_work > 0``).
 - with ``controlled=True``: the same signatures with a leading
   ``control: qview``, a one-qubit view rooting the tree — the whole walk
-  acts as the identity when the control is |0>. (A separate one-qubit
+  acts as the identity when the control is ``|0>``. (A separate one-qubit
   view, not a leading qubit of a combined register, so callers never mix
   a qview with a bare qubit in one control set. Free body gates still
-  execute at control |0>, but their conjugation pairing cancels them.)
+  execute at control ``|0>``, but their conjugation pairing cancels them.)
 
 ``kernel_adj`` is the hand-written inverse (``cudaq.adjoint`` is
 off-limits, cuda-quantum#4897/#4898): every emitted gate is self-inverse
@@ -376,7 +376,7 @@ def _emit_walk(num_address_bits: int, num_items: int, controlled: bool,
     def set_line(level: int, bit_is_one: bool) -> None:
         """ladder[level-1] ^= parent AND (address bit == value).
 
-        Self-inverse: emitted both to compute a line (from |0>) and to
+        Self-inverse: emitted both to compute a line (from ``|0>``) and to
         clear it (against the same parent value); the descent, the
         unclamp/reclamp halves of deep transitions and the final unwind
         are all built from this one gadget.

--- a/python/cudaq_algorithms/primitives/_unary_iteration.py
+++ b/python/cudaq_algorithms/primitives/_unary_iteration.py
@@ -38,8 +38,7 @@ while a compute-from-|0> AND costs 4 T (Gidney, arXiv:1709.06648).
 In T gates the fused walk is therefore ~7.5 N against the naive
 unitary walk's ~8 N — a ~6% advantage, not the 25% the Toffoli count
 suggests. Both numbers beat nothing measured: the literature's
-measured walk is 4 N T. A ``t_count`` attribute reporting this
-per-instance is planned alongside ``toffoli_count``.
+measured walk is 4 N T.
 
 The callback pattern (READ THIS — it is the template for QROM and for
 factory-composed SELECTs)

--- a/python/cudaq_algorithms/primitives/_unary_iteration.py
+++ b/python/cudaq_algorithms/primitives/_unary_iteration.py
@@ -42,7 +42,9 @@ time**: ``body(k)`` is called once per address on the host and must return
 the gate list for that address as data. The emitter flattens the whole
 tree walk (ladder gadgets + body gates) into parallel opcode/operand
 integer lists, and the minted kernel is a single flat interpreter loop
-over those captured lists. Flatness is load-bearing: CUDA-Q's
+over those captured lists, pruned to the dispatch arms whose opcodes the
+tape actually uses (see ``_mint_interpreter``). Flatness is load-bearing:
+CUDA-Q's
 control-variant generation rejects kernels that call other kernels, so
 anything built this way stays ``cudaq.control``-compatible and can sit
 inside a controlled SELECT.
@@ -575,13 +577,25 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
     (``_BASE_OPS`` plus the control/work bundles the signature carries):
     the dispatch loop would silently skip an unknown opcode — the worst
     failure mode available — so an out-of-set tape is a mint-time error.
+
+    Dispatch pruning: each dispatch arm is guarded by a captured bool
+    (``use_*``) that is True only when the opcode occurs in this tape.
+    Captured Python constants are folded at kernel-compile time, so a
+    False guard statically removes the arm from the minted module. This
+    matters twice: an arm whose opcode never occurs is classically dead
+    code, and CUDA-Q's CSE can alias a dead multi-control arm's wires
+    into illegal IR (cuda-quantum#5280 — an infinite compiler loop
+    through 0.15, a hard "linear-typed result is used more than once"
+    compile error once fixed); it also shrinks every minted module to
+    the arms it actually replays.
     """
     supported = _BASE_OPS
     if controlled:
         supported = supported | _CONTROL_OPS
     if has_work:
         supported = supported | _WORK_OPS
-    unsupported = sorted({op[0] for op in ops} - supported)
+    present = {op[0] for op in ops}
+    unsupported = sorted(present - supported)
     if unsupported:
         raise ValueError(
             f"instruction tape contains opcodes {unsupported} outside the "
@@ -624,6 +638,30 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
     op_ccx_addr_addr = _OP_CCX_ADDR_ADDR
     op_cx_ladder_target = _OP_CX_LADDER_TARGET
 
+    # Per-arm pruning flags (see the docstring): captured bools fold at
+    # kernel-compile time, so a False flag removes its arm entirely.
+    use_x_addr = _OP_X_ADDR in present
+    use_x_ladder = _OP_X_LADDER in present
+    use_cx_addr_ladder = _OP_CX_ADDR_LADDER in present
+    use_cx_ladder_ladder = _OP_CX_LADDER_LADDER in present
+    use_ccx = _OP_CCX in present
+    use_body_x = _OP_BODY_X in present
+    use_body_y = _OP_BODY_Y in present
+    use_body_z = _OP_BODY_Z in present
+    use_cx_ctrl_ladder = _OP_CX_CTRL_LADDER in present
+    use_ccx_ctrl = _OP_CCX_CTRL in present
+    use_free_x = _OP_FREE_X in present
+    use_free_cx = _OP_FREE_CX in present
+    use_and_tt = _OP_AND_TT in present
+    use_and_wt = _OP_AND_WT in present
+    use_copy_tw = _OP_COPY_TW in present
+    use_body_x_w = _OP_BODY_X_W in present
+    use_body_z_w = _OP_BODY_Z_W in present
+    use_z_ladder = _OP_Z_LADDER in present
+    use_cx_addr_addr = _OP_CX_ADDR_ADDR in present
+    use_ccx_addr_addr = _OP_CCX_ADDR_ADDR in present
+    use_cx_ladder_target = _OP_CX_LADDER_TARGET in present
+
     if controlled and has_work:
 
         @cudaq.kernel
@@ -637,48 +675,69 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
                 a = ops_a[i]
                 b = ops_b[i]
                 c = ops_c[i]
-                if op == op_x_addr:
-                    x(address[a])
-                if op == op_x_ladder:
-                    x(ladder[a])
-                if op == op_cx_addr_ladder:
-                    cx(address[a], ladder[b])
-                if op == op_cx_ladder_ladder:
-                    cx(ladder[a], ladder[b])
-                if op == op_ccx:
-                    x.ctrl(ladder[a], address[b], ladder[c])
-                if op == op_body_x:
-                    x.ctrl(ladder[a], target[b])
-                if op == op_body_y:
-                    y.ctrl(ladder[a], target[b])
-                if op == op_body_z:
-                    z.ctrl(ladder[a], target[b])
-                if op == op_cx_ctrl_ladder:
-                    cx(control[0], ladder[b])
-                if op == op_ccx_ctrl:
-                    x.ctrl(control[0], address[b], ladder[c])
-                if op == op_free_x:
-                    x(target[a])
-                if op == op_free_cx:
-                    cx(target[a], target[b])
-                if op == op_and_tt:
-                    x.ctrl(target[a], target[b], work[c])
-                if op == op_and_wt:
-                    x.ctrl(work[a], target[b], work[c])
-                if op == op_copy_tw:
-                    cx(target[a], work[b])
-                if op == op_body_x_w:
-                    x.ctrl(ladder[a], work[b], target[c])
-                if op == op_body_z_w:
-                    z.ctrl(ladder[a], work[b])
-                if op == op_z_ladder:
-                    z(ladder[a])
-                if op == op_cx_addr_addr:
-                    cx(address[a], address[b])
-                if op == op_ccx_addr_addr:
-                    x.ctrl(address[a], address[b], ladder[c])
-                if op == op_cx_ladder_target:
-                    cx(ladder[a], target[b])
+                if use_x_addr:
+                    if op == op_x_addr:
+                        x(address[a])
+                if use_x_ladder:
+                    if op == op_x_ladder:
+                        x(ladder[a])
+                if use_cx_addr_ladder:
+                    if op == op_cx_addr_ladder:
+                        cx(address[a], ladder[b])
+                if use_cx_ladder_ladder:
+                    if op == op_cx_ladder_ladder:
+                        cx(ladder[a], ladder[b])
+                if use_ccx:
+                    if op == op_ccx:
+                        x.ctrl(ladder[a], address[b], ladder[c])
+                if use_body_x:
+                    if op == op_body_x:
+                        x.ctrl(ladder[a], target[b])
+                if use_body_y:
+                    if op == op_body_y:
+                        y.ctrl(ladder[a], target[b])
+                if use_body_z:
+                    if op == op_body_z:
+                        z.ctrl(ladder[a], target[b])
+                if use_cx_ctrl_ladder:
+                    if op == op_cx_ctrl_ladder:
+                        cx(control[0], ladder[b])
+                if use_ccx_ctrl:
+                    if op == op_ccx_ctrl:
+                        x.ctrl(control[0], address[b], ladder[c])
+                if use_free_x:
+                    if op == op_free_x:
+                        x(target[a])
+                if use_free_cx:
+                    if op == op_free_cx:
+                        cx(target[a], target[b])
+                if use_and_tt:
+                    if op == op_and_tt:
+                        x.ctrl(target[a], target[b], work[c])
+                if use_and_wt:
+                    if op == op_and_wt:
+                        x.ctrl(work[a], target[b], work[c])
+                if use_copy_tw:
+                    if op == op_copy_tw:
+                        cx(target[a], work[b])
+                if use_body_x_w:
+                    if op == op_body_x_w:
+                        x.ctrl(ladder[a], work[b], target[c])
+                if use_body_z_w:
+                    if op == op_body_z_w:
+                        z.ctrl(ladder[a], work[b])
+                if use_z_ladder:
+                    if op == op_z_ladder:
+                        z(ladder[a])
+                if use_cx_addr_addr:
+                    if op == op_cx_addr_addr:
+                        cx(address[a], address[b])
+                if use_ccx_addr_addr:
+                    if op == op_ccx_addr_addr:
+                        x.ctrl(address[a], address[b], ladder[c])
+                if use_cx_ladder_target:
+                    if op == op_cx_ladder_target:
+                        cx(ladder[a], target[b])
 
         _retain(primitives_unary_walk_work_ctrl)
         return primitives_unary_walk_work_ctrl
@@ -694,44 +753,63 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
                 a = ops_a[i]
                 b = ops_b[i]
                 c = ops_c[i]
-                if op == op_x_addr:
-                    x(address[a])
-                if op == op_x_ladder:
-                    x(ladder[a])
-                if op == op_cx_addr_ladder:
-                    cx(address[a], ladder[b])
-                if op == op_cx_ladder_ladder:
-                    cx(ladder[a], ladder[b])
-                if op == op_ccx:
-                    x.ctrl(ladder[a], address[b], ladder[c])
-                if op == op_body_x:
-                    x.ctrl(ladder[a], target[b])
-                if op == op_body_y:
-                    y.ctrl(ladder[a], target[b])
-                if op == op_body_z:
-                    z.ctrl(ladder[a], target[b])
-                if op == op_free_x:
-                    x(target[a])
-                if op == op_free_cx:
-                    cx(target[a], target[b])
-                if op == op_and_tt:
-                    x.ctrl(target[a], target[b], work[c])
-                if op == op_and_wt:
-                    x.ctrl(work[a], target[b], work[c])
-                if op == op_copy_tw:
-                    cx(target[a], work[b])
-                if op == op_body_x_w:
-                    x.ctrl(ladder[a], work[b], target[c])
-                if op == op_body_z_w:
-                    z.ctrl(ladder[a], work[b])
-                if op == op_z_ladder:
-                    z(ladder[a])
-                if op == op_cx_addr_addr:
-                    cx(address[a], address[b])
-                if op == op_ccx_addr_addr:
-                    x.ctrl(address[a], address[b], ladder[c])
-                if op == op_cx_ladder_target:
-                    cx(ladder[a], target[b])
+                if use_x_addr:
+                    if op == op_x_addr:
+                        x(address[a])
+                if use_x_ladder:
+                    if op == op_x_ladder:
+                        x(ladder[a])
+                if use_cx_addr_ladder:
+                    if op == op_cx_addr_ladder:
+                        cx(address[a], ladder[b])
+                if use_cx_ladder_ladder:
+                    if op == op_cx_ladder_ladder:
+                        cx(ladder[a], ladder[b])
+                if use_ccx:
+                    if op == op_ccx:
+                        x.ctrl(ladder[a], address[b], ladder[c])
+                if use_body_x:
+                    if op == op_body_x:
+                        x.ctrl(ladder[a], target[b])
+                if use_body_y:
+                    if op == op_body_y:
+                        y.ctrl(ladder[a], target[b])
+                if use_body_z:
+                    if op == op_body_z:
+                        z.ctrl(ladder[a], target[b])
+                if use_free_x:
+                    if op == op_free_x:
+                        x(target[a])
+                if use_free_cx:
+                    if op == op_free_cx:
+                        cx(target[a], target[b])
+                if use_and_tt:
+                    if op == op_and_tt:
+                        x.ctrl(target[a], target[b], work[c])
+                if use_and_wt:
+                    if op == op_and_wt:
+                        x.ctrl(work[a], target[b], work[c])
+                if use_copy_tw:
+                    if op == op_copy_tw:
+                        cx(target[a], work[b])
+                if use_body_x_w:
+                    if op == op_body_x_w:
+                        x.ctrl(ladder[a], work[b], target[c])
+                if use_body_z_w:
+                    if op == op_body_z_w:
+                        z.ctrl(ladder[a], work[b])
+                if use_z_ladder:
+                    if op == op_z_ladder:
+                        z(ladder[a])
+                if use_cx_addr_addr:
+                    if op == op_cx_addr_addr:
+                        cx(address[a], address[b])
+                if use_ccx_addr_addr:
+                    if op == op_ccx_addr_addr:
+                        x.ctrl(address[a], address[b], ladder[c])
+                if use_cx_ladder_target:
+                    if op == op_cx_ladder_target:
+                        cx(ladder[a], target[b])
 
         _retain(primitives_unary_walk_work)
         return primitives_unary_walk_work
@@ -748,38 +826,54 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
                 a = ops_a[i]
                 b = ops_b[i]
                 c = ops_c[i]
-                if op == op_x_addr:
-                    x(address[a])
-                if op == op_x_ladder:
-                    x(ladder[a])
-                if op == op_cx_addr_ladder:
-                    cx(address[a], ladder[b])
-                if op == op_cx_ladder_ladder:
-                    cx(ladder[a], ladder[b])
-                if op == op_ccx:
-                    x.ctrl(ladder[a], address[b], ladder[c])
-                if op == op_body_x:
-                    x.ctrl(ladder[a], target[b])
-                if op == op_body_y:
-                    y.ctrl(ladder[a], target[b])
-                if op == op_body_z:
-                    z.ctrl(ladder[a], target[b])
-                if op == op_cx_ctrl_ladder:
-                    cx(control[0], ladder[b])
-                if op == op_ccx_ctrl:
-                    x.ctrl(control[0], address[b], ladder[c])
-                if op == op_free_x:
-                    x(target[a])
-                if op == op_free_cx:
-                    cx(target[a], target[b])
-                if op == op_z_ladder:
-                    z(ladder[a])
-                if op == op_cx_addr_addr:
-                    cx(address[a], address[b])
-                if op == op_ccx_addr_addr:
-                    x.ctrl(address[a], address[b], ladder[c])
-                if op == op_cx_ladder_target:
-                    cx(ladder[a], target[b])
+                if use_x_addr:
+                    if op == op_x_addr:
+                        x(address[a])
+                if use_x_ladder:
+                    if op == op_x_ladder:
+                        x(ladder[a])
+                if use_cx_addr_ladder:
+                    if op == op_cx_addr_ladder:
+                        cx(address[a], ladder[b])
+                if use_cx_ladder_ladder:
+                    if op == op_cx_ladder_ladder:
+                        cx(ladder[a], ladder[b])
+                if use_ccx:
+                    if op == op_ccx:
+                        x.ctrl(ladder[a], address[b], ladder[c])
+                if use_body_x:
+                    if op == op_body_x:
+                        x.ctrl(ladder[a], target[b])
+                if use_body_y:
+                    if op == op_body_y:
+                        y.ctrl(ladder[a], target[b])
+                if use_body_z:
+                    if op == op_body_z:
+                        z.ctrl(ladder[a], target[b])
+                if use_cx_ctrl_ladder:
+                    if op == op_cx_ctrl_ladder:
+                        cx(control[0], ladder[b])
+                if use_ccx_ctrl:
+                    if op == op_ccx_ctrl:
+                        x.ctrl(control[0], address[b], ladder[c])
+                if use_free_x:
+                    if op == op_free_x:
+                        x(target[a])
+                if use_free_cx:
+                    if op == op_free_cx:
+                        cx(target[a], target[b])
+                if use_z_ladder:
+                    if op == op_z_ladder:
+                        z(ladder[a])
+                if use_cx_addr_addr:
+                    if op == op_cx_addr_addr:
+                        cx(address[a], address[b])
+                if use_ccx_addr_addr:
+                    if op == op_ccx_addr_addr:
+                        x.ctrl(address[a], address[b], ladder[c])
+                if use_cx_ladder_target:
+                    if op == op_cx_ladder_target:
+                        cx(ladder[a], target[b])
 
         _retain(primitives_unary_walk_ctrl)
         return primitives_unary_walk_ctrl
@@ -792,34 +886,48 @@ def _mint_interpreter(ops: list, controlled: bool, has_work: bool):
             a = ops_a[i]
             b = ops_b[i]
             c = ops_c[i]
-            if op == op_x_addr:
-                x(address[a])
-            if op == op_x_ladder:
-                x(ladder[a])
-            if op == op_cx_addr_ladder:
-                cx(address[a], ladder[b])
-            if op == op_cx_ladder_ladder:
-                cx(ladder[a], ladder[b])
-            if op == op_ccx:
-                x.ctrl(ladder[a], address[b], ladder[c])
-            if op == op_body_x:
-                x.ctrl(ladder[a], target[b])
-            if op == op_body_y:
-                y.ctrl(ladder[a], target[b])
-            if op == op_body_z:
-                z.ctrl(ladder[a], target[b])
-            if op == op_free_x:
-                x(target[a])
-            if op == op_free_cx:
-                cx(target[a], target[b])
-            if op == op_z_ladder:
-                z(ladder[a])
-            if op == op_cx_addr_addr:
-                cx(address[a], address[b])
-            if op == op_ccx_addr_addr:
-                x.ctrl(address[a], address[b], ladder[c])
-            if op == op_cx_ladder_target:
-                cx(ladder[a], target[b])
+            if use_x_addr:
+                if op == op_x_addr:
+                    x(address[a])
+            if use_x_ladder:
+                if op == op_x_ladder:
+                    x(ladder[a])
+            if use_cx_addr_ladder:
+                if op == op_cx_addr_ladder:
+                    cx(address[a], ladder[b])
+            if use_cx_ladder_ladder:
+                if op == op_cx_ladder_ladder:
+                    cx(ladder[a], ladder[b])
+            if use_ccx:
+                if op == op_ccx:
+                    x.ctrl(ladder[a], address[b], ladder[c])
+            if use_body_x:
+                if op == op_body_x:
+                    x.ctrl(ladder[a], target[b])
+            if use_body_y:
+                if op == op_body_y:
+                    y.ctrl(ladder[a], target[b])
+            if use_body_z:
+                if op == op_body_z:
+                    z.ctrl(ladder[a], target[b])
+            if use_free_x:
+                if op == op_free_x:
+                    x(target[a])
+            if use_free_cx:
+                if op == op_free_cx:
+                    cx(target[a], target[b])
+            if use_z_ladder:
+                if op == op_z_ladder:
+                    z(ladder[a])
+            if use_cx_addr_addr:
+                if op == op_cx_addr_addr:
+                    cx(address[a], address[b])
+            if use_ccx_addr_addr:
+                if op == op_ccx_addr_addr:
+                    x.ctrl(address[a], address[b], ladder[c])
+            if use_cx_ladder_target:
+                if op == op_cx_ladder_target:
+                    cx(ladder[a], target[b])
 
     _retain(primitives_unary_walk)
     return primitives_unary_walk

--- a/tests/python/test_primitives_body_gates.py
+++ b/tests/python/test_primitives_body_gates.py
@@ -1,0 +1,316 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Behavioral pins for the extended body vocabulary and external control.
+
+Two advertised capabilities of ``unary_iteration_kernels`` get their
+tests here:
+
+1. The extended body gates (``free_x``, ``free_cx``, ``and_tt``,
+   ``and_wt``, ``copy_tw``, ``x_w``, ``z_w``, ``sign``). Every one is a
+   classical bit permutation with a phase, so each test states its
+   expected action as a tiny ``bits -> (bits, phase)`` function applied
+   at the active address only (free gates fire everywhere but are
+   emitted as conjugation pairs that cancel on inactive addresses), and
+   the walk's statevector on a phased superposed address must equal the
+   assembled sum exactly. Work registers must return to ``|0>``.
+
+2. ``cudaq.control`` applied by the *user* to a minted kernel. The
+   factory's ``controlled=True`` folds the control into the tree; an
+   external ``cudaq.control`` wrap is a different mechanism entirely and
+   is promised to work ("cudaq.control-compatible by construction").
+   The two routes are pinned against each other and against an analytic
+   reference in the same run.
+"""
+
+import numpy as np
+import pytest
+
+import cudaq
+
+from cudaq_algorithms.primitives import unary_iteration_kernels
+
+cudaq.set_target("qpp-cpu")
+
+_NUM_ADDR = 2
+_NUM_ITEMS = 4
+# Distinct per-bit phases so every address amplitude is different: an
+# address-dependent phase error cannot cancel in the comparison.
+_PHI = (0.4, 1.1)
+
+
+def _address_amplitude(k: int) -> complex:
+    """Amplitude of |k> after h + rz(phi) on each address bit."""
+    amp = 1.0 + 0.0j
+    for j, phi in enumerate(_PHI):
+        bit = (k >> j) & 1
+        amp *= np.exp(1j * phi / 2 if bit else -1j * phi / 2) / np.sqrt(2)
+    return amp
+
+
+def _walk_state(walk, num_target: int, num_work: int,
+                target_basis: int) -> np.ndarray:
+    """One application on |phased address> (x) |target_basis>, |0> work."""
+    kernel = walk.kernel
+
+    if num_work == 0:
+
+        @cudaq.kernel
+        def run(t_basis: int):
+            address = cudaq.qvector(_NUM_ADDR)
+            ladder = cudaq.qvector(_NUM_ADDR)
+            target = cudaq.qvector(num_target)
+            for j in range(_NUM_ADDR):
+                h(address[j])
+            rz(0.4, address[0])
+            rz(1.1, address[1])
+            for t in range(num_target):
+                if (t_basis >> t) & 1:
+                    x(target[t])
+            kernel(address, ladder, target)
+    else:
+
+        @cudaq.kernel
+        def run(t_basis: int):
+            address = cudaq.qvector(_NUM_ADDR)
+            ladder = cudaq.qvector(_NUM_ADDR)
+            target = cudaq.qvector(num_target)
+            work = cudaq.qvector(num_work)
+            for j in range(_NUM_ADDR):
+                h(address[j])
+            rz(0.4, address[0])
+            rz(1.1, address[1])
+            for t in range(num_target):
+                if (t_basis >> t) & 1:
+                    x(target[t])
+            kernel(address, ladder, target, work)
+
+    return np.array(cudaq.get_state(run, target_basis))
+
+
+def _expected_state(action, num_target: int, num_work: int,
+                    target_basis: int) -> np.ndarray:
+    """Assemble sum_k a_k |k>|0 ladder>|new bits>|0 work>.
+
+    ``action(k, bits) -> (new_bits, phase)`` is the claimed effect of the
+    body at address ``k`` on target bits ``bits`` (little-endian ints).
+    Layout (qubit 0 = LSB of the state index, allocation order): address
+    [0, A), ladder [A, 2A), target [2A, 2A + T), work above that — the
+    expected vector is nonzero only where ladder and work are 0.
+    """
+    total = 2 * _NUM_ADDR + num_target + num_work
+    expected = np.zeros(1 << total, dtype=np.complex128)
+    for k in range(_NUM_ITEMS):
+        new_bits, phase = action(k, target_basis)
+        index = k + (new_bits << (2 * _NUM_ADDR))
+        expected[index] += _address_amplitude(k) * phase
+    return expected
+
+
+def _check_walk(body, action, num_target: int, expected_work: int):
+    walk = unary_iteration_kernels(_NUM_ADDR, _NUM_ITEMS, body)
+    assert walk.num_work == expected_work
+    for target_basis in range(1 << num_target):
+        state = _walk_state(walk, num_target, walk.num_work, target_basis)
+        expected = _expected_state(action, num_target, walk.num_work,
+                                   target_basis)
+        np.testing.assert_allclose(state, expected, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# The extended vocabulary, gate by gate
+# ---------------------------------------------------------------------------
+
+
+def test_sign_is_a_phase_on_the_active_address_only():
+    marked = (1, 3)
+
+    def body(k):
+        return [("sign", )] if k in marked else []
+
+    def action(k, bits):
+        return bits, -1.0 if k in marked else 1.0
+
+    _check_walk(body, action, num_target=1, expected_work=0)
+
+
+def test_free_x_conjugation_inverts_a_leaf_controlled_z():
+    # X Z X = -Z: the conjugated core phases the |0> branch of target 0
+    # at the active address; the unconditional free_x pair must cancel
+    # exactly on every other address.
+    def body(k):
+        return [("free_x", 0), ("z", 0), ("free_x", 0)]
+
+    def action(k, bits):
+        return bits, -1.0 if (bits & 1) == 0 else 1.0
+
+    _check_walk(body, action, num_target=2, expected_work=0)
+
+
+def test_free_cx_conjugation_builds_a_parity_phase():
+    # CX(0 -> 1) Z_1 CX(0 -> 1) = Z_0 Z_1: phase -1 exactly when the two
+    # target bits differ... on bit1 XOR bit0 = 1.
+    def body(k):
+        return [("free_cx", 0, 1), ("z", 1), ("free_cx", 0, 1)]
+
+    def action(k, bits):
+        parity = ((bits >> 1) ^ bits) & 1
+        return bits, -1.0 if parity else 1.0
+
+    _check_walk(body, action, num_target=2, expected_work=0)
+
+
+def test_and_tt_with_z_w_is_a_ccz_at_the_active_address():
+    # Compute t0 AND t1 into work 0, phase on it, uncompute: CCZ(t0, t1)
+    # delivered only at the marked addresses; work back to |0> always.
+    marked = (0, 2)
+
+    def body(k):
+        if k not in marked:
+            return []
+        return [("and_tt", 0, 1, 0), ("z_w", 0), ("and_tt", 0, 1, 0)]
+
+    def action(k, bits):
+        both = (bits & 1) and (bits >> 1) & 1
+        return bits, -1.0 if (k in marked and both) else 1.0
+
+    _check_walk(body, action, num_target=2, expected_work=1)
+
+
+def test_and_wt_chains_to_a_cccz_at_the_active_address():
+    # work0 := t0 AND t1 (and_tt), work1 := work0 AND t2 (and_wt), phase
+    # on work1, uncompute both: CCCZ(t0, t1, t2) at every address here.
+    def body(k):
+        return [
+            ("and_tt", 0, 1, 0),
+            ("and_wt", 0, 2, 1),
+            ("z_w", 1),
+            ("and_wt", 0, 2, 1),
+            ("and_tt", 0, 1, 0),
+        ]
+
+    def action(k, bits):
+        all_three = (bits & 1) and (bits >> 1) & 1 and (bits >> 2) & 1
+        return bits, -1.0 if all_three else 1.0
+
+    _check_walk(body, action, num_target=3, expected_work=2)
+
+
+def test_copy_tw_with_x_w_is_a_leaf_controlled_cx():
+    # work0 := copy of t0, x_w flips t1 when (leaf AND work0): the net
+    # body is CX(t0 -> t1) at the active address; the copy uncomputes.
+    marked = (1, 2)
+
+    def body(k):
+        if k not in marked:
+            return []
+        return [("copy_tw", 0, 0), ("x_w", 0, 1), ("copy_tw", 0, 0)]
+
+    def action(k, bits):
+        if k in marked and (bits & 1):
+            return bits ^ 2, 1.0
+        return bits, 1.0
+
+    _check_walk(body, action, num_target=2, expected_work=1)
+
+
+def test_work_gate_toffoli_count_matches_the_compiler():
+    # The emitter's toffoli_count must stay equal to the compiled count
+    # when the body itself contributes Toffolis (and_tt / and_wt / x_w
+    # are 2-controlled gates on top of the walk's own ladder Toffolis).
+    pytest.importorskip("cudaq", reason="resource estimation probe")
+    if not hasattr(cudaq, "estimate_resources"):
+        pytest.skip("cudaq.estimate_resources is not available")
+
+    def body(k):
+        return [("and_tt", 0, 1, 0), ("z_w", 0), ("and_tt", 0, 1, 0)]
+
+    walk = unary_iteration_kernels(_NUM_ADDR, _NUM_ITEMS, body)
+    kernel = walk.kernel
+
+    @cudaq.kernel
+    def harness():
+        address = cudaq.qvector(_NUM_ADDR)
+        ladder = cudaq.qvector(_NUM_ADDR)
+        target = cudaq.qvector(2)
+        work = cudaq.qvector(1)
+        kernel(address, ladder, target, work)
+
+    resources = cudaq.estimate_resources(harness)
+    compiled = resources.count_controls("x", 2)
+    assert compiled == walk.toffoli_count
+
+
+# ---------------------------------------------------------------------------
+# External cudaq.control vs the factory's controlled=True
+# ---------------------------------------------------------------------------
+
+
+def test_external_cudaq_control_matches_builtin_controlled():
+    """The two ways to control a walk must implement the same unitary.
+
+    ``controlled=True`` folds the control into the tree (3N/2 - 1
+    Toffolis); ``cudaq.control`` on the plain kernel lets CUDA-Q add a
+    control to every gate (more expensive, but promised to be correct:
+    the minted kernel is flat by construction). Same prep, both routes,
+    equality to each other AND to the analytic state — so they cannot
+    agree by being wrong the same way.
+    """
+    marked = (0, 3)
+
+    def body(k):
+        return [("z", 0)] if k in marked else []
+
+    plain = unary_iteration_kernels(_NUM_ADDR, _NUM_ITEMS, body)
+    builtin = unary_iteration_kernels(_NUM_ADDR,
+                                      _NUM_ITEMS,
+                                      body,
+                                      controlled=True)
+    plain_kernel = plain.kernel
+    builtin_kernel = builtin.kernel
+    theta = 0.7
+
+    @cudaq.kernel
+    def run_wrapped():
+        control = cudaq.qvector(1)
+        address = cudaq.qvector(_NUM_ADDR)
+        ladder = cudaq.qvector(_NUM_ADDR)
+        target = cudaq.qvector(1)
+        ry(theta, control[0])
+        for j in range(_NUM_ADDR):
+            h(address[j])
+        rz(0.4, address[0])
+        rz(1.1, address[1])
+        x(target[0])
+        cudaq.control(plain_kernel, control[0], address, ladder, target)
+
+    @cudaq.kernel
+    def run_builtin():
+        control = cudaq.qvector(1)
+        address = cudaq.qvector(_NUM_ADDR)
+        ladder = cudaq.qvector(_NUM_ADDR)
+        target = cudaq.qvector(1)
+        ry(theta, control[0])
+        for j in range(_NUM_ADDR):
+            h(address[j])
+        rz(0.4, address[0])
+        rz(1.1, address[1])
+        x(target[0])
+        builtin_kernel(control, address, ladder, target)
+
+    wrapped = np.array(cudaq.get_state(run_wrapped))
+    built = np.array(cudaq.get_state(run_builtin))
+
+    # Analytic reference. Layout: control 0, address [1, 3), ladder
+    # [3, 5), target 5; target holds |1> so the leaf-controlled Z kicks
+    # a -1 exactly on (control = 1) x (marked address).
+    c = (np.cos(theta / 2), np.sin(theta / 2))
+    expected = np.zeros(1 << (2 * _NUM_ADDR + 2), dtype=np.complex128)
+    for control_bit in range(2):
+        for k in range(_NUM_ITEMS):
+            sign = -1.0 if (control_bit == 1 and k in marked) else 1.0
+            index = control_bit + (k << 1) + (1 << (2 * _NUM_ADDR + 1))
+            expected[index] = c[control_bit] * _address_amplitude(k) * sign
+
+    np.testing.assert_allclose(wrapped, expected, atol=1e-12)
+    np.testing.assert_allclose(built, expected, atol=1e-12)
+    np.testing.assert_allclose(wrapped, built, atol=1e-12)

--- a/tests/python/test_primitives_interpreter.py
+++ b/tests/python/test_primitives_interpreter.py
@@ -20,12 +20,12 @@ import pytest
 import cudaq
 
 from cudaq_algorithms.primitives._unary_iteration import (
-    _BASE_OPS, _CONTROL_OPS, _OP_AND_TT, _OP_AND_WT, _OP_BODY_X,
-    _OP_BODY_X_W, _OP_BODY_Y, _OP_BODY_Z, _OP_BODY_Z_W, _OP_CCX,
-    _OP_CCX_ADDR_ADDR, _OP_CCX_CTRL, _OP_COPY_TW, _OP_CX_ADDR_ADDR,
-    _OP_CX_ADDR_LADDER, _OP_CX_CTRL_LADDER, _OP_CX_LADDER_LADDER,
-    _OP_CX_LADDER_TARGET, _OP_FREE_CX, _OP_FREE_X, _OP_X_ADDR, _OP_X_LADDER,
-    _OP_Z_LADDER, _WORK_OPS, _mint_interpreter)
+    _BASE_OPS, _CONTROL_OPS, _OP_AND_TT, _OP_AND_WT, _OP_BODY_X, _OP_BODY_X_W,
+    _OP_BODY_Y, _OP_BODY_Z, _OP_BODY_Z_W, _OP_CCX, _OP_CCX_ADDR_ADDR,
+    _OP_CCX_CTRL, _OP_COPY_TW, _OP_CX_ADDR_ADDR, _OP_CX_ADDR_LADDER,
+    _OP_CX_CTRL_LADDER, _OP_CX_LADDER_LADDER, _OP_CX_LADDER_TARGET,
+    _OP_FREE_CX, _OP_FREE_X, _OP_X_ADDR, _OP_X_LADDER, _OP_Z_LADDER, _WORK_OPS,
+    _mint_interpreter)
 
 # Register widths in the harness: control 1, address 2, ladder 2,
 # target 2, work 2 — enough for two distinct operand indices per
@@ -61,8 +61,7 @@ _SPECS = {
     "body_z_w": (_OP_BODY_Z_W, (0, 1, 0), "cz", [("l", 0), ("w", 1)]),
     "z_ladder": (_OP_Z_LADDER, (1, 0, 0), "z", [("l", 1)]),
     "cx_addr_addr": (_OP_CX_ADDR_ADDR, (0, 1, 0), "cx", [("a", 0), ("a", 1)]),
-    "ccx_addr_addr": (_OP_CCX_ADDR_ADDR, (0, 1, 1), "ccx", [("a", 0),
-                                                            ("a", 1),
+    "ccx_addr_addr": (_OP_CCX_ADDR_ADDR, (0, 1, 1), "ccx", [("a", 0), ("a", 1),
                                                             ("l", 1)]),
     "cx_ladder_target": (_OP_CX_LADDER_TARGET, (0, 1, 0), "cx", [("l", 0),
                                                                  ("t", 1)]),
@@ -261,7 +260,9 @@ def test_opcode_semantics(opcode, operands, kind, refs, controlled, has_work):
         index = sum(out[reg] << off for reg, off in offsets.items())
         expected[index] = phase
         np.testing.assert_allclose(
-            state, expected, atol=1e-12,
+            state,
+            expected,
+            atol=1e-12,
             err_msg=(f"opcode {opcode} (ctrl={controlled}, work={has_work}) "
                      f"wrong on input {regs}"))
 

--- a/tests/python/test_primitives_interpreter.py
+++ b/tests/python/test_primitives_interpreter.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-opcode semantic pins for the flat interpreter.
+
+One test per (opcode, interpreter variant): mint a one-instruction tape,
+run it on every basis state of the qubits the gate touches, and compare
+the full statevector — including phases — against the opcode's documented
+action. Running each opcode under EVERY variant whose signature supports
+it also proves each variant's dispatch chain has an arm for it (a missing
+arm would silently no-op the gate and fail the pin).
+
+Also pins the mint-time tape validation: a tape carrying an opcode
+outside the minted variant's dispatch set must be rejected loudly, never
+silently skipped.
+"""
+
+import numpy as np
+import pytest
+
+import cudaq
+
+from cudaq_algorithms.primitives._unary_iteration import (
+    _BASE_OPS, _CONTROL_OPS, _OP_AND_TT, _OP_AND_WT, _OP_BODY_X,
+    _OP_BODY_X_W, _OP_BODY_Y, _OP_BODY_Z, _OP_BODY_Z_W, _OP_CCX,
+    _OP_CCX_ADDR_ADDR, _OP_CCX_CTRL, _OP_COPY_TW, _OP_CX_ADDR_ADDR,
+    _OP_CX_ADDR_LADDER, _OP_CX_CTRL_LADDER, _OP_CX_LADDER_LADDER,
+    _OP_CX_LADDER_TARGET, _OP_FREE_CX, _OP_FREE_X, _OP_X_ADDR, _OP_X_LADDER,
+    _OP_Z_LADDER, _WORK_OPS, _mint_interpreter)
+
+# Register widths in the harness: control 1, address 2, ladder 2,
+# target 2, work 2 — enough for two distinct operand indices per
+# register, so operand-order bugs are visible.
+_WIDTHS = {"c": 1, "a": 2, "l": 2, "t": 2, "w": 2}
+
+# Each spec: opcode, its (a, b, c) operand values, the gate kind, and
+# the touched qubits as (register, index) refs in gate order — controls
+# first, target last. Operand values are chosen to match the dispatch
+# arms in _mint_interpreter exactly.
+_SPECS = {
+    "x_addr": (_OP_X_ADDR, (1, 0, 0), "x", [("a", 1)]),
+    "x_ladder": (_OP_X_LADDER, (1, 0, 0), "x", [("l", 1)]),
+    "cx_addr_ladder": (_OP_CX_ADDR_LADDER, (1, 0, 0), "cx", [("a", 1),
+                                                             ("l", 0)]),
+    "cx_ladder_ladder": (_OP_CX_LADDER_LADDER, (0, 1, 0), "cx", [("l", 0),
+                                                                 ("l", 1)]),
+    "ccx": (_OP_CCX, (0, 1, 1), "ccx", [("l", 0), ("a", 1), ("l", 1)]),
+    "body_x": (_OP_BODY_X, (0, 1, 0), "cx", [("l", 0), ("t", 1)]),
+    "body_y": (_OP_BODY_Y, (0, 1, 0), "cy", [("l", 0), ("t", 1)]),
+    "body_z": (_OP_BODY_Z, (0, 1, 0), "cz", [("l", 0), ("t", 1)]),
+    "cx_ctrl_ladder": (_OP_CX_CTRL_LADDER, (0, 1, 0), "cx", [("c", 0),
+                                                             ("l", 1)]),
+    "ccx_ctrl": (_OP_CCX_CTRL, (0, 1, 1), "ccx", [("c", 0), ("a", 1),
+                                                  ("l", 1)]),
+    "free_x": (_OP_FREE_X, (1, 0, 0), "x", [("t", 1)]),
+    "free_cx": (_OP_FREE_CX, (0, 1, 0), "cx", [("t", 0), ("t", 1)]),
+    "and_tt": (_OP_AND_TT, (0, 1, 1), "ccx", [("t", 0), ("t", 1), ("w", 1)]),
+    "and_wt": (_OP_AND_WT, (0, 1, 1), "ccx", [("w", 0), ("t", 1), ("w", 1)]),
+    "copy_tw": (_OP_COPY_TW, (0, 1, 0), "cx", [("t", 0), ("w", 1)]),
+    "body_x_w": (_OP_BODY_X_W, (0, 1, 1), "ccx", [("l", 0), ("w", 1),
+                                                  ("t", 1)]),
+    "body_z_w": (_OP_BODY_Z_W, (0, 1, 0), "cz", [("l", 0), ("w", 1)]),
+    "z_ladder": (_OP_Z_LADDER, (1, 0, 0), "z", [("l", 1)]),
+    "cx_addr_addr": (_OP_CX_ADDR_ADDR, (0, 1, 0), "cx", [("a", 0), ("a", 1)]),
+    "ccx_addr_addr": (_OP_CCX_ADDR_ADDR, (0, 1, 1), "ccx", [("a", 0),
+                                                            ("a", 1),
+                                                            ("l", 1)]),
+    "cx_ladder_target": (_OP_CX_LADDER_TARGET, (0, 1, 0), "cx", [("l", 0),
+                                                                 ("t", 1)]),
+}
+
+_ALL_VARIANTS = [(False, False), (True, False), (False, True), (True, True)]
+
+
+def _variants_for(opcode):
+    """Every (controlled, has_work) signature that supports the opcode."""
+    if opcode in _CONTROL_OPS:
+        return [(True, False), (True, True)]
+    if opcode in _WORK_OPS:
+        return [(False, True), (True, True)]
+    return list(_ALL_VARIANTS)
+
+
+def _spec_cases():
+    return [
+        pytest.param(opcode,
+                     operands,
+                     kind,
+                     refs,
+                     controlled,
+                     has_work,
+                     id=f"{name}-ctrl{int(controlled)}-work{int(has_work)}")
+        for name, (opcode, operands, kind, refs) in sorted(_SPECS.items())
+        for controlled, has_work in _variants_for(opcode)
+    ]
+
+
+def _mint_harness(op, controlled, has_work):
+    """One-instruction interpreter plus a basis-state-prep entry kernel."""
+    interp = _mint_interpreter([op], controlled, has_work)
+
+    if controlled and has_work:
+
+        @cudaq.kernel
+        def run_cw(c_init: int, a_init: int, l_init: int, t_init: int,
+                   w_init: int):
+            control = cudaq.qvector(1)
+            address = cudaq.qvector(2)
+            ladder = cudaq.qvector(2)
+            target = cudaq.qvector(2)
+            work = cudaq.qvector(2)
+            if c_init == 1:
+                x(control[0])
+            for i in range(2):
+                if ((a_init >> i) & 1) == 1:
+                    x(address[i])
+                if ((l_init >> i) & 1) == 1:
+                    x(ladder[i])
+                if ((t_init >> i) & 1) == 1:
+                    x(target[i])
+                if ((w_init >> i) & 1) == 1:
+                    x(work[i])
+            interp(control, address, ladder, target, work)
+
+        return run_cw
+
+    if controlled:
+
+        @cudaq.kernel
+        def run_c(c_init: int, a_init: int, l_init: int, t_init: int):
+            control = cudaq.qvector(1)
+            address = cudaq.qvector(2)
+            ladder = cudaq.qvector(2)
+            target = cudaq.qvector(2)
+            if c_init == 1:
+                x(control[0])
+            for i in range(2):
+                if ((a_init >> i) & 1) == 1:
+                    x(address[i])
+                if ((l_init >> i) & 1) == 1:
+                    x(ladder[i])
+                if ((t_init >> i) & 1) == 1:
+                    x(target[i])
+            interp(control, address, ladder, target)
+
+        return run_c
+
+    if has_work:
+
+        @cudaq.kernel
+        def run_w(a_init: int, l_init: int, t_init: int, w_init: int):
+            address = cudaq.qvector(2)
+            ladder = cudaq.qvector(2)
+            target = cudaq.qvector(2)
+            work = cudaq.qvector(2)
+            for i in range(2):
+                if ((a_init >> i) & 1) == 1:
+                    x(address[i])
+                if ((l_init >> i) & 1) == 1:
+                    x(ladder[i])
+                if ((t_init >> i) & 1) == 1:
+                    x(target[i])
+                if ((w_init >> i) & 1) == 1:
+                    x(work[i])
+            interp(address, ladder, target, work)
+
+        return run_w
+
+    @cudaq.kernel
+    def run_p(a_init: int, l_init: int, t_init: int):
+        address = cudaq.qvector(2)
+        ladder = cudaq.qvector(2)
+        target = cudaq.qvector(2)
+        for i in range(2):
+            if ((a_init >> i) & 1) == 1:
+                x(address[i])
+            if ((l_init >> i) & 1) == 1:
+                x(ladder[i])
+            if ((t_init >> i) & 1) == 1:
+                x(target[i])
+        interp(address, ladder, target)
+
+    return run_p
+
+
+def _layout(controlled, has_work):
+    """(register -> bit offset, total qubits) for the harness layout."""
+    offsets = {}
+    off = 0
+    if controlled:
+        offsets["c"] = off
+        off += 1
+    for reg in ("a", "l", "t"):
+        offsets[reg] = off
+        off += _WIDTHS[reg]
+    if has_work:
+        offsets["w"] = off
+        off += 2
+    return offsets, off
+
+
+def _apply(kind, refs, regs):
+    """The opcode's documented action on basis-state register values."""
+    out = dict(regs)
+
+    def bit(ref):
+        reg, i = ref
+        return (out[reg] >> i) & 1
+
+    def flip(ref):
+        reg, i = ref
+        out[reg] ^= 1 << i
+
+    phase = 1.0 + 0.0j
+    if kind == "x":
+        flip(refs[0])
+    elif kind == "cx":
+        if bit(refs[0]):
+            flip(refs[1])
+    elif kind == "ccx":
+        if bit(refs[0]) and bit(refs[1]):
+            flip(refs[2])
+    elif kind == "cy":
+        if bit(refs[0]):
+            phase = 1.0j if bit(refs[1]) == 0 else -1.0j
+            flip(refs[1])
+    elif kind == "cz":
+        if bit(refs[0]) and bit(refs[1]):
+            phase = -1.0
+    elif kind == "z":
+        if bit(refs[0]):
+            phase = -1.0
+    else:
+        raise AssertionError(f"unknown gate kind {kind}")
+    return out, phase
+
+
+@pytest.mark.parametrize("opcode,operands,kind,refs,controlled,has_work",
+                         _spec_cases())
+def test_opcode_semantics(opcode, operands, kind, refs, controlled, has_work):
+    a, b, c = operands
+    harness = _mint_harness((opcode, a, b, c), controlled, has_work)
+    offsets, num_qubits = _layout(controlled, has_work)
+
+    touched = sorted(set(refs))
+    for combo in range(1 << len(touched)):
+        regs = {"c": 0, "a": 0, "l": 0, "t": 0, "w": 0}
+        for j, (reg, i) in enumerate(touched):
+            if (combo >> j) & 1:
+                regs[reg] |= 1 << i
+
+        args = []
+        if controlled:
+            args.append(regs["c"])
+        args.extend([regs["a"], regs["l"], regs["t"]])
+        if has_work:
+            args.append(regs["w"])
+        state = np.array(cudaq.get_state(harness, *args))
+
+        out, phase = _apply(kind, refs, regs)
+        expected = np.zeros(1 << num_qubits, dtype=np.complex128)
+        index = sum(out[reg] << off for reg, off in offsets.items())
+        expected[index] = phase
+        np.testing.assert_allclose(
+            state, expected, atol=1e-12,
+            err_msg=(f"opcode {opcode} (ctrl={controlled}, work={has_work}) "
+                     f"wrong on input {regs}"))
+
+
+def test_mint_rejects_out_of_set_opcodes():
+    # A work opcode on a no-work tape (and a control opcode on an
+    # uncontrolled tape) must be a loud mint-time error: the dispatch
+    # loop would silently skip it.
+    with pytest.raises(ValueError, match="outside the interpreter"):
+        _mint_interpreter([(_OP_AND_TT, 0, 1, 1)],
+                          controlled=False,
+                          has_work=False)
+    with pytest.raises(ValueError, match="outside the interpreter"):
+        _mint_interpreter([(_OP_CCX_CTRL, 0, 1, 1)],
+                          controlled=False,
+                          has_work=True)
+    with pytest.raises(ValueError, match="outside the interpreter"):
+        _mint_interpreter([(_OP_BODY_Z_W, 0, 1, 0)],
+                          controlled=True,
+                          has_work=False)
+
+
+def test_opcode_sets_cover_the_specs():
+    # The spec table above and the module's declared dispatch sets must
+    # name exactly the same opcodes — a new opcode must land in both.
+    spec_ops = {spec[0] for spec in _SPECS.values()}
+    assert spec_ops == (_BASE_OPS | _CONTROL_OPS | _WORK_OPS)

--- a/tests/python/test_primitives_payload_sum.py
+++ b/tests/python/test_primitives_payload_sum.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Large-payload SELECT semantics: sum over superposed addresses.
+
+The walker's other tests use one-gate bodies. Here each address carries a
+random multi-gate Pauli sequence on a 6-qubit target — non-commuting,
+phase-carrying (Y contributes ``+/-i``) — and the address register enters
+in a phased superposition, so one application must produce
+
+    sum_k  a_k |k> (x) |ladder=0> (x) U_k |psi>
+
+with every ``U_k`` built independently in NumPy as a dense 64x64 product
+of embedded Paulis. Any leaf-line error, ordering error, or phase error
+in the walk misassembles the sum; any ladder residue leaks amplitude out
+of the ``ladder=0`` block.
+
+The Toffoli contract rides along: Pauli payloads are leaf-controlled
+two-qubit gates, so the walk's Toffoli count must NOT grow with payload
+size — the structural formula holds and the compiler agrees.
+
+The file parametrizes over every walker importable on the current
+branch: the coherent fused walk always, the measured (MBU) walk when its
+module is present. One file, both branches, no rebase conflict.
+"""
+
+import functools
+
+import numpy as np
+import pytest
+
+import cudaq
+
+from cudaq_algorithms.primitives import unary_iteration_kernels
+
+_WALKERS = [("coherent", unary_iteration_kernels)]
+try:
+    from cudaq_algorithms.primitives import measured_unary_iteration_kernels
+    _WALKERS.append(("measured", measured_unary_iteration_kernels))
+except ImportError:
+    pass
+
+_NUM_TARGET = 6
+_PAULI = {
+    "x": np.array([[0, 1], [1, 0]], dtype=np.complex128),
+    "y": np.array([[0, -1j], [1j, 0]], dtype=np.complex128),
+    "z": np.array([[1, 0], [0, -1]], dtype=np.complex128),
+}
+_ID = np.eye(2, dtype=np.complex128)
+
+
+def _random_payloads(num_items, rng):
+    """Per-address random Pauli sequences on the 6-qubit target."""
+    payloads = []
+    for _ in range(num_items):
+        length = int(rng.integers(3, 7))
+        payloads.append([(("x", "y", "z")[int(rng.integers(3))],
+                          int(rng.integers(_NUM_TARGET)))
+                         for _ in range(length)])
+    return payloads
+
+
+def _embed(gate, qubit):
+    """Single-qubit Pauli embedded on the 6-qubit target, qubit 0 = LSB."""
+    factors = [_PAULI[gate] if i == qubit else _ID for i in range(_NUM_TARGET)]
+    return functools.reduce(np.kron, reversed(factors))
+
+
+def _dense_unitary(payload):
+    """Dense 64x64 product of the payload, applied in list order."""
+    unitary = np.eye(1 << _NUM_TARGET, dtype=np.complex128)
+    for gate, qubit in payload:
+        unitary = _embed(gate, qubit) @ unitary
+    return unitary
+
+
+def _target_state(rng):
+    """Random product state on the target, complex amplitudes."""
+    state = np.ones(1, dtype=np.complex128)
+    angles = []
+    for _ in range(_NUM_TARGET):
+        theta = float(rng.uniform(0.2, 2.9))
+        phi = float(rng.uniform(0.1, 6.2))
+        angles.append((theta, phi))
+        # cudaq rz(phi) = diag(e^{-i phi/2}, e^{+i phi/2}) — keep the
+        # half-angle phases so the comparison is exact, not up-to-phase.
+        qubit = np.array([
+            np.exp(-0.5j * phi) * np.cos(theta / 2.0),
+            np.exp(+0.5j * phi) * np.sin(theta / 2.0)
+        ])
+        state = np.kron(qubit, state)  # new qubit is the higher bit
+    return state, angles
+
+
+@pytest.mark.parametrize("walker_name,walker",
+                         _WALKERS,
+                         ids=[name for name, _ in _WALKERS])
+@pytest.mark.parametrize("num_bits,num_items", [(3, 8), (4, 16), (4, 11)])
+def test_superposed_address_sum_with_multiqubit_payloads(
+        num_bits, num_items, walker_name, walker):
+    rng = np.random.default_rng(1000 * num_bits + num_items)
+    payloads = _random_payloads(num_items, rng)
+    walk = walker(num_bits,
+                  num_items,
+                  lambda k: payloads[k],
+                  include_adjoint=False)
+    kernel = walk.kernel
+    target_state, target_angles = _target_state(rng)
+    address_phases = [float(rng.uniform(0.1, 3.0)) for _ in range(num_bits)]
+    thetas = [a[0] for a in target_angles]
+    phis = [a[1] for a in target_angles]
+
+    @cudaq.kernel
+    def harness():
+        address_reg = cudaq.qvector(num_bits)
+        ladder = cudaq.qvector(num_bits)
+        target = cudaq.qvector(_NUM_TARGET)
+        for i in range(num_bits):
+            h(address_reg[i])
+            rz(address_phases[i], address_reg[i])
+        for i in range(_NUM_TARGET):
+            ry(thetas[i], target[i])
+            rz(phis[i], target[i])
+        kernel(address_reg, ladder, target)
+
+    state = np.array(cudaq.get_state(harness))
+
+    # Reference: address amplitude a_k from the phased uniform prep
+    # (rz(phi)|+> = (e^{-i phi/2}|0> + e^{+i phi/2}|1>)/sqrt(2)); the
+    # target picks up U_k on the address-k branch; ladder ends |0>.
+    dim = 1 << (num_bits + num_bits + _NUM_TARGET)
+    expected = np.zeros(dim, dtype=np.complex128)
+    for k in range(1 << num_bits):
+        amplitude = 1.0 + 0.0j
+        for i in range(num_bits):
+            bit = (k >> i) & 1
+            sign = 1.0 if bit else -1.0
+            amplitude *= np.exp(sign * 0.5j * address_phases[i]) / np.sqrt(2)
+        unitary = _dense_unitary(payloads[k]) if k < num_items else np.eye(
+            1 << _NUM_TARGET, dtype=np.complex128)
+        block = amplitude * (unitary @ target_state)
+        base = k  # address bits are the global LSBs; ladder block is 0
+        stride = 1 << (2 * num_bits)
+        for t in range(1 << _NUM_TARGET):
+            expected[base + t * stride] = block[t]
+
+    np.testing.assert_allclose(state, expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("walker_name,walker",
+                         _WALKERS,
+                         ids=[name for name, _ in _WALKERS])
+def test_payload_size_does_not_change_toffoli_count(walker_name, walker):
+    # Leaf-controlled Paulis are two-qubit gates: the Toffoli count is a
+    # property of the walk structure alone. A 6-gate-per-address payload
+    # must cost exactly as many Toffolis as a 1-gate payload — pinned
+    # against both the emitter and the compiler.
+    rng = np.random.default_rng(7)
+    payloads = _random_payloads(8, rng)
+    small = walker(3, 8, lambda k: [("x", 0)], include_adjoint=False)
+    large = walker(3, 8, lambda k: payloads[k], include_adjoint=False)
+    assert large.toffoli_count == small.toffoli_count
+
+    if not hasattr(cudaq, "estimate_resources"):
+        pytest.skip("cudaq.estimate_resources is not available")
+    kernel = large.kernel
+
+    @cudaq.kernel
+    def harness():
+        address_reg = cudaq.qvector(3)
+        ladder = cudaq.qvector(3)
+        target = cudaq.qvector(_NUM_TARGET)
+        kernel(address_reg, ladder, target)
+
+    resources = cudaq.estimate_resources(harness)
+    assert resources.count_controls("x", 2) == large.toffoli_count

--- a/tests/python/test_primitives_payload_sum.py
+++ b/tests/python/test_primitives_payload_sum.py
@@ -17,10 +17,6 @@ of the ``ladder=0`` block.
 The Toffoli contract rides along: Pauli payloads are leaf-controlled
 two-qubit gates, so the walk's Toffoli count must NOT grow with payload
 size — the structural formula holds and the compiler agrees.
-
-The file parametrizes over every walker importable on the current
-branch: the coherent fused walk always, the measured (MBU) walk when its
-module is present. One file, both branches, no rebase conflict.
 """
 
 import functools
@@ -33,11 +29,6 @@ import cudaq
 from cudaq_algorithms.primitives import unary_iteration_kernels
 
 _WALKERS = [("coherent", unary_iteration_kernels)]
-try:
-    from cudaq_algorithms.primitives import measured_unary_iteration_kernels
-    _WALKERS.append(("measured", measured_unary_iteration_kernels))
-except ImportError:
-    pass
 
 _NUM_TARGET = 6
 _PAULI = {

--- a/tests/python/test_primitives_qrom.py
+++ b/tests/python/test_primitives_qrom.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the QROM lookup (select and select_swap variants).
+
+Correctness is pinned exhaustively: for random tables every address is
+read out via basis-state extraction (`cudaq.get_state`), including the
+out-of-range addresses of non-power-of-two tables (which must read
+zero), for both constructions. Both variants are exactly self-inverse —
+that property is tested on superposed addresses instead of a duplicate
+adjoint kernel — and the SELECT-SWAP lookup is checked to be
+behaviorally identical to the plain unary-iteration lookup on the same
+table (equal (address, output) amplitudes with the clean ancillas traced
+as |0>).
+"""
+
+import numpy as np
+import pytest
+
+import cudaq
+
+from cudaq_algorithms.primitives import QROM
+
+
+def _basis(index: int, num_qubits: int) -> np.ndarray:
+    ket = np.zeros(1 << num_qubits, dtype=np.complex128)
+    ket[index] = 1.0
+    return ket
+
+
+# Register layout in the harnesses: address at [0, A), ladder at
+# [A, A + L), output at [A + L, A + L + W) — so the expected state on
+# reading address k is the basis vector k + (data[k] << (A + L)), the
+# ladder having returned to 0.
+
+
+def _qrom_readout_state(qrom: QROM, address: int) -> np.ndarray:
+    lookup = qrom.kernel()
+    num_address = qrom.num_address
+    num_ladder = qrom.num_ladder
+    num_output = qrom.num_output
+
+    @cudaq.kernel
+    def run():
+        address_reg = cudaq.qvector(num_address)
+        ladder = cudaq.qvector(num_ladder)
+        output = cudaq.qvector(num_output)
+        for b in range(num_address):
+            if ((address >> b) & 1) == 1:
+                x(address_reg[b])
+        lookup(address_reg, ladder, output)
+
+    return np.array(cudaq.get_state(run))
+
+
+def _exhaustive_readout(qrom: QROM, data):
+    total = qrom.num_address + qrom.num_ladder + qrom.num_output
+    shift = qrom.num_address + qrom.num_ladder
+    for address in range(1 << qrom.num_address):
+        # Out-of-range addresses of a short table must read zero.
+        expected_word = data[address] if address < len(data) else 0
+        state = _qrom_readout_state(qrom, address)
+        expected = _basis(address + (expected_word << shift), total)
+        np.testing.assert_allclose(state, expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("address_bits,num_entries", [(1, 2), (2, 4), (2, 3),
+                                                      (3, 8), (3, 5), (4, 16),
+                                                      (4, 11)])
+@pytest.mark.parametrize("output_bits", [1, 3, 6])
+def test_qrom_select_exhaustive_readout(address_bits, num_entries,
+                                        output_bits):
+    rng = np.random.default_rng(7 * address_bits + num_entries + output_bits)
+    data = [int(v) for v in rng.integers(0, 1 << output_bits, num_entries)]
+    qrom = QROM(data, address_bits, output_bits, variant="select")
+    assert qrom.variant == "select"
+    assert qrom.num_ladder == address_bits
+    _exhaustive_readout(qrom, data)
+
+
+@pytest.mark.parametrize("address_bits,num_entries,output_bits,block_size",
+                         [(2, 4, 3, 2), (2, 3, 3, 2), (3, 8, 2, 2),
+                          (3, 5, 2, 2), (3, 8, 1, 4), (4, 16, 1, 4),
+                          (4, 11, 1, 2), (4, 9, 1, 8)])
+def test_qrom_select_swap_exhaustive_readout(address_bits, num_entries,
+                                             output_bits, block_size):
+    rng = np.random.default_rng(3 * address_bits + num_entries + block_size)
+    data = [int(v) for v in rng.integers(0, 1 << output_bits, num_entries)]
+    qrom = QROM(data,
+                address_bits,
+                output_bits,
+                variant="select_swap",
+                block_size=block_size)
+    assert qrom.variant == "select_swap"
+    assert qrom.block_size == block_size
+    low_bits = block_size.bit_length() - 1
+    assert qrom.num_ladder == (address_bits - low_bits +
+                               block_size * output_bits)
+    _exhaustive_readout(qrom, data)
+
+
+@pytest.mark.parametrize("variant,block_size", [("select", None),
+                                                ("select_swap", 2)])
+def test_qrom_is_self_inverse(variant, block_size):
+    # X-only write phase: applying the lookup twice XORs the table twice
+    # (and the select_swap sandwich W S C S^-1 W squares to identity).
+    # Run on all addresses at once (H on the address) with a non-zero
+    # initial output word to pin |y XOR d XOR d> = |y>.
+    data = [5, 3, 0, 6, 7]
+    qrom = QROM(data,
+                address_bits=3,
+                output_bits=3,
+                variant=variant,
+                block_size=block_size)
+    lookup = qrom.kernel()
+    num_ladder = qrom.num_ladder
+    initial = 0b101
+
+    @cudaq.kernel
+    def run():
+        address_reg = cudaq.qvector(3)
+        ladder = cudaq.qvector(num_ladder)
+        output = cudaq.qvector(3)
+        for b in range(3):
+            h(address_reg[b])
+            if ((initial >> b) & 1) == 1:
+                x(output[b])
+        lookup(address_reg, ladder, output)
+        lookup(address_reg, ladder, output)
+
+    total = 3 + num_ladder + 3
+    state = np.array(cudaq.get_state(run))
+    expected = np.zeros(1 << total, dtype=np.complex128)
+    for address in range(8):
+        expected[address + (initial << (3 + num_ladder))] = 1.0 / np.sqrt(8.0)
+    np.testing.assert_allclose(state, expected, atol=1e-12)
+
+
+def test_qrom_select_swap_equals_select_on_superposed_addresses():
+    # Same table through both constructions: the (address, output)
+    # amplitudes must agree exactly, the ancillas being |0> in both.
+    data = [3, 0, 5, 6, 1, 7]
+    address_bits, output_bits = 3, 3
+
+    def joint_amplitudes(qrom: QROM) -> np.ndarray:
+        lookup = qrom.kernel()
+        num_ladder = qrom.num_ladder
+
+        @cudaq.kernel
+        def run():
+            address_reg = cudaq.qvector(address_bits)
+            ladder = cudaq.qvector(num_ladder)
+            output = cudaq.qvector(output_bits)
+            for b in range(address_bits):
+                h(address_reg[b])
+            lookup(address_reg, ladder, output)
+
+        state = np.array(cudaq.get_state(run))
+        tensor = state.reshape(1 << output_bits, 1 << num_ladder,
+                               1 << address_bits)
+        # Ancillas must be exactly |0>.
+        np.testing.assert_allclose(np.delete(tensor, 0, axis=1),
+                                   0.0,
+                                   atol=1e-12)
+        return tensor[:, 0, :]
+
+    select = QROM(data, address_bits, output_bits, variant="select")
+    swap = QROM(data,
+                address_bits,
+                output_bits,
+                variant="select_swap",
+                block_size=2)
+    np.testing.assert_allclose(joint_amplitudes(select),
+                               joint_amplitudes(swap),
+                               atol=1e-12)
+
+
+def test_qrom_auto_dispatch_picks_the_cheaper_variant():
+    # Big table, narrow output: routing is cheap, the block walk is a
+    # fraction of the full walk -> select_swap wins.
+    wide = QROM(list(range(2)) * 32, 6, 1)
+    assert wide.variant == "select_swap"
+    assert wide.block_size is not None
+    # Tiny table, wide output: every swapped register costs output_bits
+    # Toffolis per direction -> the plain walk wins.
+    narrow = QROM([200, 3, 118, 25], 2, 8)
+    assert narrow.variant == "select"
+    assert narrow.block_size is None
+    # Whatever auto picks must be priced no worse than the alternatives.
+    for block_size in (2, 4, 8, 16, 32):
+        forced = QROM(list(range(2)) * 32,
+                      6,
+                      1,
+                      variant="select_swap",
+                      block_size=block_size)
+        assert wide.toffoli_count <= forced.toffoli_count
+    assert wide.toffoli_count <= QROM(list(range(2)) * 32,
+                                      6,
+                                      1,
+                                      variant="select").toffoli_count
+
+
+def test_qrom_select_swap_default_block_size_is_cost_optimal():
+    data = [int(v) for v in np.arange(32) % 4]
+    auto_block = QROM(data, 5, 2, variant="select_swap")
+    assert auto_block.block_size is not None
+    for block_size in (2, 4, 8, 16):
+        forced = QROM(data, 5, 2, variant="select_swap", block_size=block_size)
+        assert auto_block.toffoli_count <= forced.toffoli_count
+
+
+def test_qrom_toffoli_count_bound():
+    data = list(range(16))
+    qrom = QROM(data, address_bits=4, output_bits=4, variant="select")
+    assert 0 < qrom.toffoli_count <= 2 * (len(data) - 1)
+    short = QROM(data[:5], address_bits=4, output_bits=4, variant="select")
+    assert short.toffoli_count < qrom.toffoli_count
+
+
+def test_qrom_validation_raises():
+    with pytest.raises(ValueError, match="data must be non-empty"):
+        QROM([], address_bits=2, output_bits=2)
+    with pytest.raises(ValueError, match="addresses only 4"):
+        QROM([1] * 5, address_bits=2, output_bits=2)
+    with pytest.raises(ValueError, match="non-negative"):
+        QROM([1, -2], address_bits=1, output_bits=2)
+    with pytest.raises(ValueError, match="does not fit in output_bits"):
+        QROM([1, 4], address_bits=1, output_bits=2)
+    with pytest.raises(ValueError, match="address_bits must be a positive"):
+        QROM([1], address_bits=0, output_bits=1)
+    with pytest.raises(ValueError, match="output_bits must be a positive"):
+        QROM([1], address_bits=1, output_bits=0)
+    with pytest.raises(ValueError, match="entries must be integers"):
+        QROM([1.5], address_bits=1, output_bits=2)
+    with pytest.raises(ValueError, match="variant must be one of"):
+        QROM([1, 2], address_bits=1, output_bits=2, variant="qroam")
+    with pytest.raises(ValueError, match="only valid with variant="):
+        QROM([1, 2], address_bits=1, output_bits=2, block_size=2)
+    with pytest.raises(ValueError, match="power of two"):
+        QROM([1] * 8,
+             address_bits=3,
+             output_bits=1,
+             variant="select_swap",
+             block_size=3)
+    with pytest.raises(ValueError, match="at least one block-index"):
+        QROM([1] * 8,
+             address_bits=3,
+             output_bits=1,
+             variant="select_swap",
+             block_size=8)

--- a/tests/python/test_primitives_qrom.py
+++ b/tests/python/test_primitives_qrom.py
@@ -34,7 +34,7 @@ def _basis(index: int, num_qubits: int) -> np.ndarray:
 
 
 def _qrom_readout_state(qrom: QROM, address: int) -> np.ndarray:
-    lookup = qrom.kernel()
+    lookup = qrom.kernel
     num_address = qrom.num_address
     num_ladder = qrom.num_ladder
     num_output = qrom.num_output
@@ -111,7 +111,7 @@ def test_qrom_is_self_inverse(variant, block_size):
                 output_bits=3,
                 variant=variant,
                 block_size=block_size)
-    lookup = qrom.kernel()
+    lookup = qrom.kernel
     num_ladder = qrom.num_ladder
     initial = 0b101
 
@@ -142,7 +142,7 @@ def test_qrom_select_swap_equals_select_on_superposed_addresses():
     address_bits, output_bits = 3, 3
 
     def joint_amplitudes(qrom: QROM) -> np.ndarray:
-        lookup = qrom.kernel()
+        lookup = qrom.kernel
         num_ladder = qrom.num_ladder
 
         @cudaq.kernel
@@ -231,6 +231,15 @@ def test_qrom_validation_raises():
         QROM([1], address_bits=1, output_bits=0)
     with pytest.raises(ValueError, match="entries must be integers"):
         QROM([1.5], address_bits=1, output_bits=2)
+    # A single-pass iterable must get the same float rejection as a list
+    # (regression: the check once ran on an already-exhausted iterator).
+    with pytest.raises(ValueError, match="entries must be integers"):
+        QROM((v for v in [1.5, 2]), address_bits=1, output_bits=2)
+    with pytest.raises(ValueError, match="requires address_bits >= 2"):
+        QROM([1, 2], address_bits=1, output_bits=2, variant="select_swap")
+    # ... and a valid single-pass iterable must load fully.
+    assert QROM((v for v in [1, 2]), address_bits=1,
+                output_bits=2).data == (1, 2)
     with pytest.raises(ValueError, match="variant must be one of"):
         QROM([1, 2], address_bits=1, output_bits=2, variant="qroam")
     with pytest.raises(ValueError, match="only valid with variant="):

--- a/tests/python/test_primitives_qrom.py
+++ b/tests/python/test_primitives_qrom.py
@@ -216,6 +216,20 @@ def test_qrom_toffoli_count_bound():
     assert short.toffoli_count < qrom.toffoli_count
 
 
+def test_qrom_select_single_address_bit():
+    # Regression for cuda-quantum#5280: a one-address-bit select lookup
+    # has a Toffoli-free walk, so the interpreter's Toffoli dispatch arm
+    # is classically dead — and CUDA-Q's CSE aliased the dead arm's
+    # control/target wires into illegal IR (an infinite compiler loop
+    # through 0.15, a hard compile error once fixed upstream). Dispatch
+    # pruning removes the dead arm at mint time; this pins that the
+    # minted lookup constructs and reads out correctly.
+    data = [5, 2]
+    qrom = QROM(data, address_bits=1, output_bits=3, variant="select")
+    assert qrom.toffoli_count == 0
+    _exhaustive_readout(qrom, data)
+
+
 def test_qrom_validation_raises():
     with pytest.raises(ValueError, match="data must be non-empty"):
         QROM([], address_bits=2, output_bits=2)

--- a/tests/python/test_primitives_resources.py
+++ b/tests/python/test_primitives_resources.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compiler-pinned Toffoli costs of the primitives.
+
+The fused unary-iteration walk documents an exact unitary Toffoli count
+(``3 N / 2 - 5`` on full uncontrolled trees of ``N >= 8`` addresses,
+``3 N / 2 - 1`` controlled) and QROM documents an exact price for each
+variant. These tests hold those claims against the compiler rather than
+the emitter: ``cudaq.estimate_resources`` counts the ``ccx`` operations
+actually synthesized, which (a) must equal the emitter's bookkeeping —
+a multi-control expansion or a decomposition surprise would break the
+equality — and (b) must equal the documented closed forms, with the
+per-doubling *increment* (not the ratio: affine costs approach their
+asymptote from above) making the O(N) scaling directly visible.
+
+The papers' headline counts (``N - 1`` for unary iteration in
+arXiv:1805.03662, ``ceil(N/B) + b (B - 1)`` for QROAM in
+arXiv:1812.00954) assume measurement-based ancilla uncomputation; the
+strictly unitary counts pinned here are the honest coherent prices.
+
+``estimate_resources`` traces the kernel without executing it, so no
+simulator target or tolerance is involved; every assertion is an exact
+integer comparison.
+"""
+
+import cudaq
+import pytest
+
+from cudaq_algorithms.primitives import QROM, unary_iteration_kernels
+from cudaq_algorithms.primitives._unary_iteration import _walk_toffoli_count
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(cudaq, "estimate_resources"),
+    reason="cudaq.estimate_resources is not available in this CUDA-Q")
+
+
+def _compiled_toffolis_of(kernel, *widths) -> int:
+    """Compile a harness allocating the given register widths and count
+    the synthesized Toffolis."""
+    num_registers = len(widths)
+    padded = list(widths) + [1] * (4 - num_registers)
+    # Unpack to scalars before defining the kernel (no container capture).
+    w0, w1, w2, w3 = padded
+
+    if num_registers == 3:
+
+        @cudaq.kernel
+        def harness():
+            r0 = cudaq.qvector(w0)
+            r1 = cudaq.qvector(w1)
+            r2 = cudaq.qvector(w2)
+            kernel(r0, r1, r2)
+    else:
+
+        @cudaq.kernel
+        def harness():
+            r0 = cudaq.qvector(w0)
+            r1 = cudaq.qvector(w1)
+            r2 = cudaq.qvector(w2)
+            r3 = cudaq.qvector(w3)
+            kernel(r0, r1, r2, r3)
+
+    resources = cudaq.estimate_resources(harness)
+    # A Toffoli is an x with two controls; ``count_controls`` is the
+    # arity-aware accessor (``count("ccx")`` matches nothing — the
+    # display name is not the lookup key and returns 0).
+    return resources.count_controls("x", 2)
+
+
+def _walk_toffolis(num_address_bits: int, num_items: int,
+                   controlled: bool) -> tuple[int, int]:
+    """Return (emitter toffoli_count, compiler ccx count) for one walk."""
+    walk = unary_iteration_kernels(num_address_bits,
+                                   num_items,
+                                   lambda k: [("x", 0)],
+                                   controlled=controlled,
+                                   include_adjoint=False)
+    if controlled:
+        compiled = _compiled_toffolis_of(walk.kernel, 1, num_address_bits,
+                                         num_address_bits, 1)
+    else:
+        compiled = _compiled_toffolis_of(walk.kernel, num_address_bits,
+                                         num_address_bits, 1)
+    return walk.toffoli_count, compiled
+
+
+@pytest.mark.parametrize("num_address_bits,num_items", [(2, 4), (3, 8), (3, 5),
+                                                        (4, 16), (4, 11),
+                                                        (2, 1)])
+@pytest.mark.parametrize("controlled", [False, True])
+def test_compiled_toffolis_match_emitter_count(num_address_bits, num_items,
+                                               controlled):
+    # The emitter's cost accounting is only trustworthy if the compiler
+    # synthesizes exactly the Toffolis it claims to emit.
+    claimed, compiled = _walk_toffolis(num_address_bits, num_items, controlled)
+    assert compiled == claimed
+    assert claimed == _walk_toffoli_count(num_address_bits, num_items,
+                                          controlled)
+
+
+def test_full_tree_walk_cost_is_the_documented_closed_form():
+    # Headline: the fused walk costs exactly 3N/2 - 5 Toffolis on a full
+    # uncontrolled tree of N >= 8 addresses (2 at N = 4, 0 at N = 2) and
+    # 3N/2 - 1 controlled — compiler-counted, not emitter-claimed. The
+    # paper's N - 1 (arXiv:1805.03662 Fig. 7) prices AND uncomputation
+    # via measurement; unitarily, exhaustive circuit search shows these
+    # counts are optimal at the small sizes it can cover.
+    assert _walk_toffolis(1, 2, controlled=False)[1] == 0
+    assert _walk_toffolis(2, 4, controlled=False)[1] == 2
+    for num_address_bits in (3, 4, 5, 6):
+        capacity = 1 << num_address_bits
+        assert (_walk_toffolis(num_address_bits, capacity,
+                               controlled=False)[1] == 3 * capacity // 2 - 5)
+    for num_address_bits in (1, 2, 3, 4, 5):
+        capacity = 1 << num_address_bits
+        assert (_walk_toffolis(num_address_bits, capacity,
+                               controlled=True)[1] == 3 * capacity // 2 - 1)
+
+
+def test_walk_cost_grows_linearly_per_doubling():
+    # O(N) via increments: the cost is affine (3N/2 - 5), so the
+    # doubling *ratio* approaches 3/2 from above — the increment is the
+    # robust check and is exactly 3N/2 additional Toffolis per doubling.
+    compiled = {}
+    for num_address_bits in (3, 4, 5, 6):
+        num_items = 1 << num_address_bits
+        compiled[num_items] = _walk_toffolis(num_address_bits,
+                                             num_items,
+                                             controlled=False)[1]
+    for num_items in (8, 16, 32):
+        increment = compiled[2 * num_items] - compiled[num_items]
+        assert increment == 3 * num_items // 2, (
+            f"doubling N from {num_items} added {increment} Toffolis "
+            f"(expected exactly {3 * num_items // 2}): {compiled}")
+
+
+def test_partial_tree_costs_no_more_than_full():
+    # Skipped addresses are never entered: a partial tree cannot cost
+    # more Toffolis than the full tree.
+    full = _walk_toffolis(4, 16, controlled=False)[1]
+    partial = _walk_toffolis(4, 11, controlled=False)[1]
+    assert partial < full
+
+
+@pytest.mark.parametrize("variant,block_size", [("select", None),
+                                                ("select_swap", 2),
+                                                ("select_swap", 4)])
+def test_qrom_compiled_toffolis_match_emitter_count(variant, block_size):
+    data = [3, 0, 5, 6, 1, 7, 2, 2, 4, 1, 6]
+    qrom = QROM(data,
+                address_bits=4,
+                output_bits=3,
+                variant=variant,
+                block_size=block_size)
+    compiled = _compiled_toffolis_of(qrom.kernel(), qrom.num_address,
+                                     qrom.num_ladder, qrom.num_output)
+    assert compiled == qrom.toffoli_count
+
+
+def test_qrom_select_swap_cost_matches_documented_formula():
+    # Documented contract: 2 W(high_bits, num_blocks) + 2 b (B - 1),
+    # every controlled register swap being b Fredkins (one Toffoli each)
+    # and both the block writes and the routing running twice (compute +
+    # unitary uncompute).
+    data = list(range(2)) * 16
+    for block_size in (2, 4, 8):
+        qrom = QROM(data,
+                    address_bits=5,
+                    output_bits=1,
+                    variant="select_swap",
+                    block_size=block_size)
+        low_bits = block_size.bit_length() - 1
+        num_blocks = -(-len(data) // block_size)
+        expected = (2 * _walk_toffoli_count(5 - low_bits, num_blocks) + 2 * 1 *
+                    (block_size - 1))
+        assert qrom.toffoli_count == expected
+        compiled = _compiled_toffolis_of(qrom.kernel(), qrom.num_address,
+                                         qrom.num_ladder, qrom.num_output)
+        assert compiled == expected
+
+
+def test_qrom_auto_picks_the_cheaper_side_of_the_crossover():
+    # Above the crossover (large table, narrow output) select_swap must
+    # win and beat the plain walk...
+    data = [int(v) % 2 for v in range(64)]
+    auto = QROM(data, 6, 1)
+    select = QROM(data, 6, 1, variant="select")
+    assert auto.variant == "select_swap"
+    assert auto.toffoli_count < select.toffoli_count
+    # ...and below it (small table, wide output) the plain walk wins.
+    data = [200, 3, 118, 25]
+    auto = QROM(data, 2, 8)
+    swapped = QROM(data, 2, 8, variant="select_swap")
+    assert auto.variant == "select"
+    assert auto.toffoli_count < swapped.toffoli_count

--- a/tests/python/test_primitives_resources.py
+++ b/tests/python/test_primitives_resources.py
@@ -152,7 +152,7 @@ def test_qrom_compiled_toffolis_match_emitter_count(variant, block_size):
                 output_bits=3,
                 variant=variant,
                 block_size=block_size)
-    compiled = _compiled_toffolis_of(qrom.kernel(), qrom.num_address,
+    compiled = _compiled_toffolis_of(qrom.kernel, qrom.num_address,
                                      qrom.num_ladder, qrom.num_output)
     assert compiled == qrom.toffoli_count
 
@@ -174,7 +174,7 @@ def test_qrom_select_swap_cost_matches_documented_formula():
         expected = (2 * _walk_toffoli_count(5 - low_bits, num_blocks) + 2 * 1 *
                     (block_size - 1))
         assert qrom.toffoli_count == expected
-        compiled = _compiled_toffolis_of(qrom.kernel(), qrom.num_address,
+        compiled = _compiled_toffolis_of(qrom.kernel, qrom.num_address,
                                          qrom.num_ladder, qrom.num_output)
         assert compiled == expected
 

--- a/tests/python/test_primitives_unary_iteration.py
+++ b/tests/python/test_primitives_unary_iteration.py
@@ -21,9 +21,10 @@ import pytest
 import cudaq
 
 from cudaq_algorithms.primitives import unary_iteration_kernels
-from cudaq_algorithms.primitives._unary_iteration import (_TOFFOLI_OPCODES,
-                                                          _emit_walk,
-                                                          _walk_toffoli_count)
+from cudaq_algorithms.primitives._unary_iteration import (
+    _OP_BODY_X, _OP_CCX, _OP_CCX_ADDR_ADDR, _OP_CCX_CTRL, _OP_CX_ADDR_ADDR,
+    _OP_CX_ADDR_LADDER, _OP_CX_CTRL_LADDER, _OP_CX_LADDER_LADDER, _OP_X_ADDR,
+    _OP_X_LADDER, _TOFFOLI_OPCODES, _emit_walk, _walk_toffoli_count)
 
 
 def _basis(index: int, num_qubits: int) -> np.ndarray:
@@ -60,17 +61,18 @@ def _verify_tape(num_bits: int, num_items: int, controlled: bool):
     original = list(address)
     bodies_seen = 0
     for opcode, a, b, c in ops:
-        if opcode == 0:
+        if opcode == _OP_X_ADDR:
             address[a] ^= full
-        elif opcode == 1:
+        elif opcode == _OP_X_LADDER:
             ladder[a] ^= full
-        elif opcode == 2:
+        elif opcode == _OP_CX_ADDR_LADDER:
             ladder[b] ^= address[a]
-        elif opcode == 3:
+        elif opcode == _OP_CX_LADDER_LADDER:
             ladder[b] ^= ladder[a]
-        elif opcode == 4:
+        elif opcode == _OP_CCX:
             ladder[c] ^= ladder[a] & address[b]
-        elif opcode == 5:  # the body marker: leaf line must be [addr == k]
+        elif opcode == _OP_BODY_X:
+            # The body marker: leaf line must be [addr == k].
             expected = 0
             for point in range(npoints):
                 active = (point & ((1 << num_bits) - 1)) == bodies_seen
@@ -83,13 +85,13 @@ def _verify_tape(num_bits: int, num_items: int, controlled: bool):
                 f"indicator (bits={num_bits}, items={num_items}, "
                 f"controlled={controlled})")
             bodies_seen += 1
-        elif opcode == 8:
+        elif opcode == _OP_CX_CTRL_LADDER:
             ladder[b] ^= control
-        elif opcode == 9:
+        elif opcode == _OP_CCX_CTRL:
             ladder[c] ^= control & address[b]
-        elif opcode == 18:
+        elif opcode == _OP_CX_ADDR_ADDR:
             address[b] ^= address[a]
-        elif opcode == 19:
+        elif opcode == _OP_CCX_ADDR_ADDR:
             ladder[c] ^= address[a] & address[b]
         else:
             raise AssertionError(f"unexpected opcode {opcode} in walk tape")

--- a/tests/python/test_primitives_unary_iteration.py
+++ b/tests/python/test_primitives_unary_iteration.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the fused unary-iteration walk.
+
+Two layers of evidence. The emitted instruction tape is verified
+*classically and exhaustively* (every address width up to 6, every
+partial-tree size, controlled and uncontrolled) by tracking each ladder
+line as a Boolean truth table over the address bits: at every body slot
+the leaf line must be the exact address-``k`` indicator, and at the end
+the ladder must be zero and the address wires restored — that is the
+full circuit identity "walk == SELECT". The minted kernels are then
+pinned on the statevector: per-address phase kicks (including partial
+trees), the Y-body sign convention, the hand-written inverse against
+non-commuting bodies, and the externally controlled variant at |0> and
+|1>.
+"""
+
+import numpy as np
+import pytest
+
+import cudaq
+
+from cudaq_algorithms.primitives import unary_iteration_kernels
+from cudaq_algorithms.primitives._unary_iteration import (_TOFFOLI_OPCODES,
+                                                          _emit_walk,
+                                                          _walk_toffoli_count)
+
+
+def _basis(index: int, num_qubits: int) -> np.ndarray:
+    ket = np.zeros(1 << num_qubits, dtype=np.complex128)
+    ket[index] = 1.0
+    return ket
+
+
+# ----------------------------------------------------------------------
+# Classical truth-table verification of the emitted tape
+# ----------------------------------------------------------------------
+
+
+def _verify_tape(num_bits: int, num_items: int, controlled: bool):
+    """Track every wire as a truth table over the (control +) address
+    bits; body markers are injected through a body that emits a plain
+    ("x", 0) so their tape positions are recoverable."""
+    marker = [("x", 0)]
+    ops = _emit_walk(num_bits, num_items, controlled, lambda k: marker)
+    num_inputs = num_bits + (1 if controlled else 0)
+    npoints = 1 << num_inputs
+    full = (1 << npoints) - 1
+
+    def input_wire(i):
+        table = 0
+        for point in range(npoints):
+            if (point >> i) & 1:
+                table |= 1 << point
+        return table
+
+    address = [input_wire(i) for i in range(num_bits)]
+    control = input_wire(num_bits) if controlled else 0
+    ladder = [0] * num_bits
+    original = list(address)
+    bodies_seen = 0
+    for opcode, a, b, c in ops:
+        if opcode == 0:
+            address[a] ^= full
+        elif opcode == 1:
+            ladder[a] ^= full
+        elif opcode == 2:
+            ladder[b] ^= address[a]
+        elif opcode == 3:
+            ladder[b] ^= ladder[a]
+        elif opcode == 4:
+            ladder[c] ^= ladder[a] & address[b]
+        elif opcode == 5:  # the body marker: leaf line must be [addr == k]
+            expected = 0
+            for point in range(npoints):
+                active = (point & ((1 << num_bits) - 1)) == bodies_seen
+                if controlled and not ((point >> num_bits) & 1):
+                    active = False
+                if active:
+                    expected |= 1 << point
+            assert ladder[a] == expected, (
+                f"body({bodies_seen}): leaf line is not the address "
+                f"indicator (bits={num_bits}, items={num_items}, "
+                f"controlled={controlled})")
+            bodies_seen += 1
+        elif opcode == 8:
+            ladder[b] ^= control
+        elif opcode == 9:
+            ladder[c] ^= control & address[b]
+        elif opcode == 18:
+            address[b] ^= address[a]
+        elif opcode == 19:
+            ladder[c] ^= address[a] & address[b]
+        else:
+            raise AssertionError(f"unexpected opcode {opcode} in walk tape")
+    assert bodies_seen == num_items
+    assert address == original, "address wires not restored"
+    assert all(line == 0 for line in ladder), "ladder not returned to |0>"
+    return sum(1 for op in ops if op[0] in _TOFFOLI_OPCODES)
+
+
+@pytest.mark.parametrize("controlled", [False, True])
+def test_tape_is_select_for_every_tree_shape(controlled):
+    # Exhaustive: every width up to 6 and every partial-tree size.
+    for num_bits in range(1, 7):
+        for num_items in range(1, (1 << num_bits) + 1):
+            _verify_tape(num_bits, num_items, controlled)
+
+
+def test_tape_toffoli_counts_match_documented_formulas():
+    # Fused-walk headline: 3N/2 - 5 uncontrolled (N >= 8; 2 at N = 4,
+    # 0 at N = 2) and 3N/2 - 1 controlled, on full trees. The paper's
+    # N - 1 (arXiv:1805.03662) assumes measurement-based uncomputation;
+    # these are the strictly unitary counts.
+    for num_bits in range(1, 8):
+        capacity = 1 << num_bits
+        counted = _verify_tape(num_bits, capacity, False)
+        assert counted == _walk_toffoli_count(num_bits, capacity, False)
+        if num_bits >= 3:
+            assert counted == 3 * capacity // 2 - 5
+        counted = _verify_tape(num_bits, capacity, True)
+        assert counted == _walk_toffoli_count(num_bits, capacity, True)
+        assert counted == 3 * capacity // 2 - 1
+        # Partial trees: the analytic counter matches the tape exactly.
+        for num_items in range(1, capacity + 1):
+            assert (_verify_tape(num_bits, num_items,
+                                 False) == _walk_toffoli_count(
+                                     num_bits, num_items, False))
+
+
+# ----------------------------------------------------------------------
+# Statevector pinning of the minted kernels
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("num_items,marked", [(8, (1, 3, 4)), (5, (0, 4)),
+                                              (1, (0, ))])
+def test_unary_iteration_phase_kick_per_address(num_items, marked):
+    # body(k) = Z on a |1> target for marked addresses: a uniform address
+    # superposition picks up a -1 phase exactly on those addresses.
+    walk = unary_iteration_kernels(3, num_items, lambda k: [("z", 0)]
+                                   if k in marked else [])
+    kernel = walk.kernel
+
+    @cudaq.kernel
+    def run():
+        address_reg = cudaq.qvector(3)
+        ladder = cudaq.qvector(3)
+        target = cudaq.qvector(1)
+        x(target[0])
+        for b in range(3):
+            h(address_reg[b])
+        kernel(address_reg, ladder, target)
+
+    state = np.array(cudaq.get_state(run))
+    expected = np.zeros(1 << 7, dtype=np.complex128)
+    for address in range(8):
+        sign = -1.0 if address in marked else 1.0
+        expected[address + (1 << 6)] = sign / np.sqrt(8.0)
+    np.testing.assert_allclose(state, expected, atol=1e-12)
+
+
+def test_unary_iteration_y_body_sign_convention():
+    # body(2) = Y on target 0: |2>|0> -> i |2>|1>; other addresses idle.
+    walk = unary_iteration_kernels(2, 4, lambda k: [("y", 0)]
+                                   if k == 2 else [])
+    kernel = walk.kernel
+
+    def run_state(address: int) -> np.ndarray:
+
+        @cudaq.kernel
+        def run():
+            address_reg = cudaq.qvector(2)
+            ladder = cudaq.qvector(2)
+            target = cudaq.qvector(1)
+            for b in range(2):
+                if ((address >> b) & 1) == 1:
+                    x(address_reg[b])
+            kernel(address_reg, ladder, target)
+
+        return np.array(cudaq.get_state(run))
+
+    expected = np.zeros(1 << 5, dtype=np.complex128)
+    expected[2 + (1 << 4)] = 1.0j
+    np.testing.assert_allclose(run_state(2), expected, atol=1e-12)
+    np.testing.assert_allclose(run_state(1), _basis(1, 5), atol=1e-12)
+
+
+def test_unary_iteration_matches_dense_select_reference():
+    # Independent dense reference: SELECT = sum_k |k><k| (x) U_k (+
+    # identity on unvisited addresses), built from NumPy Pauli matrices.
+    # Multi-gate bodies on two targets, partial tree.
+    paulis = {
+        "x": np.array([[0, 1], [1, 0]], dtype=np.complex128),
+        "y": np.array([[0, -1j], [1j, 0]], dtype=np.complex128),
+        "z": np.array([[1, 0], [0, -1]], dtype=np.complex128),
+    }
+    bodies = {
+        0: [("x", 0), ("y", 1)],
+        1: [("z", 0)],
+        2: [("y", 0), ("x", 1), ("z", 1)],
+        4: [("x", 1)],
+    }
+    num_items = 5
+    walk = unary_iteration_kernels(3, num_items, lambda k: bodies.get(k, []))
+    kernel = walk.kernel
+    identity = np.eye(4, dtype=np.complex128)
+
+    def body_matrix(k: int) -> np.ndarray:
+        matrix = identity
+        for gate, t in bodies.get(k, []):
+            op = [np.eye(2, dtype=np.complex128)] * 2
+            op[t] = paulis[gate]
+            # qubit 0 = LSB: rightmost Kronecker factor.
+            matrix = np.kron(op[1], op[0]) @ matrix
+        return matrix
+
+    # Column extraction: every (address, target) basis input against the
+    # matching dense-reference column.
+    for address in range(8):
+        for column in range(4):
+
+            @cudaq.kernel
+            def run():
+                address_reg = cudaq.qvector(3)
+                ladder = cudaq.qvector(3)
+                target = cudaq.qvector(2)
+                for b in range(3):
+                    if ((address >> b) & 1) == 1:
+                        x(address_reg[b])
+                for b in range(2):
+                    if ((column >> b) & 1) == 1:
+                        x(target[b])
+                kernel(address_reg, ladder, target)
+
+            state = np.array(cudaq.get_state(run))
+            expected = np.zeros(1 << 8, dtype=np.complex128)
+            reference = (body_matrix(address)
+                         if address < num_items else identity)[:, column]
+            for t in range(4):
+                expected[address + (t << 6)] = reference[t]
+            np.testing.assert_allclose(state, expected, atol=1e-12)
+
+
+def test_unary_iteration_adjoint_composes_to_identity():
+    # Non-commuting multi-gate bodies (X, Z, Y mixed) so the walk is NOT
+    # an involution; only the hand-written reversed-instruction inverse
+    # restores the state.
+    def body(k):
+        if k % 2 == 1:
+            return [("x", 0), ("z", 0), ("y", 1)]
+        return [("x", 1)]
+
+    walk = unary_iteration_kernels(3, 6, body)
+    kernel = walk.kernel
+    kernel_adj = walk.kernel_adj
+
+    @cudaq.kernel
+    def run():
+        address_reg = cudaq.qvector(3)
+        ladder = cudaq.qvector(3)
+        target = cudaq.qvector(2)
+        x(target[0])
+        for b in range(3):
+            h(address_reg[b])
+        kernel(address_reg, ladder, target)
+        kernel_adj(address_reg, ladder, target)
+
+    state = np.array(cudaq.get_state(run))
+    expected = np.zeros(1 << 8, dtype=np.complex128)
+    for address in range(8):
+        expected[address + (1 << 6)] = 1.0 / np.sqrt(8.0)
+    np.testing.assert_allclose(state, expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("control_value", [0, 1])
+def test_unary_iteration_controlled_variant(control_value):
+    marked = (1, 2)
+    walk = unary_iteration_kernels(2,
+                                   4,
+                                   lambda k: [("z", 0)] if k in marked else [],
+                                   controlled=True)
+    kernel = walk.kernel
+    assert walk.controlled
+
+    @cudaq.kernel
+    def run():
+        control = cudaq.qvector(1)
+        address_reg = cudaq.qvector(2)
+        ladder = cudaq.qvector(2)
+        target = cudaq.qvector(1)
+        if control_value == 1:
+            x(control[0])
+        x(target[0])
+        for b in range(2):
+            h(address_reg[b])
+        kernel(control, address_reg, ladder, target)
+
+    state = np.array(cudaq.get_state(run))
+    expected = np.zeros(1 << 6, dtype=np.complex128)
+    for address in range(4):
+        kicked = control_value == 1 and address in marked
+        sign = -1.0 if kicked else 1.0
+        # Layout: control at 0, address at [1, 3), ladder [3, 5), target 5.
+        expected[control_value + (address << 1) + (1 << 5)] = \
+            sign / 2.0
+    np.testing.assert_allclose(state, expected, atol=1e-12)
+
+
+def test_unary_iteration_validation_raises():
+    body = lambda k: []
+    with pytest.raises(ValueError, match="num_address_bits must be a"):
+        unary_iteration_kernels(0, 1, body)
+    with pytest.raises(ValueError, match=r"num_items must be an integer in"):
+        unary_iteration_kernels(2, 0, body)
+    with pytest.raises(ValueError, match=r"num_items must be an integer in"):
+        unary_iteration_kernels(2, 5, body)
+    with pytest.raises(ValueError, match="unsupported gate 'q'"):
+        unary_iteration_kernels(2, 4, lambda k: [("q", 0)])
+    with pytest.raises(ValueError, match="invalid target qubit index"):
+        unary_iteration_kernels(2, 4, lambda k: [("x", -1)])

--- a/tests/python/test_primitives_unary_iteration.py
+++ b/tests/python/test_primitives_unary_iteration.py
@@ -247,7 +247,11 @@ def test_unary_iteration_matches_dense_select_reference():
 def test_unary_iteration_adjoint_composes_to_identity():
     # Non-commuting multi-gate bodies (X, Z, Y mixed) so the walk is NOT
     # an involution; only the hand-written reversed-instruction inverse
-    # restores the state.
+    # restores the state. With U_odd = Y1 Z0 X0, (Z X)^2 = -I, so a
+    # kernel_adj that secretly replayed the FORWARD tape would leave a
+    # -1 phase on the odd addresses — visible against the superposed
+    # address register. The involution=False premise is asserted first,
+    # so this test cannot silently degrade into a self-inverse check.
     def body(k):
         if k % 2 == 1:
             return [("x", 0), ("z", 0), ("y", 1)]
@@ -258,7 +262,7 @@ def test_unary_iteration_adjoint_composes_to_identity():
     kernel_adj = walk.kernel_adj
 
     @cudaq.kernel
-    def run():
+    def run(use_adjoint: bool):
         address_reg = cudaq.qvector(3)
         ladder = cudaq.qvector(3)
         target = cudaq.qvector(2)
@@ -266,17 +270,30 @@ def test_unary_iteration_adjoint_composes_to_identity():
         for b in range(3):
             h(address_reg[b])
         kernel(address_reg, ladder, target)
-        kernel_adj(address_reg, ladder, target)
+        if use_adjoint:
+            kernel_adj(address_reg, ladder, target)
+        else:
+            kernel(address_reg, ladder, target)
 
-    state = np.array(cudaq.get_state(run))
     expected = np.zeros(1 << 8, dtype=np.complex128)
     for address in range(8):
         expected[address + (1 << 6)] = 1.0 / np.sqrt(8.0)
+
+    # Premise: forward-forward is NOT the identity (the walk is not an
+    # involution for this body), so the identity below is non-vacuous.
+    twice = np.array(cudaq.get_state(run, False))
+    assert np.abs(twice - expected).max() > 0.5
+
+    state = np.array(cudaq.get_state(run, True))
     np.testing.assert_allclose(state, expected, atol=1e-12)
 
 
-@pytest.mark.parametrize("control_value", [0, 1])
-def test_unary_iteration_controlled_variant(control_value):
+# theta = 0 and pi pin the classical branches; 0.7 puts the control in
+# genuine superposition, where a phase error between the branches (the
+# failure mode measurement-based uncomputation would introduce) is
+# invisible to the classical cases but breaks the amplitude comparison.
+@pytest.mark.parametrize("theta", [0.0, np.pi, 0.7])
+def test_unary_iteration_controlled_variant(theta):
     marked = (1, 2)
     walk = unary_iteration_kernels(2,
                                    4,
@@ -286,26 +303,27 @@ def test_unary_iteration_controlled_variant(control_value):
     assert walk.controlled
 
     @cudaq.kernel
-    def run():
+    def run(angle: float):
         control = cudaq.qvector(1)
         address_reg = cudaq.qvector(2)
         ladder = cudaq.qvector(2)
         target = cudaq.qvector(1)
-        if control_value == 1:
-            x(control[0])
+        ry(angle, control[0])
         x(target[0])
         for b in range(2):
             h(address_reg[b])
         kernel(control, address_reg, ladder, target)
 
-    state = np.array(cudaq.get_state(run))
+    state = np.array(cudaq.get_state(run, theta))
+    amp = (np.cos(theta / 2), np.sin(theta / 2))
     expected = np.zeros(1 << 6, dtype=np.complex128)
-    for address in range(4):
-        kicked = control_value == 1 and address in marked
-        sign = -1.0 if kicked else 1.0
-        # Layout: control at 0, address at [1, 3), ladder [3, 5), target 5.
-        expected[control_value + (address << 1) + (1 << 5)] = \
-            sign / 2.0
+    for control_bit in range(2):
+        for address in range(4):
+            kicked = control_bit == 1 and address in marked
+            sign = -1.0 if kicked else 1.0
+            # Layout: control at 0, address [1, 3), ladder [3, 5), target 5.
+            expected[control_bit + (address << 1) + (1 << 5)] = \
+                sign * amp[control_bit] / 2.0
     np.testing.assert_allclose(state, expected, atol=1e-12)
 
 

--- a/tests/python/test_primitives_unary_iteration.py
+++ b/tests/python/test_primitives_unary_iteration.py
@@ -319,3 +319,16 @@ def test_unary_iteration_validation_raises():
         unary_iteration_kernels(2, 4, lambda k: [("q", 0)])
     with pytest.raises(ValueError, match="invalid target qubit index"):
         unary_iteration_kernels(2, 4, lambda k: [("x", -1)])
+
+
+def test_describe_decodes_the_tape():
+    # describe() is the human-readable form of the minted circuit: its
+    # Toffoli-tagged lines must agree with toffoli_count, and the body
+    # gates must appear once per address, in address order.
+    walk = unary_iteration_kernels(2, 4, lambda k: [("x", 0)])
+    text = walk.describe()
+    lines = text.splitlines()
+    assert lines[0].startswith("unary-iteration walk: 4 addresses")
+    assert sum("# Toffoli" in line for line in lines) == walk.toffoli_count
+    body_lines = [line for line in lines if line.startswith("x(target[0])")]
+    assert len(body_lines) == 4


### PR DESCRIPTION
## Summary

Adds the first primitives to `cudaq_algorithms.primitives`:

- Unary iteration for applying an address-dependent operation
- QROM for coherent table lookup

These primitives provide the foundation for the THC block encoding and future SELECT-style constructions.

All implementations in this PR are strictly unitary. They use no mid-circuit measurement or classical feedback, compose under `cudaq.control`, and support CUDA-Q sampling, statevector, and observable workflows.

## Unary iteration

Adds `unary_iteration_kernels`, a factory for constructing address-controlled operations from a callback that emits the operation for each address.

The default fused walker updates the unary ladder in place instead of uncomputing and recomputing it. For a complete sweep over `N` addresses, this reduces the Toffoli count from `2N - 4` for the conventional compute/uncompute construction to `3N/2 - 5`.

The controlled construction uses `3N/2 - 1` Toffolis.

This is the strictly unitary select(V) walk of Childs et al. (arXiv:1711.10980, Appendix G.4, Lemma G.7); the lower `N - 1` unary-iteration count of Babbush et al. (arXiv:1805.03662) requires measurement-based uncomputation (Gidney, arXiv:1709.06648), which this PR deliberately excludes.

The factory also provides:

- Explicit inverse kernels
- `cudaq.control` compatibility
- `describe()` output for inspecting generated operations
- Analytical `toffoli_count` bookkeeping verified against compiled circuits

## QROM

Adds:

```python
QROM(data, address_bits, output_bits)
```

with two lookup strategies:

- `select`: lookup using unary iteration
- `select_swap`: SELECT-SWAP/QROAM using clean block ancillas

With `variant="auto"`, QROM evaluates the available strategies and selects the lowest-cost variant and block size for the supplied table dimensions.

### Example resource costs

For a 10-bit address register and `N = 1024`:

| Construction | Toffolis |
|---|---:|
| Conventional unary walker | 2044 |
| Fused unary walker | 1531 |
| QROM `select` | 1531 |
| QROM `select_swap`, 8-bit output | 422 |
| QROM `select_swap`, 16-bit output | 598 |

All reported counts are checked against the compiled circuits using `cudaq.estimate_resources`.

## Validation

The tests cover:

- Exhaustive unary-iteration truth tables through six address bits
- All supported unary tree shapes
- Dense statevector references
- Random QROM tables
- Power-of-two and non-power-of-two table sizes
- Both QROM strategies
- Automatic strategy and block-size selection around crossover points
- Multi-qubit, noncommuting SELECT payloads
- Phased-superposition address states
- Forward and inverse circuit behavior
- Equality between analytical and compiler-reported Toffoli counts

Test result at the current branch tip:

```text
391 passed, 3 skipped
```

## References

- Babbush et al., [arXiv:1805.03662](https://arxiv.org/abs/1805.03662)
- Gidney, [arXiv:1709.06648](https://arxiv.org/abs/1709.06648)
- Low, Kliuchnikov, and Schaeffer, [arXiv:1812.00954](https://arxiv.org/abs/1812.00954)
