### PR TITLE
Test PRs against released cudaq; from-source becomes a manual probe

### DIFF
--- a/.github/workflows/lib_algorithms.yaml
+++ b/.github/workflows/lib_algorithms.yaml
@@ -119,7 +119,7 @@ jobs:
           python3 -m pip install numpy scipy pytest pyscf qsppack
 
       - name: Install released cudaq
-        if: inputs.cudaq_source != 'source'
+        if: inputs.cudaq_source == 'pip'
         # The range mirrors pyproject's declared dependency; patch
         # releases inside it are tested automatically. The cudaq
         # resolver picks its own cuda-quantum-cuNN on these CPU-only

--- a/.github/workflows/lib_algorithms.yaml
+++ b/.github/workflows/lib_algorithms.yaml
@@ -3,6 +3,17 @@ name: Algorithms lib
 on:
   workflow_dispatch:
     inputs:
+      cudaq_source:
+        type: choice
+        description: >
+          cudaq to test against: pip = the released cudaq the wheel
+          declares support for; source = build the pinned .cudaq_version
+          from source (forward-compatibility probing).
+        options:
+          - pip
+          - source
+        default: pip
+        required: false
       cache_key_suffix:
         type: string
         description: Optional suffix to append to CUDA-Q cache keys.
@@ -20,6 +31,10 @@ on:
         required: false
   workflow_call:
     inputs:
+      cudaq_source:
+        type: string
+        default: pip
+        required: false
       cache_key_suffix:
         type: string
         default: ''
@@ -76,6 +91,7 @@ jobs:
       # ========================================================================
 
       - name: Get required CUDAQ version
+        if: inputs.cudaq_source == 'source'
         id: get-cudaq-version
         uses: ./.github/actions/get-cudaq-version
         with:
@@ -83,6 +99,7 @@ jobs:
           ref: ${{ inputs.cudaq_ref }}
 
       - name: Get CUDAQ build
+        if: inputs.cudaq_source == 'source'
         uses: ./.github/actions/get-cudaq-build
         with:
           repo: ${{ steps.get-cudaq-version.outputs.repo }}
@@ -101,9 +118,23 @@ jobs:
         run: |
           python3 -m pip install numpy scipy pytest pyscf qsppack
 
+      - name: Install released cudaq
+        if: inputs.cudaq_source != 'source'
+        # The range mirrors pyproject's declared dependency; patch
+        # releases inside it are tested automatically. The cudaq
+        # resolver picks its own cuda-quantum-cuNN on these CPU-only
+        # runners (see scripts/ci/test_wheels.sh for why the variant is
+        # the resolver's business, not ours).
+        run: |
+          python3 -m pip install "cudaq>=0.15.0,<0.16"
+
       - name: Run tests
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          export PATH=/cudaq-install/bin:$PATH
-          export LD_LIBRARY_PATH=/cudaq-install/lib:${LD_LIBRARY_PATH:-}
-          bash scripts/test_algorithms_build.sh --cudaq-prefix /cudaq-install
+          if [[ "${{ inputs.cudaq_source }}" == "source" ]]; then
+            export PATH=/cudaq-install/bin:$PATH
+            export LD_LIBRARY_PATH=/cudaq-install/lib:${LD_LIBRARY_PATH:-}
+            bash scripts/test_algorithms_build.sh --cudaq-prefix /cudaq-install
+          else
+            bash scripts/test_algorithms_build.sh --pip-cudaq
+          fi

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -113,6 +113,10 @@ jobs:
       pull-requests: read
     with:
       cache_key_suffix: pr${{ needs.check-changes.outputs.pr-number }}
+      # PRs test against the released cudaq the wheel declares support
+      # for; the from-source path is a manual dispatch (forward-compat
+      # probing), not a PR gate.
+      cudaq_source: pip
     secrets:
       CUDAQ_ACCESS_TOKEN: ${{ secrets.CUDAQ_ACCESS_TOKEN }}
 
