### PR TITLE
fix: Probe CuPy with a real kernel and collect CuPy DF tests only on nvidia simulator

### DIFF
--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -61,11 +61,13 @@ def resolve_backend(backend: str = "auto",
                     gpu_min_size: int = 0) -> tuple[ArrayModule, str]:
     """Return ``(array_module, name)`` for the requested backend.
 
-    ``"auto"`` selects CuPy when a GPU is available *and* the problem is large
-    enough to amortize GPU launch/sync overhead -- i.e. ``problem_size`` (the
-    orbital count ``n``) is at least ``gpu_min_size`` -- otherwise NumPy. With no
-    ``problem_size`` hint it keeps the legacy behavior: CuPy whenever a GPU is
-    present. ``"cupy"`` / ``"numpy"`` force the backend regardless of size.
+    ``"auto"`` selects CuPy when the problem is large enough to amortize GPU
+    launch/sync overhead -- i.e. ``problem_size`` (the orbital count ``n``) is
+    at least ``gpu_min_size`` -- *and* a GPU is available; otherwise NumPy. The
+    size check is evaluated first so a below-threshold problem does not create
+    a CUDA context. With no ``problem_size`` hint it keeps the legacy behavior:
+    CuPy whenever a GPU is present. ``"cupy"`` / ``"numpy"`` force the backend
+    regardless of size.
     """
     if backend == "numpy":
         return np, "numpy"
@@ -75,8 +77,8 @@ def resolve_backend(backend: str = "auto",
                                "CuPy/GPU is available.")
         return _cupy, "cupy"
     if backend == "auto":
