### PR TITLE
Bump the cuda-quantum pin past the nanobind 3 breakage

### DIFF
--- a/.cudaq_version
+++ b/.cudaq_version
@@ -1,6 +1,6 @@
 {
   "cudaq": {
     "repository": "NVIDIA/cuda-quantum",
-    "ref": "2a7911fca1265b869c6c4e623111f345c5e7267c"
+    "ref": "b28cf0f6f2d9387f12ca81b6824b8833a38530af"
   }
 }


### PR DESCRIPTION
The from-source CUDA-Q wheel builds (Custom mode / PR CI) fail on any cache miss: nanobind 3.x broke the MLIR python-bindings stage, and our pinned ref (2a7911f, Jul 23) predates upstream's fix. cuda-quantum pinned `nanobind<3` in b28cf0f (NVIDIA/cuda-quantum#5234, Aug 23); this advances our `.cudaq_version` to that commit.

First seen on #40, whose four `Build CUDA-Q wheels` lanes hit a cold cache after the runner-image migration (Node 24) evicted the old caches — the failure is infrastructure rot, unrelated to that PR's content. Once this merges, re-running #40's checks should go green.

Heads-up worth passing along: cudaqx pins cuda-quantum at 28f195f (Aug 7), which also predates the fix — same time bomb on their next cache miss.