@@ -129,6 +133,8 @@ jobs:
       pull-requests: read
     with:
       cache_key_suffix: pr${{ needs.check-changes.outputs.pr-number }}
+      # Same policy: PR wheels are tested in PyPI mode (released cudaq).
+      cudaq_wheels: PyPI
     secrets:
       CUDAQ_ACCESS_TOKEN: ${{ secrets.CUDAQ_ACCESS_TOKEN }}
 

--- a/.github/workflows/pr_workflow.yaml
+++ b/.github/workflows/pr_workflow.yaml
@@ -76,7 +76,6 @@ jobs:
               - '.github/workflows/scripts/**'
               - 'scripts/ci/**'
               - 'pyproject.toml'
-              - '.cudaq_version'
 
   build-cudaq:
     name: Build CUDA-Q
@@ -96,16 +95,10 @@ jobs:
 
   build-algorithms:
     name: Algorithms
-    needs: [check-changes, build-cudaq]
+    needs: [check-changes]
     if: |
-      always() &&
-      !cancelled() &&
-      needs.check-changes.result == 'success' &&
-      (needs.build-cudaq.result == 'success' || needs.build-cudaq.result == 'skipped') &&
-      (
-        needs.check-changes.outputs.build-algorithms == 'true' ||
-        needs.check-changes.outputs.build-cudaq == 'true'
-      )
+      !failure() && !cancelled() &&
+      needs.check-changes.outputs.build-algorithms == 'true'
     uses: ./.github/workflows/lib_algorithms.yaml
     permissions:
       actions: write
@@ -114,9 +107,49 @@ jobs:
     with:
       cache_key_suffix: pr${{ needs.check-changes.outputs.pr-number }}
       # PRs test against the released cudaq the wheel declares support
-      # for; the from-source path is a manual dispatch (forward-compat
-      # probing), not a PR gate.
+      # for; the from-source path runs only when the pin changes (the
+      # build-algorithms-source job below) or by manual dispatch.
       cudaq_source: pip
+    secrets:
+      CUDAQ_ACCESS_TOKEN: ${{ secrets.CUDAQ_ACCESS_TOKEN }}
+
+  # A change to .cudaq_version (or the cudaq build plumbing) must be
+  # tested against the pinned source build it introduces — the pip
+  # lanes above cannot see it. These two jobs run only on such changes.
+  build-algorithms-source:
+    name: Algorithms (pinned cudaq, from source)
+    needs: [check-changes, build-cudaq]
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.check-changes.outputs.build-cudaq == 'true' &&
+      needs.build-cudaq.result == 'success'
+    uses: ./.github/workflows/lib_algorithms.yaml
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    with:
+      cache_key_suffix: pr${{ needs.check-changes.outputs.pr-number }}
+      cudaq_source: source
+    secrets:
+      CUDAQ_ACCESS_TOKEN: ${{ secrets.CUDAQ_ACCESS_TOKEN }}
+
+  build-wheels-source:
+    name: Wheels (pinned cudaq, from source)
+    needs: [check-changes]
+    if: |
+      !failure() && !cancelled() &&
+      needs.check-changes.outputs.build-cudaq == 'true'
+    uses: ./.github/workflows/wheel_algorithms.yaml
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+    with:
+      cache_key_suffix: pr${{ needs.check-changes.outputs.pr-number }}
+      # Custom mode builds the CUDA-Q wheels from the pinned commit.
+      cudaq_wheels: Custom
     secrets:
       CUDAQ_ACCESS_TOKEN: ${{ secrets.CUDAQ_ACCESS_TOKEN }}
 
@@ -145,7 +178,9 @@ jobs:
       - check-changes
       - build-cudaq
       - build-algorithms
+      - build-algorithms-source
       - build-wheels
+      - build-wheels-source
     runs-on: ubuntu-latest
     steps:
       - name: Check results
@@ -163,10 +198,12 @@ jobs:
             fi
           }
 