-        if cupy_gpu_available() and (problem_size is None
-                                     or problem_size >= gpu_min_size):
+        if ((problem_size is None or problem_size >= gpu_min_size)
+                and cupy_gpu_available()):
             return _cupy, "cupy"
         return np, "numpy"
     raise ValueError(f"unknown backend '{backend}'; expected 'auto', 'cupy', "

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -75,8 +75,10 @@ def resolve_backend(backend: str = "auto",
         return np, "numpy"
     if backend == "cupy":
         if not cupy_gpu_available():
-            raise RuntimeError("the 'cupy' backend was requested but no "
-                               "CuPy/GPU is available.")
+            raise RuntimeError(
+                "the 'cupy' backend was requested but CuPy/GPU is not "
+                "usable (not installed, no device, or the kernel probe "
+                "failed).")
         return _cupy, "cupy"
     if backend == "auto":
         if ((problem_size is None or problem_size >= gpu_min_size)

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -43,14 +43,16 @@ def cupy_gpu_available() -> bool:
 
     ``getDeviceCount`` only talks to the driver, so a driver-only install
     (no NVRTC / CUDA toolkit) would otherwise look usable and then fail on
-    the first compiled kernel. The tiny ``arange`` forces that compile.
+    the first compiled kernel. The tiny ``arange`` forces that compile, and
+    ``.sum()`` into a host ``float`` waits for the device so a fault that
+    only appears at synchronization is not missed.
     """
     if _cupy is None:
         return False
     try:
         if _cupy.cuda.runtime.getDeviceCount() <= 0:
             return False
-        _cupy.arange(1) + 1
+        float((_cupy.arange(1) + 1).sum())
         return True
     except Exception:  # pragma: no cover - driver/runtime/NVRTC issues
         return False

--- a/python/cudaq_algorithms/double_factorization/_backend.py
+++ b/python/cudaq_algorithms/double_factorization/_backend.py
@@ -39,12 +39,20 @@ AUTO_GPU_MIN_ORBITALS_EXPLICIT = 56
 
 
 def cupy_gpu_available() -> bool:
-    """Return True when CuPy is importable and at least one GPU is visible."""
+    """Return True when CuPy can run a kernel on a visible GPU.
+
+    ``getDeviceCount`` only talks to the driver, so a driver-only install
+    (no NVRTC / CUDA toolkit) would otherwise look usable and then fail on
+    the first compiled kernel. The tiny ``arange`` forces that compile.
+    """
     if _cupy is None:
         return False
     try:
-        return _cupy.cuda.runtime.getDeviceCount() > 0
-    except Exception:  # pragma: no cover - driver/runtime issues
+        if _cupy.cuda.runtime.getDeviceCount() <= 0:
+            return False
+        _cupy.arange(1) + 1
+        return True
+    except Exception:  # pragma: no cover - driver/runtime/NVRTC issues
         return False
 
 

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -13,11 +13,14 @@ os.environ.setdefault("OMP_NUM_THREADS", "1")
 
 df = algorithms.double_factorization
 
-# NumPy always. CuPy only on the GPU simulator leg (nvidia*), never under
-# qpp-cpu: these tests are classical linear algebra, and a dead GPU must not
-# be reported as a CPU-simulator failure.
+# NumPy always. CuPy when the GPU simulator leg is nvidia*, or when the
+# kernel probe passes: these tests are classical linear algebra, so a
+# working GPU must still be covered on a qpp-cpu / unset dev box. A dead
+# GPU on nvidia* is collected then skipped at call time (visible skip);
+# a dead GPU on qpp-cpu fails the probe and is not collected.
 _BACKENDS = ["numpy"]
-if os.environ.get("CUDAQ_DEFAULT_SIMULATOR", "qpp-cpu").startswith("nvidia"):
+if (os.environ.get("CUDAQ_DEFAULT_SIMULATOR", "qpp-cpu").startswith("nvidia")
+        or df.cupy_gpu_available()):
     _BACKENDS.append("cupy")
 
 

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -261,14 +261,21 @@ def test_cg_accelerators_preserve_accuracy(backend):
             df.factorization_error(eri, plain)) < 1.0e-4
 
 
-def test_auto_backend_is_size_aware():
+def test_auto_backend_is_size_aware(monkeypatch):
     from cudaq_algorithms.double_factorization._backend import resolve_backend
+    import cudaq_algorithms.double_factorization._backend as B
     # Explicit choices are honored regardless of size.
     assert resolve_backend("numpy")[1] == "numpy"
-    # A tiny problem under the GPU threshold always resolves to NumPy (whether or
-    # not a GPU is present): below the crossover the GPU loses.
+
+    # A tiny problem under the GPU threshold always resolves to NumPy, and
+    # must not run the kernel probe (that would pin a CUDA context).
+    def _must_not_probe():
+        raise AssertionError("kernel probe ran for a below-threshold auto")
+
+    monkeypatch.setattr(B, "cupy_gpu_available", _must_not_probe)
     assert resolve_backend("auto", problem_size=4, gpu_min_size=1000)[1] \
         == "numpy"
+    monkeypatch.undo()
     # A large problem resolves to CuPy when a GPU is present, else NumPy.
     expected = "cupy" if df.cupy_gpu_available() else "numpy"
     assert resolve_backend("auto", problem_size=10000, gpu_min_size=1)[1] \

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -13,10 +13,23 @@ os.environ.setdefault("OMP_NUM_THREADS", "1")
 
 df = algorithms.double_factorization
 
-# Run every test on the NumPy backend, plus the CuPy (GPU) backend when present.
+# NumPy always. CuPy only on the GPU simulator leg (nvidia*), never under
+# qpp-cpu: these tests are classical linear algebra, and a dead GPU must not
+# be reported as a CPU-simulator failure.
 _BACKENDS = ["numpy"]
-if df.cupy_gpu_available():
+if os.environ.get("CUDAQ_DEFAULT_SIMULATOR", "qpp-cpu").startswith("nvidia"):
     _BACKENDS.append("cupy")
+
+
+@pytest.fixture(autouse=True)
+def _skip_cupy_if_unusable(request):
+    # Call-time skip so a device that disappears after collection is a skip
+    # with a reason, not a failure.
+    params = getattr(getattr(request.node, "callspec", None), "params", None)
+    if not params or params.get("backend") != "cupy":
+        return
+    if not df.cupy_gpu_available():
+        pytest.skip("CuPy/GPU is not usable")
 
 
 def _synthetic_eri(n, num_vectors, seed):
@@ -610,3 +623,63 @@ def test_cdf_objective_is_a_function_of_x(backend, inner_solver, monkeypatch):
     # once the warm start is keyed by x rather than by call order.
     assert replay["df"] < 1.0e-12
     assert replay["dg"] < 1.0e-9
+
+
+def _enumerating_but_dead_cupy(monkeypatch):
+    # QA-6 / RT-A: getDeviceCount is fine, the first compiled kernel is not.
+    import cudaq_algorithms.double_factorization._backend as B
+    import cudaq_algorithms.double_factorization._factorization as F
+
+    class _DeadCuPy:
+        ndarray = type("_DeadCuPyNdArray", (), {})
+
+        class cuda:
+
+            class runtime:
+
+                @staticmethod
+                def getDeviceCount():
+                    return 2
+
+        @staticmethod
+        def arange(*args, **kwargs):
+            raise RuntimeError("cudaErrorDevicesUnavailable: CUDA-capable "
+                               "device(s) is/are busy or unavailable")
+
+    monkeypatch.setattr(B, "_cupy", _DeadCuPy)
+    # n=4 is below both real crossovers; drop them so auto would pick CuPy
+    # if the probe still trusted getDeviceCount alone.
+    monkeypatch.setattr(F, "AUTO_GPU_MIN_ORBITALS_EXPLICIT", 0)
+    monkeypatch.setattr(F, "AUTO_GPU_MIN_ORBITALS_COMPRESSED", 0)
+
+
+def test_cupy_gpu_available_requires_a_working_kernel(monkeypatch):
+    # Enumeration is not enough: a kernel must run.
+    import cudaq_algorithms.double_factorization._backend as B
+    _enumerating_but_dead_cupy(monkeypatch)
+    assert B.cupy_gpu_available() is False
+
+
+@pytest.mark.parametrize("kind", ["xdf", "cdf"])
+def test_auto_uses_numpy_when_cupy_kernel_probe_fails(kind, monkeypatch):
+    # backend="auto" must stay on NumPy when the GPU is visible but unusable.
+    _enumerating_but_dead_cupy(monkeypatch)
+    eri = _synthetic_eri(n=4, num_vectors=2, seed=0)
+    if kind == "xdf":
+        factorization = df.explicit_double_factorization(eri,
+                                                         threshold=0.0,
+                                                         backend="auto")
+    else:
+        factorization = df.compressed_double_factorization(eri,
+                                                           num_leaves=1,
+                                                           backend="auto")
+    assert factorization.method == ("X-DF" if kind == "xdf" else "C-DF")
+    assert factorization.num_leaves >= 1
+
+
+def test_explicit_cupy_backend_errors_when_kernel_probe_fails(monkeypatch):
+    # backend="cupy" is a hard request: a dead GPU must still raise.
+    _enumerating_but_dead_cupy(monkeypatch)
+    eri = _synthetic_eri(n=4, num_vectors=2, seed=0)
+    with pytest.raises(RuntimeError, match="no CuPy/GPU is available"):
+        df.explicit_double_factorization(eri, threshold=0.0, backend="cupy")

--- a/tests/python/test_double_factorization.py
+++ b/tests/python/test_double_factorization.py
@@ -688,5 +688,8 @@ def test_explicit_cupy_backend_errors_when_kernel_probe_fails(monkeypatch):
     # backend="cupy" is a hard request: a dead GPU must still raise.
     _enumerating_but_dead_cupy(monkeypatch)
     eri = _synthetic_eri(n=4, num_vectors=2, seed=0)
-    with pytest.raises(RuntimeError, match="no CuPy/GPU is available"):
+    with pytest.raises(
+            RuntimeError,
+            match=r"not usable \(not installed, no device, or the kernel "
+            r"probe failed\)"):
         df.explicit_double_factorization(eri, threshold=0.0, backend="cupy")


### PR DESCRIPTION
This PR tries to fix [[B] 6682868](https://nvbugspro.nvidia.com/bug/6682868).
It also adds 3 test cases to expose the bug and verify the fix.
Thanks for looking at this PR.

In this suggested fix:
We update `cupy_gpu_available()` so a visible device also has to run a tiny compiled kernel (`arange`) before `"auto"` may select CuPy.
In addition, we collect the `[cupy]` double-factorization tests only when `CUDAQ_DEFAULT_SIMULATOR` starts with `nvidia` (with a call-time skip if that probe then fails).
In this case, `backend="auto"` choosing CuPy when the GPU is listed but cannot compute, and CuPy DF tests running (and failing) on the `qpp-cpu` validation leg, can be avoided.

Added test cases:
- `test_cupy_gpu_available_requires_a_working_kernel`:
We install a fake CuPy whose `getDeviceCount()` is 2 but whose `arange` raises, then check that `cupy_gpu_available()` is False so a driver-only / dead-context GPU is not treated as usable.
- `test_auto_uses_numpy_when_cupy_kernel_probe_fails`:
We use the same fake CuPy, drop the size crossovers so `"auto"` would have picked CuPy under the old probe, then run X-DF and C-DF with `backend="auto"` and check that both still return a valid factorization (NumPy path) so the old crash is exposed if the kernel probe is dropped.
- `test_explicit_cupy_backend_errors_when_kernel_probe_fails`:
We use the same fake CuPy and call X-DF with `backend="cupy"`, then check that it raises `RuntimeError` matching `no CuPy/GPU is available` so a hard CuPy request does not silently fall back.

Tests passed on local machine as:
```
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0 -- /root/.miniconda3/envs/algo312/bin/python
rootdir: /CUDA-QX/kaiqiy/cudaq-algorithms
configfile: pyproject.toml
collecting ... 1
collected 4 items

tests/python/test_double_factorization.py::test_cupy_gpu_available_requires_a_working_kernel PASSED [ 25%]
tests/python/test_double_factorization.py::test_auto_uses_numpy_when_cupy_kernel_probe_fails[xdf] PASSED [ 50%]
tests/python/test_double_factorization.py::test_auto_uses_numpy_when_cupy_kernel_probe_fails[cdf] PASSED [ 75%]
tests/python/test_double_factorization.py::test_explicit_cupy_backend_errors_when_kernel_probe_fails PASSED [100%]

============================== 4 passed in 2.04s ===============================
```