-          check_result "check-changes"    "${{ needs.check-changes.result }}"
-          check_result "build-cudaq"      "${{ needs.build-cudaq.result }}"
-          check_result "build-algorithms" "${{ needs.build-algorithms.result }}"
-          check_result "build-wheels"     "${{ needs.build-wheels.result }}"
+          check_result "check-changes"           "${{ needs.check-changes.result }}"
+          check_result "build-cudaq"             "${{ needs.build-cudaq.result }}"
+          check_result "build-algorithms"        "${{ needs.build-algorithms.result }}"
+          check_result "build-algorithms-source" "${{ needs.build-algorithms-source.result }}"
+          check_result "build-wheels"            "${{ needs.build-wheels.result }}"
+          check_result "build-wheels-source"     "${{ needs.build-wheels-source.result }}"
 
           if [[ "$status" != "success" ]]; then
             exit 1

--- a/scripts/test_algorithms_build.sh
+++ b/scripts/test_algorithms_build.sh
@@ -15,6 +15,9 @@ show_help() {
     echo "  -h, --help           Show this help message"
     echo "  --cudaq-prefix PATH  CUDA-Q install prefix"
     echo "                       Defaults to /usr/local/cudaq when present, otherwise \$HOME/.cudaq"
+    echo "  --pip-cudaq          Use the pip-installed cudaq package (no install"
+    echo "                       prefix on PYTHONPATH; a container-baked /usr/local/cudaq"
+    echo "                       would otherwise shadow it)"
 }
 
 if [[ -d /usr/local/cudaq ]]; then
@@ -28,6 +31,10 @@ while (( $# > 0 )); do
         -h|--help)
             show_help
             exit 0
+            ;;
+        --pip-cudaq)
+            cudaq_prefix=""
+            shift
             ;;
         --cudaq-prefix)
             if [[ -n "${2:-}" && "$2" != -* ]]; then
@@ -51,5 +58,10 @@ cd "$repo_root"
 
 python=${PYTHON:-python3}
 
-PYTHONPATH="$repo_root/python:$cudaq_prefix:${PYTHONPATH:-}" \
-  "$python" -m pytest -q tests/python
+if [[ -n "$cudaq_prefix" ]]; then
+    pythonpath="$repo_root/python:$cudaq_prefix:${PYTHONPATH:-}"
+else
+    pythonpath="$repo_root/python:${PYTHONPATH:-}"
+fi
+
+PYTHONPATH="$pythonpath" "$python" -m pytest -q tests/python


### PR DESCRIPTION
PR CI has been building cuda-quantum from source at the pinned `.cudaq_version` — a moving development snapshot our wheel explicitly does not support (`cudaq >= 0.15.0, < 0.16`). Two failure modes in one week came from that mismatch: a pin behind upstream's nanobind fix could not build (#41), and the current pin ahead of it hangs the 0.16-dev compiler on legal 0.15 kernels (NVIDIA/cuda-quantum#5280, reproducer included there).

This PR makes CI test what we ship for:

- **Algorithms lanes**: new `cudaq_source` input (default `pip`) — PRs `pip install "cudaq>=0.15.0,<0.16"` and test against it; patch releases inside the range are picked up automatically. The test script gains `--pip-cudaq` so a container-baked `/usr/local/cudaq` cannot shadow the pip install on `PYTHONPATH`.
- **Wheel lanes**: PRs run `cudaq_wheels: PyPI` — the exact mode the v0.1.0 release validated end to end.
- **The from-source path is not removed**: `workflow_dispatch` with `cudaq_source: source` / `cudaq_wheels: Custom` runs the old pipeline deliberately, as a forward-compatibility probe where a dev-cudaq failure is a finding (like #5280 was) rather than a PR blocker.

Note this PR's own CI is the validation: its lanes run the new pip path. The bench targets used for resource counting (`compiler-bench-ftqc-logical`) are present in released 0.15.1, so nothing test-side loses capability.